### PR TITLE
[Design] Hide Save Settings button when form is unchanged

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1320,11 +1320,10 @@ export default function Settings() {
               Discard Changes
             </Button>
           )}
-          {inConfigSection && (
+          {inConfigSection && (hasChanges || updateMutation.isPending) && (
             <Button
               onClick={handleSave}
               loading={updateMutation.isPending}
-              disabled={!hasChanges}
             >
               Save Settings
             </Button>


### PR DESCRIPTION
## What a user would notice

Before this change, the Settings page always showed a gray "Save Settings" button in the top-right corner, even when you hadn't changed anything. It looked like a disabled button sitting there permanently. A non-technical user could reasonably wonder: is something broken? Why does it look grayed out? Does clicking it do anything?

After this change, the button is hidden when the form is clean. It only appears (orange, active) when you have actually changed a setting. This matches the existing behavior of the "Discard Changes" button, which already uses this pattern.

## What changed

One line in `frontend/src/pages/Settings.jsx`: the "Save Settings" button render condition now requires `hasChanges` to be true (or a save to be in progress), instead of always rendering with a `disabled` prop when unchanged.

## Before / After

**Desktop - Before:** "Save Settings" always visible, gray/inactive with no changes pending.
![Before desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1512760684663013538/settings_desktop_before.png)

**Desktop - After:** Button hidden when form is clean. Appears orange when you make a change.
![After desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1512760703344447488/settings_desktop_after.png)

**Mobile - Before:**
![Before mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1512760720411066419/settings_mobile_before.png)

**Mobile - After:**
![After mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1512760723615387688/settings_mobile_after.png)

## How it was tested

Screenshots captured with Playwright at desktop (1280x800) and mobile (390x844) widths. The button appearance was verified in both states: hidden when no changes pending, visible and orange when a field is edited.