### PR TITLE
Fix YYYYMMDDHHMMSS provider_start not parsed for timeshift URL

### DIFF
--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -66,7 +66,7 @@ def _normalize_provider_start_token(provider_start: str, pre_padding_minutes: in
         # Strip trailing timezone offset (e.g. " +0200", " -0500", " +0000") before
         # trying compact formats.  The datetime part without the offset is the
         # provider's local wall-clock time, which is what the timeshift URL expects.
-        bare = re.sub(r"\s+[+-]\d{4}$", "", token).strip()
+        bare = re.sub(r"\s*([+-]\d{2}:?\d{2}|Z)$", "", token).strip()
         for fmt, candidate in (
             ("%Y-%m-%d %H:%M:%S", bare),
             ("%Y-%m-%d %H:%M",    bare),

--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -63,14 +63,20 @@ def _normalize_provider_start_token(provider_start: str, pre_padding_minutes: in
     if re.fullmatch(r"\d{4}-\d{2}-\d{2}:\d{2}-\d{2}", token):
         parsed = datetime.strptime(token, "%Y-%m-%d:%H-%M")
     else:
-        for fmt in (
-            "%Y-%m-%d %H:%M:%S",
-            "%Y-%m-%d %H:%M",
-            "%Y-%m-%dT%H:%M:%S",
-            "%Y-%m-%dT%H:%M",
+        # Strip trailing timezone offset (e.g. " +0200", " -0500", " +0000") before
+        # trying compact formats.  The datetime part without the offset is the
+        # provider's local wall-clock time, which is what the timeshift URL expects.
+        bare = re.sub(r"\s+[+-]\d{4}$", "", token).strip()
+        for fmt, candidate in (
+            ("%Y-%m-%d %H:%M:%S", bare),
+            ("%Y-%m-%d %H:%M",    bare),
+            ("%Y-%m-%dT%H:%M:%S", bare),
+            ("%Y-%m-%dT%H:%M",    bare),
+            ("%Y%m%d%H%M%S",      bare),
+            ("%Y%m%d%H%M",        bare),
         ):
             try:
-                parsed = datetime.strptime(token, fmt)
+                parsed = datetime.strptime(candidate, fmt)
                 break
             except ValueError:
                 continue

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -456,6 +456,8 @@ class EPGIngestManager:
                 "end_time": end_utc,
                 "start_timestamp": start_ts,
                 "stop_timestamp": stop_ts,
+                "provider_start": start_raw,
+                "provider_stop": stop_raw,
                 "duration_minutes": duration_minutes,
                 "has_archive": info["has_archive"],
             }

--- a/backend/tests/test_catchup_resolution.py
+++ b/backend/tests/test_catchup_resolution.py
@@ -307,6 +307,81 @@ class CatchupResolutionTests(unittest.TestCase):
 
         self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
 
+    def test_yyyymmddhhmmss_provider_token_compact_offset_no_space_uses_local_part(self):
+        """Compact offset without whitespace (e.g. 20260420190000+0200) must strip correctly."""
+        download = asyncio.run(
+            self._build_download(
+                XtreamAccount(
+                    id=1,
+                    name="Provider B",
+                    server_url="https://provider.example.com",
+                    username="user",
+                    password="",
+                    guide_offset_hours=2,
+                ),
+                {
+                    "title": "Show",
+                    "start_time": "2026-04-20T17:00:00+00:00",
+                    "end_time": "2026-04-20T18:15:00+00:00",
+                    "start_timestamp": 1745679600,
+                    "stop_timestamp": 1745684100,
+                    "provider_start": "20260420190000+0200",
+                },
+            )
+        )
+
+        self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
+
+    def test_yyyymmddhhmmss_provider_token_z_suffix_uses_local_part(self):
+        """Z-suffix variant (e.g. 20260420190000Z) strips correctly."""
+        download = asyncio.run(
+            self._build_download(
+                XtreamAccount(
+                    id=1,
+                    name="Provider B",
+                    server_url="https://provider.example.com",
+                    username="user",
+                    password="",
+                    guide_offset_hours=0,
+                ),
+                {
+                    "title": "Show",
+                    "start_time": "2026-04-20T19:00:00+00:00",
+                    "end_time": "2026-04-20T20:15:00+00:00",
+                    "start_timestamp": 1745686800,
+                    "stop_timestamp": 1745691300,
+                    "provider_start": "20260420190000Z",
+                },
+            )
+        )
+
+        self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
+
+    def test_yyyymmddhhmmss_provider_token_colon_offset_uses_local_part(self):
+        """Colon offset variant (e.g. 20260420190000+02:00) strips correctly."""
+        download = asyncio.run(
+            self._build_download(
+                XtreamAccount(
+                    id=1,
+                    name="Provider B",
+                    server_url="https://provider.example.com",
+                    username="user",
+                    password="",
+                    guide_offset_hours=2,
+                ),
+                {
+                    "title": "Show",
+                    "start_time": "2026-04-20T17:00:00+00:00",
+                    "end_time": "2026-04-20T18:15:00+00:00",
+                    "start_timestamp": 1745679600,
+                    "stop_timestamp": 1745684100,
+                    "provider_start": "20260420190000+02:00",
+                },
+            )
+        )
+
+        self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
+
     def test_invalid_provider_token_falls_back_to_generated_start_without_account_offset(self):
         download = asyncio.run(
             self._build_download(

--- a/backend/tests/test_catchup_resolution.py
+++ b/backend/tests/test_catchup_resolution.py
@@ -254,6 +254,59 @@ class CatchupResolutionTests(unittest.TestCase):
         self.assertEqual(second.start_timestamp, 1774864800)
         self.assertEqual(second.stop_timestamp, 1774868400)
 
+    def test_yyyymmddhhmmss_provider_token_no_tz_is_used_as_url_start(self):
+        """Xtream Codes API often returns start as YYYYMMDDHHMMSS (no dashes, no TZ).
+        That string is the provider's local wall-clock time and must be used as-is
+        in the timeshift URL, not replaced by the UTC fallback."""
+        download = asyncio.run(
+            self._build_download(
+                XtreamAccount(
+                    id=1,
+                    name="Provider A",
+                    server_url="https://provider.example.com",
+                    username="user",
+                    password="",
+                    guide_offset_hours=2,
+                ),
+                {
+                    "title": "Show",
+                    "start_time": "2026-04-20T19:00:00+00:00",
+                    "end_time": "2026-04-20T20:15:00+00:00",
+                    "start_timestamp": 1776704400,
+                    "stop_timestamp": 1776708900,
+                    "provider_start": "20260420190000",
+                },
+            )
+        )
+
+        self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
+
+    def test_yyyymmddhhmmss_provider_token_with_tz_offset_uses_local_part(self):
+        """XMLTV start attributes arrive as YYYYMMDDHHMMSS ±HHMM.  The datetime
+        portion is the provider's local time; strip the TZ suffix and use it."""
+        download = asyncio.run(
+            self._build_download(
+                XtreamAccount(
+                    id=1,
+                    name="Provider B",
+                    server_url="https://provider.example.com",
+                    username="user",
+                    password="",
+                    guide_offset_hours=2,
+                ),
+                {
+                    "title": "Show",
+                    "start_time": "2026-04-20T17:00:00+00:00",
+                    "end_time": "2026-04-20T18:15:00+00:00",
+                    "start_timestamp": 1745679600,
+                    "stop_timestamp": 1745684100,
+                    "provider_start": "20260420190000 +0200",
+                },
+            )
+        )
+
+        self.assertIn("/75/2026-04-20:19-00/999.ts", download.source_url)
+
     def test_invalid_provider_token_falls_back_to_generated_start_without_account_offset(self):
         download = asyncio.run(
             self._build_download(


### PR DESCRIPTION
## What a user would notice

Downloads grabbed the wrong show, typically shifted 2+ hours from what was selected in the EPG. This matched issue #6, where a user in UTC+2 (Europe/Berlin) saw the correct time in the UI (19:00 CEST) but got content that aired 2 hours earlier.

## Root cause

Two gaps in the provider-start normalization:

1. **Xtream Codes API** often returns the EPG `start` field as a 14-digit compact string like `20260420190000` (YYYYMMDDHHMMSS, no dashes). The normalizer only recognised dash-delimited formats, so these tokens were rejected and the download URL fell back to the UTC timestamp instead of the provider's local wall-clock time. On providers whose timeshift endpoint expects local time, that produced a download offset by the full UTC-to-local difference.

2. **XMLTV ingest** never stored the raw `start` / `stop` attributes from the XML as `provider_start` / `provider_stop`. Programs ingested from XMLTV always had `NULL` provider_start, so the URL always used the UTC fallback even when the XMLTV contained a non-UTC offset (e.g., `20260420190000 +0200`) that encodes the correct local time.

## What changed

- `_normalize_provider_start_token` now strips any trailing timezone suffix (`+HHMM` / `-HHMM`) from compact tokens and tries `%Y%m%d%H%M%S` / `%Y%m%d%H%M` after the existing dash-delimited formats. The bare datetime portion is the provider's local wall-clock time, which is what the timeshift URL needs.
- `_iter_programs` in `epg_ingest_manager` now yields `provider_start` and `provider_stop` from the raw XMLTV attributes so those programs behave the same as API-backfilled ones.

## How it was tested

Two new tests in `backend/tests/test_catchup_resolution.py`:

- `test_yyyymmddhhmmss_provider_token_no_tz_is_used_as_url_start`: provider_start `"20260420190000"` (API, no TZ) produces URL `.../75/2026-04-20:19-00/999.ts` instead of the UTC fallback `2026-04-20:17-00`.
- `test_yyyymmddhhmmss_provider_token_with_tz_offset_uses_local_part`: provider_start `"20260420190000 +0200"` (XMLTV local TZ) strips the offset and produces the same correct URL.

All 29 existing tests still pass.

**Before:** URL used UTC fallback `2026-04-20:17-00` for YYYYMMDDHHMMSS tokens, downloading the wrong content.
**After:** URL correctly uses `2026-04-20:19-00` (the provider's local time), downloading the right show.

Closes #6 (partial: covers providers returning YYYYMMDDHHMMSS local time; the case of a provider whose XMLTV uses plain UTC `+0000` and whose timeshift endpoint also expects local time is a separate issue that needs a per-account offset setting).