### PR TITLE
Fix null start_time crash: HTTP 500 when EPG program has no timestamps

### DIFF
--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -23,8 +23,12 @@ def _parse_program_times(program: dict) -> tuple[datetime, datetime, int, dateti
         program_end_utc = datetime.fromtimestamp(int(stop_timestamp), tz=timezone.utc)
         duration_minutes = int((program_end_utc - program_start_utc).total_seconds() / 60)
     else:
-        program_start_utc = datetime.fromisoformat(program["start_time"])
-        program_end_utc = datetime.fromisoformat(program["end_time"])
+        start_time = program.get("start_time")
+        end_time = program.get("end_time")
+        if not start_time or not end_time:
+            raise ValueError("Program has no valid start or end time")
+        program_start_utc = datetime.fromisoformat(start_time)
+        program_end_utc = datetime.fromisoformat(end_time)
         duration_minutes = int((program_end_utc - program_start_utc).total_seconds() / 60)
 
     if program.get("start_time") and program.get("end_time"):

--- a/backend/tests/test_download_builder_null_timestamps.py
+++ b/backend/tests/test_download_builder_null_timestamps.py
@@ -1,0 +1,66 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_builder import _parse_program_times
+
+
+class ParseProgramTimesNullTests(unittest.TestCase):
+    def test_null_start_time_raises_value_error(self):
+        """start_time=None with no timestamps raises ValueError, not TypeError (HTTP 400 not 500)."""
+        program = {
+            "start_timestamp": 0,
+            "stop_timestamp": 0,
+            "start_time": None,
+            "end_time": None,
+        }
+        with self.assertRaises(ValueError) as ctx:
+            _parse_program_times(program)
+        self.assertIn("no valid start or end time", str(ctx.exception))
+
+    def test_missing_start_time_raises_value_error(self):
+        """start_time key absent with no timestamps raises ValueError."""
+        program = {"start_timestamp": 0, "stop_timestamp": 0}
+        with self.assertRaises(ValueError):
+            _parse_program_times(program)
+
+    def test_null_start_time_only_raises_value_error(self):
+        """start_time=None but end_time present still raises ValueError."""
+        program = {
+            "start_timestamp": 0,
+            "stop_timestamp": 0,
+            "start_time": None,
+            "end_time": "2026-03-30T18:00:00",
+        }
+        with self.assertRaises(ValueError):
+            _parse_program_times(program)
+
+    def test_valid_timestamps_still_work(self):
+        """Regression: programs with valid UNIX timestamps continue to parse correctly."""
+        import datetime
+        program = {
+            "start_timestamp": 1743354000,
+            "stop_timestamp": 1743357600,
+        }
+        start, end, duration, _, _ = _parse_program_times(program)
+        self.assertEqual(duration, 60)
+        self.assertEqual(start.tzinfo, datetime.timezone.utc)
+
+    def test_valid_iso_strings_still_work(self):
+        """Regression: programs with valid ISO strings (no UNIX timestamps) continue to parse."""
+        program = {
+            "start_timestamp": 0,
+            "stop_timestamp": 0,
+            "start_time": "2026-03-30T17:00:00+00:00",
+            "end_time": "2026-03-30T18:00:00+00:00",
+        }
+        _, _, duration, _, _ = _parse_program_times(program)
+        self.assertEqual(duration, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If you clicked **Download** on a program from a provider with a broken EPG feed (programs where the start and end time were never populated), the app returned a plain **HTTP 500 Internal Server Error** with no explanation. There was no way to tell what went wrong.

After this fix, clicking Download on a program with missing timestamps returns **HTTP 400** with the message: *"Program has no valid start or end time"* so the problem is clear.

## What changed

`_parse_program_times()` in `backend/services/download_builder.py` (lines 25-28) falls back to `datetime.fromisoformat(program["start_time"])` when no UNIX timestamp is present. If `start_time` is `None` (stored that way when the EPG ingest received a null), Python raises `TypeError: fromisoformat: argument must be str`. The caller in `api/downloads.py` only catches `ValueError`, so the `TypeError` escaped and became a 500.

Fix: check that `start_time` and `end_time` are non-null before calling `fromisoformat`, and raise `ValueError` with a plain-English message if either is missing.

## Before

```
POST /api/downloads/
{
  "program": { "start_timestamp": 0, "stop_timestamp": 0, "start_time": null, "end_time": null, ... }
}

-> HTTP 500 Internal Server Error
   TypeError: fromisoformat: argument must be str
```

## After

```
POST /api/downloads/
{
  "program": { "start_timestamp": 0, "stop_timestamp": 0, "start_time": null, "end_time": null, ... }
}

-> HTTP 400 Bad Request
   { "detail": "Program has no valid start or end time" }
```

## How it was tested

5 new unit tests in `backend/tests/test_download_builder_null_timestamps.py`:
- `null start_time raises ValueError` (primary regression)
- `missing start_time key raises ValueError`
- `null start_time only (end_time present) raises ValueError`
- `valid UNIX timestamps still parse correctly` (regression guard)
- `valid ISO strings still parse correctly` (regression guard)

Full suite: 53 tests, all pass.

```
python -m unittest discover -s tests
----------------------------------------------------------------------
Ran 53 tests in 0.035s
OK
```