### PR TITLE
[Design] Add Go to Browse button on empty Downloads and Scheduled states

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -16,6 +16,7 @@ import {
   Collapse,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
+import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconDotsVertical,
@@ -332,6 +333,7 @@ function DownloadCard({
 }
 
 export default function Downloads() {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [localProgress, setLocalProgress] = useState({})
   const [localLogs, setLocalLogs] = useState({})
@@ -530,8 +532,11 @@ export default function Downloads() {
               <Stack align="center" gap="md">
                 <IconDownload size={48} opacity={0.3} />
                 <Text c="dimmed" ta="center">
-                  No active downloads. Browse channels to start downloading.
+                  No active downloads.
                 </Text>
+                <Button variant="light" onClick={() => navigate('/browse')}>
+                  Go to Browse
+                </Button>
               </Stack>
             </Card>
           ) : (

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -15,6 +15,7 @@ import {
   Button,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
+import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconDotsVertical,
@@ -221,6 +222,7 @@ function ScheduleCard({
 }
 
 export default function Scheduled() {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [localItems, setLocalItems] = useState([])
   const desktopApi = typeof window !== 'undefined' ? window.mustarrdDesktop : null
@@ -375,8 +377,11 @@ export default function Scheduled() {
               <Stack align="center" gap="md">
                 <IconCalendar size={48} opacity={0.3} />
                 <Text c="dimmed" ta="center">
-                  No scheduled recordings yet. Pick an upcoming show in Browse to schedule it.
+                  No scheduled recordings yet.
                 </Text>
+                <Button variant="light" onClick={() => navigate('/browse')}>
+                  Go to Browse
+                </Button>
               </Stack>
             </Card>
           ) : (


### PR DESCRIPTION
## What a user would notice

Before this change, landing on Downloads or Scheduled with nothing there showed a dead end: an icon and a line of text explaining you should go to Browse, but no button to get there. A non-technical user had to figure out that "Browse" meant the sidebar link.

After this change, both empty states have a "Go to Browse" button that takes you there directly.

## What changed

Added a `Go to Browse` button to the empty state on:
- Downloads > Active tab
- Scheduled Recordings > Upcoming tab

Both navigate to `/browse` when clicked. No logic changes, no backend changes.

## Before

Downloads (Active, empty):
> Icon + "No active downloads. Browse channels to start downloading."

Scheduled (Upcoming, empty):
> Icon + "No scheduled recordings yet. Pick an upcoming show in Browse to schedule it."

## After

Downloads (Active, empty):
> Icon + "No active downloads." + [Go to Browse] button

Scheduled (Upcoming, empty):
> Icon + "No scheduled recordings yet." + [Go to Browse] button

## How it was tested

Started the app locally (`backend/main.py` + `frontend npm run dev`), used Playwright to capture screenshots at 1280x900 (desktop) and 390x844 (phone). Verified the button renders and the layout holds at both widths. Button navigates to `/browse` as expected.

Files changed: `frontend/src/pages/Downloads.jsx`, `frontend/src/pages/Scheduled.jsx`