### PR TITLE
Add changelog entry for PR #11 (Go to Browse button)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Improved: Empty Downloads and Scheduled pages now have a button to Browse
+
+**What you would notice:** If you open Downloads or Scheduled and nothing is there yet, you now see a "Go to Browse" button. Previously the page told you to go to Browse but gave you nothing to click.
+
+**What changed:** Both empty-state pages now include a button that takes you directly to the Browse page so you can find something to download.
+
+---
+
 ## 2026-04-29
 
 ### Fixed: Show times now display in the channel's local time


### PR DESCRIPTION
## What changed

Adds a plain-English changelog entry for PR #11, which shipped in the same release as PR #8 and #9 but was merged after the previous changelog PR (#10) was already closed.

## What a user would notice

The CHANGELOG now has an entry under 2026-06-06 describing the new Go to Browse button on empty Downloads and Scheduled pages.

## How it was tested

Diff reviewed against the merged PR #11 description and the existing CHANGELOG format. No code changes.