### PR TITLE
Strip null bytes and control chars from EPG titles in filename sanitizer

### DIFF
--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -22,8 +22,8 @@ class FileNamer:
         # Remove stylized "Live" markers frequently injected by providers
         name = re.sub(r'[\[\(\-–—|:]*\s*ᴸᶦᵛᵉ\s*[\]\)]*\s*(?:-\s*)?', ' ', name)
 
-        # Replace invalid characters with spaces
-        invalid_chars = r'[<>:"/\\|?*]'
+        # Replace invalid characters with spaces (includes null byte and other control chars)
+        invalid_chars = r'[<>:"/\\|?*\x00-\x1f]'
         sanitized = re.sub(invalid_chars, ' ', name)
         # Remove multiple spaces
         sanitized = re.sub(r'\s+', ' ', sanitized)

--- a/backend/tests/test_file_namer.py
+++ b/backend/tests/test_file_namer.py
@@ -1,0 +1,42 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.file_namer import FileNamer
+
+
+class SanitizeFilenameTests(unittest.TestCase):
+    def test_strips_null_byte(self):
+        result = FileNamer.sanitize_filename("The Crown\x00S01E01")
+        self.assertNotIn("\x00", result)
+        self.assertEqual(result, "The Crown S01E01")
+
+    def test_strips_other_control_chars(self):
+        # Tab (\x09), carriage return (\x0d), and other control chars should be removed
+        result = FileNamer.sanitize_filename("Show\x09Name\x0dEpisode\x1fTitle")
+        for cp in range(0x00, 0x20):
+            self.assertNotIn(chr(cp), result)
+
+    def test_null_byte_mid_title_collapses_space(self):
+        # Multiple adjacent control chars should collapse to a single space
+        result = FileNamer.sanitize_filename("Show\x00\x00Name")
+        self.assertEqual(result, "Show Name")
+
+    def test_normal_title_unchanged(self):
+        result = FileNamer.sanitize_filename("Breaking Bad S01E01")
+        self.assertEqual(result, "Breaking Bad S01E01")
+
+    def test_windows_invalid_chars_still_stripped(self):
+        result = FileNamer.sanitize_filename('Bad:Title/Name\\Here?')
+        self.assertNotIn(':', result)
+        self.assertNotIn('/', result)
+        self.assertNotIn('\\', result)
+        self.assertNotIn('?', result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Some IPTV providers embed null bytes or other control characters (characters your terminal never shows) inside EPG program titles. When Mustarrd tried to create a download folder using that title, Python raised a cryptic `ValueError: mkdir: embedded null character in path` and the download silently failed with no useful message to the user.

**Before:** a title like `The Crown` (with a hidden null byte) produced `ValueError: mkdir: embedded null character in path`. Download marked FAILED.

**After:** the null byte is stripped during filename sanitization, producing `The Crown S01E01.ts`. Download proceeds normally.

## What was fixed

`sanitize_filename` in `backend/services/file_namer.py` already stripped Windows-forbidden characters (`< > : " / \ | ? *`) but did not strip control characters (bytes 0x00-0x1F), which include the null byte. Added `\x00-\x1f` to the invalid-character regex so all control characters are replaced with a space and collapsed.

## How it was tested

New test file `backend/tests/test_file_namer.py` with five cases, including a regression test that directly reproduces the reported failure:

```
python -m unittest discover -s tests -v
...
test_strips_null_byte ... ok
test_strips_other_control_chars ... ok
test_null_byte_mid_title_collapses_space ... ok
test_normal_title_unchanged ... ok
test_windows_invalid_chars_still_stripped ... ok
...
Ran 32 tests in 0.021s

OK
```

All 32 tests pass.