### PR TITLE
Fail download when provider returns empty body

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -552,12 +552,17 @@ class DownloadManager:
                 )
 
                 # Start download
-                await self._download_file(
+                downloaded_bytes = await self._download_file(
                     download.source_url,
                     download.output_path,
                     download_id,
                     session
                 )
+                if downloaded_bytes == 0:
+                    raise Exception(
+                        "Provider returned an empty response. "
+                        "The catchup window for this program may have expired."
+                    )
                 await self._broadcast_log(download_id, "Download transfer complete.")
 
                 settings_result = await session.execute(select(AppSettings))
@@ -984,6 +989,7 @@ class DownloadManager:
                     download_id,
                     f"Download bytes written: {downloaded:,}."
                 )
+                return downloaded
 
     async def _post_process(
         self,

--- a/backend/tests/test_download_manager_zero_bytes.py
+++ b/backend/tests/test_download_manager_zero_bytes.py
@@ -1,0 +1,131 @@
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+class ZeroBytesDownloadTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_zero_byte_response_marked_failed_not_completed(self):
+        """A provider returning an empty body must be marked FAILED, not COMPLETED."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = output_file
+            mock_download.source_url = "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts"
+            mock_download.progress = 0.0
+            mock_download.downloaded_bytes = 0
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_download
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield mock_session
+
+            async def fake_download_file_zero_bytes(url, path, download_id, session):
+                # Provider returns HTTP 200 with empty body: file created but no bytes written.
+                open(path, "wb").close()
+                return 0
+
+            with patch("services.download_manager.async_session_maker", mock_session_maker):
+                with patch.object(self.manager, "_download_file", fake_download_file_zero_bytes):
+                    with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                        with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                            asyncio.run(self.manager._execute_download(1))
+
+            self.assertEqual(
+                mock_download.status,
+                DownloadStatus.FAILED.value,
+                "Zero-byte download must be marked FAILED, not COMPLETED",
+            )
+            self.assertFalse(
+                os.path.exists(output_file),
+                "Zero-byte output file must be cleaned up after failure",
+            )
+            self.assertIn(
+                "empty response",
+                mock_download.error_message.lower(),
+                "Error message must mention empty response",
+            )
+
+    def test_normal_download_not_affected(self):
+        """A download with actual bytes must still be marked COMPLETED."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "show.ts")
+            completed_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 2
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = output_file
+            mock_download.source_url = "http://provider/timeshift/user/pass/60/2026-06-06:00-00/2.ts"
+            mock_download.progress = 0.0
+            mock_download.downloaded_bytes = 0
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_download
+            mock_settings_result = MagicMock()
+            mock_settings_result.scalar_one_or_none.return_value = None
+            mock_session = AsyncMock()
+            mock_session.commit = AsyncMock()
+
+            call_count = 0
+
+            async def side_effect_execute(stmt):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return mock_result
+                return mock_settings_result
+
+            mock_session.execute = side_effect_execute
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield mock_session
+
+            async def fake_download_file_with_bytes(url, path, download_id, session):
+                with open(path, "wb") as f:
+                    f.write(b"\x00" * 1024)
+                return 1024
+
+            with patch("services.download_manager.async_session_maker", mock_session_maker):
+                with patch.object(self.manager, "_download_file", fake_download_file_with_bytes):
+                    with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                        with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                            with patch.object(self.manager, "_needs_post_processing", return_value=False):
+                                with patch.object(self.manager, "_move_to_completed", return_value=completed_file):
+                                    with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
+                                        with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
+                                            with patch.object(self.manager, "_trigger_plex_refresh", AsyncMock()):
+                                                asyncio.run(self.manager._execute_download(2))
+
+            self.assertEqual(
+                mock_download.status,
+                DownloadStatus.COMPLETED.value,
+                "Normal download with bytes must be marked COMPLETED",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If you tried to download a recording that was outside the provider's catchup window (usually 3 to 7 days), the download would show as Completed and a 0-byte .ts file would appear in your completed folder. Playing it in Plex or Jellyfin would fail silently with no error. Multiple stale scheduled recordings (for example, ones that were paused due to low disk space and then re-fired days later) could fill the completed folder with empty files.

After this fix, the download is marked Failed with a clear message: "Provider returned an empty response. The catchup window for this program may have expired."

## What changed

`_download_file` now returns the number of bytes written. In `_execute_download`, after the transfer finishes, if the byte count is 0 the code raises an exception with an actionable message. The existing failure handler then marks the download Failed, sets that message as the error, and deletes the 0-byte file from disk (same cleanup path added in PR #14 for ENOSPC).

## How it was tested

New regression test in `backend/tests/test_download_manager_zero_bytes.py`:

- Mocks `_download_file` to create an empty file and return 0 bytes.
- Asserts status is FAILED (not COMPLETED) and the file is cleaned up.
- A second test confirms normal downloads (returning 1024 bytes) are still marked COMPLETED.

**Before the fix:**
```
FAIL: test_zero_byte_response_marked_failed_not_completed
AssertionError: 'completed' != 'failed' : Zero-byte download must be marked FAILED, not COMPLETED
```

**After the fix:**
```
Ran 48 tests in 0.033s
OK
```