### PR TITLE
Fix partial .ts file left on disk after cancelled download

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -604,6 +604,11 @@ class DownloadManager:
                 # Download was cancelled
                 download.status = DownloadStatus.CANCELLED.value
                 await session.commit()
+                if download.output_path and os.path.exists(download.output_path):
+                    try:
+                        os.unlink(download.output_path)
+                    except OSError:
+                        pass
                 await self._broadcast_progress(
                     download_id, download.progress, DownloadStatus.CANCELLED.value
                 )

--- a/backend/tests/test_download_manager_cancel_cleanup.py
+++ b/backend/tests/test_download_manager_cancel_cleanup.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+class CancelCleanupTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_cancel_cleans_up_partial_output_file(self):
+        """Partial .ts file must be deleted when a download is cancelled mid-transfer."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            partial_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = partial_file
+            mock_download.source_url = "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts"
+            mock_download.progress = 0.0
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_download
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield mock_session
+
+            async def fake_download_file(url, path, download_id, session):
+                with open(path, "wb") as f:
+                    f.write(b"\x00" * 1024)
+                raise asyncio.CancelledError()
+
+            with patch("services.download_manager.async_session_maker", mock_session_maker):
+                with patch.object(self.manager, "_download_file", fake_download_file):
+                    with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                        with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                            asyncio.run(self.manager._execute_download(1))
+
+            self.assertFalse(
+                os.path.exists(partial_file),
+                "Partial download file must be deleted after cancel",
+            )
+            self.assertEqual(mock_download.status, DownloadStatus.CANCELLED.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If you cancelled a download mid-transfer, the partial `.ts` file stayed on disk indefinitely. Over time (especially with slow or unreliable providers that need repeated retries), these orphan files accumulate silently and waste disk space.

After this fix, cancelling a download cleans up the partial file immediately, the same way a disk-full failure already does.

## What changed

`_execute_download` in `download_manager.py` has two error-handling branches: one for general failures (`except Exception`) and one for user cancellation (`except asyncio.CancelledError`). The cancel branch was missing the `os.unlink` guard that removes the partial output file.

Added the same unlink guard (with `OSError` protection) to the cancel branch.

## How it was tested

New regression test in `backend/tests/test_download_manager_cancel_cleanup.py`:

- Mocks `_download_file` to write 1 KB of data then raise `asyncio.CancelledError`.
- Confirms the partial file is deleted and the download status is `CANCELLED`.

**Before the fix:**
```
FAIL: test_cancel_cleans_up_partial_output_file
AssertionError: True is not false : Partial download file must be deleted after cancel
```

**After the fix:**
```
Ran 1 test in 0.002s
OK
```

Full suite (33 tests): all pass.

## Relation to PR #14

PR #14 fixed the same leak for the disk-full (`ENOSPC`) path. This PR fixes the identical gap in the cancel path. The two branches touch different `except` blocks so there is no conflict.