### PR TITLE
Add changelog entries for PRs #13, #17, #20, #21, and #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ### Improved: Browse setup buttons are now clearer for first-time users
 
-**What you would notice:** When no IPTV account is connected, the Browse page used to show two buttons ("Open Setup" and "Add Account") with no explanation of which to press first. The buttons now have clearer labels and helper text below each one. "Open Setup" is now "Start Setup Wizard" with the note "Guided walkthrough for first-time setup." The "Add Account" button now has the note "Already set up? Add another IPTV account" below it so returning users know which option is for them.
+**What you would notice:** When no IPTV account is connected, the Browse page used to show two buttons ("Open Setup" and "Add Account") with no explanation of which to press first. The buttons now have clearer labels and helper text below each one. "Open Setup" is now "Start Setup Wizard" with the note "Guided walkthrough for first-time setup." The "Add Account" button keeps its label but now has the note "Already set up? Add another IPTV account" below it so returning users know it is for them.
 
 **What changed:** Button labels and descriptions on the Browse page were updated. No functionality changed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,46 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Fixed: Downloading a program outside the catchup window silently created an empty file
+
+**What you would notice:** If you tried to download a recording that was older than your provider's catchup window (usually 3 to 7 days back), the download would show as Completed and a 0-byte file would appear in your completed folder. Playing it in Plex or Jellyfin would fail silently. Scheduled recordings that were delayed past the catchup window by a full disk could quietly accumulate empty files.
+
+**What changed:** Mustarrd now checks whether the provider actually sent any content. If it receives an empty response, it marks the download as Failed with the message "Provider returned an empty response. The catchup window for this program may have expired." The empty file is also deleted automatically.
+
+---
+
+### Improved: REC indicator now only shows when a download is active
+
+**What you would notice:** Previously, a red pulsing REC dot appeared in the corner on every screen, even on the login page when nothing was recording. Many users read the constant red pulse as an alarm or error. The indicator now only appears when at least one download is actually in progress.
+
+**What changed:** The REC dot is now hidden when there are no active downloads. It appears and pulses normally as soon as a download starts.
+
+---
+
+### Improved: Save Settings button now only appears when you have changes pending
+
+**What you would notice:** The Settings page used to always show a grayed-out "Save Settings" button, even when you had not changed anything. This was confusing because the button looked disabled or broken. The button now stays hidden until you actually edit a setting, at which point it turns orange and becomes clickable.
+
+**What changed:** The "Save Settings" button now follows the same pattern as "Discard Changes": both buttons only appear when there is something to act on.
+
+---
+
+### Improved: Browse setup buttons are now clearer for first-time users
+
+**What you would notice:** When no IPTV account is connected, the Browse page used to show two buttons ("Open Setup" and "Add Account") with no explanation of which to press first. The buttons now have clearer labels and helper text below each one. "Open Setup" is now "Start Setup Wizard" with the note "Guided walkthrough for first-time setup." The "Add Account" button now has the note "Already set up? Add another IPTV account" below it so returning users know which option is for them.
+
+**What changed:** Button labels and descriptions on the Browse page were updated. No functionality changed.
+
+---
+
+### Improved: Setup wizard no longer shows a grayed-out Continue button before your account is saved
+
+**What you would notice:** When you first open Mustarrd and reach the account setup step, you previously saw two buttons: an orange "Save & Continue" and a grayed-out "Continue" with no explanation of why it was disabled. This looked broken. The Continue button is now hidden until you have successfully saved your first account, at which point it appears if you want to skip adding a second account.
+
+**What changed:** The Continue button on the account setup step is now hidden until an account has been saved, instead of always being shown in a disabled state.
+
+---
+
 ## 2026-04-29
 
 ### Fixed: Show times now display in the channel's local time


### PR DESCRIPTION
## What this does

Adds plain-English changelog entries for five changes that merged on 2026-06-06 but were not yet documented:

- **PR #13:** The red pulsing REC dot appeared on every screen, even the login page when nothing was recording. Non-technical users read the constant red pulse as an alarm or error. It now only shows when a download is actually in progress.
- **PR #17:** The "Save Settings" button was always visible in Settings, grayed out even when nothing had changed. This looked broken or disabled. The button now stays hidden until you edit something, then appears orange and active.
- **PR #20:** The Browse page showed two buttons ("Open Setup" and "Add Account") with no explanation of which to press first. The buttons now have clearer labels and helper text to guide first-time users.
- **PR #21:** The account setup step showed an orange "Save & Continue" button and a grayed-out "Continue" button with no explanation. The Continue button is now hidden until an account is saved, removing the broken-looking disabled state.
- **PR #23:** Downloads that returned an empty response from the provider were marked Completed with a 0-byte file. They are now marked Failed with an actionable message ("The catchup window for this program may have expired"), and the empty file is cleaned up automatically.

This branch is rebased onto current main (which includes PRs #21, #22, and #23).

## What users will see

Five new entries under the 2026-06-06 date heading in CHANGELOG.md, written for a non-technical Unraid user.

## How it was tested

Read CHANGELOG.md on this branch to confirm all five entries are accurate, plain English, no em dashes, and consistent with the existing changelog style.