### PR TITLE
Fix partial .ts file left on disk after ENOSPC download failure

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -619,6 +619,11 @@ class DownloadManager:
                     download.status = DownloadStatus.FAILED.value
                     download.error_message = str(e)
                     await session.commit()
+                    try:
+                        if download.output_path and os.path.exists(download.output_path):
+                            os.unlink(download.output_path)
+                    except OSError:
+                        pass
 
                 await self._broadcast_progress(
                     download_id,

--- a/backend/tests/test_disk_full.py
+++ b/backend/tests/test_disk_full.py
@@ -1,0 +1,128 @@
+import asyncio
+import errno
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+class _FakeDownload:
+    def __init__(self, dl_id, output_path):
+        self.id = dl_id
+        self.status = DownloadStatus.PENDING.value
+        self.output_path = output_path
+        self.source_url = "http://provider.test/timeshift/1.ts"
+        self.requested_by_user_id = None
+        self.is_vod = False
+        self.progress = 0.0
+        self.downloaded_bytes = 0
+        self.file_size = 0
+        self.error_message = None
+        self.completed_at = None
+        self.account_id = 1
+
+
+class _FakeSession:
+    """Minimal async session stub. Returns the same download for every execute()."""
+
+    def __init__(self, download):
+        self._download = download
+
+    async def execute(self, _stmt):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = self._download
+        return result
+
+    async def commit(self):
+        pass
+
+    def add(self, obj):
+        pass
+
+    async def refresh(self, obj):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _make_session_ctx(session):
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+class DiskFullTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_enospc_partial_output_file_cleaned_up(self):
+        """
+        When a download fails with ENOSPC (disk full), the partial output file
+        must be deleted so the disk is freed and recovery is possible.
+
+        BUG: This test currently FAILS because _execute_download does not remove
+        the partial file in its except-Exception handler. The partial file persists
+        on disk, keeps the disk full, and blocks every subsequent download until
+        the operator manually deletes it.
+
+        Fix: in the except-Exception block of _execute_download, unlink
+        download.output_path if it exists before marking FAILED.
+        """
+        manager = DownloadManager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "Show.S01E01.ts")
+            download = _FakeDownload(dl_id=42, output_path=output_path)
+            session = _FakeSession(download)
+
+            async def fake_download_file(url, path, dl_id, ses):
+                # Simulate provider sends some bytes, then disk fills.
+                with open(path, "wb") as fh:
+                    fh.write(b"\x47" * 512 * 1024)  # 512 KB partial TS data
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            with patch.object(manager, "_download_file", new=fake_download_file), \
+                 patch("services.download_manager.async_session_maker",
+                       return_value=_make_session_ctx(session)), \
+                 patch.object(manager, "_broadcast_progress", new_callable=AsyncMock), \
+                 patch.object(manager, "_broadcast_log", new_callable=AsyncMock):
+                await manager._execute_download(42)
+
+            # Assertions must be inside the tempdir context so the directory
+            # is not cleaned up before we check file existence.
+
+            # Download correctly marked FAILED.
+            self.assertEqual(
+                download.status,
+                DownloadStatus.FAILED.value,
+                "Download must be marked FAILED on ENOSPC.",
+            )
+            self.assertIn(
+                "28",
+                download.error_message or "",
+                "error_message must reference errno 28.",
+            )
+
+            # Partial file must be gone. This assertion FAILS on the current codebase.
+            self.assertFalse(
+                os.path.exists(output_path),
+                "Partial download file must be deleted on ENOSPC to free disk space. "
+                "Currently _execute_download leaves it on disk, keeping the disk full "
+                "and blocking all subsequent downloads until manual cleanup.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

When a recording ran out of disk space mid-download, the app correctly marked it as Failed, but left the partial `.ts` file on disk. That partial file could be gigabytes in size, keeping the disk full and causing every subsequent download to also fail with `[Errno 28] No space left on device`. A non-technical Unraid operator had no way to know they needed to manually find and delete the partial file to recover.

**Before:** disk-full failure left partial `.ts` on disk. Disk stayed full. All further downloads failed until manual cleanup.

**After:** the partial `.ts` is automatically deleted as part of the failure path. Disk space is freed immediately. Next download can proceed.

## What changed

In `_execute_download` (`backend/services/download_manager.py`), the `except Exception` handler already marks the download FAILED and commits the status to the database. Added a `try/except OSError` block right after the commit to unlink `download.output_path` if it exists:

```python
try:
    if download.output_path and os.path.exists(download.output_path):
        os.unlink(download.output_path)
except OSError:
    pass
```

The inner `OSError` guard ensures a secondary filesystem error (permissions, file already gone) never masks the FAILED status or error message the user sees.

## How it was tested

Regression test in `backend/tests/test_disk_full.py` (added by Gremlin's QA pass) patches `_download_file` to write 512 KB of partial TS data then raise `OSError(ENOSPC)`. It asserts the download is marked FAILED and the partial file is gone.

```
python -m unittest tests.test_disk_full -v

test_enospc_partial_output_file_cleaned_up ... ok

Ran 1 test in 0.001s
OK
```

Full suite (28 tests):

```
python -m unittest discover -s tests -v
...
Ran 28 tests in 0.023s
OK
```

Test **failed before this commit** (partial file survived) and **passes after** (partial file deleted).