### PR TITLE
Fix _parse_edl crash on malformed EDL timing values from ComSkip

### DIFF
--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import shutil
 import platform
@@ -10,6 +11,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional, Callable, List, Dict, Tuple
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 
 class OutputFormat(str, Enum):
@@ -1445,9 +1448,13 @@ class PostProcessor:
             for line in f:
                 parts = line.strip().split()
                 if len(parts) >= 3:
-                    start = float(parts[0])
-                    end = float(parts[1])
-                    seg_type = int(parts[2])
+                    try:
+                        start = float(parts[0])
+                        end = float(parts[1])
+                        seg_type = int(parts[2])
+                    except (ValueError, IndexError):
+                        logger.warning("Skipping malformed EDL line: %r", line.strip())
+                        continue
                     # Type 0 = cut, 3 = commercial
                     if seg_type in [0, 3]:
                         segments.append((start, end, seg_type))

--- a/backend/tests/test_parse_edl_malformed.py
+++ b/backend/tests/test_parse_edl_malformed.py
@@ -1,0 +1,71 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_under_test", MODULE_PATH)
+POST_PROCESSOR_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(POST_PROCESSOR_MODULE)
+
+PostProcessor = POST_PROCESSOR_MODULE.PostProcessor
+
+
+def _write_edl(tmp_dir, lines):
+    path = Path(tmp_dir) / "test.edl"
+    path.write_text("\n".join(lines) + "\n")
+    return str(path)
+
+
+class ParseEdlMalformedTests(unittest.TestCase):
+    def setUp(self):
+        self.processor = PostProcessor()
+
+    def test_valid_edl_parses_correctly(self):
+        """Baseline: a well-formed EDL file returns the expected segments."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_edl(tmp, ["0.000000 30.000000 0", "60.000000 90.000000 3"])
+            segments = self.processor._parse_edl(path)
+        self.assertEqual(segments, [(0.0, 30.0, 0), (60.0, 90.0, 3)])
+
+    def test_na_timing_field_skipped_not_crash(self):
+        """
+        BUG: ComSkip can emit N/A for timing values on short or corrupt input.
+        Before the fix, float("N/A") raised ValueError and crashed _parse_edl,
+        marking the download FAILED with a cryptic Python traceback.
+
+        After the fix, malformed lines are skipped and processing continues.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_edl(tmp, ["N/A 30.000000 3", "60.000000 90.000000 0"])
+            # Must not raise ValueError
+            segments = self.processor._parse_edl(path)
+        # The bad line is skipped; the valid line is returned
+        self.assertEqual(segments, [(60.0, 90.0, 0)])
+
+    def test_all_malformed_lines_returns_empty(self):
+        """All-malformed EDL yields empty list, not a crash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_edl(tmp, ["N/A N/A 0", "abc 30.0 3", "0.0 N/A 0"])
+            segments = self.processor._parse_edl(path)
+        self.assertEqual(segments, [])
+
+    def test_non_numeric_seg_type_skipped(self):
+        """Non-integer segment type is skipped without crash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_edl(tmp, ["0.0 30.0 cut", "60.0 90.0 3"])
+            segments = self.processor._parse_edl(path)
+        self.assertEqual(segments, [(60.0, 90.0, 3)])
+
+    def test_blank_and_short_lines_ignored(self):
+        """Lines with fewer than 3 fields are silently skipped (pre-existing behavior)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_edl(tmp, ["", "0.0 30.0", "60.0 90.0 0"])
+            segments = self.processor._parse_edl(path)
+        self.assertEqual(segments, [(60.0, 90.0, 0)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`_parse_edl` in `post_processor.py` crashed with an unhandled `ValueError` when ComSkip produced an EDL file with non-numeric timing values (for example `N/A`). This marked the download as FAILED with a cryptic Python error the operator could not act on. The fix wraps the three numeric conversions in a `try/except` that logs a warning and skips the bad line, so processing continues normally.

## Why this happens

ComSkip can emit `N/A` for start or end times when the input file is very short, truncated, or encoded in a way ComSkip cannot fully parse. Nothing in `_parse_edl` guarded against this before this change.

## Before

```
Download status: FAILED
Error: could not convert string to float: 'N/A'
```

The operator sees a Python traceback with no explanation of what went wrong or how to fix it. The download is permanently stuck as FAILED.

## After

```
WARNING  post_processor:post_processor.py:1453 Skipping malformed EDL line: 'N/A 30.000000 3'
```

The bad line is skipped. If any valid commercial segments remain, removal proceeds on those. If none remain, commercial removal is skipped gracefully. The download is not marked FAILED due to a malformed EDL line.

## How to test

1. Enable ComSkip + commercial removal.
2. Place an EDL file next to a `.ts` in the download folder containing: `N/A 30.000000 3`
3. Trigger commercial removal.
4. Before this fix: download status flips to FAILED with a `ValueError` traceback.
5. After this fix: the bad line is logged as a warning and skipped; download completes.

Alternatively, run the new regression tests:

```
cd backend && python -m unittest tests/test_parse_edl_malformed.py -v
# Ran 5 tests ... OK
```

Full suite: `python -m unittest discover -s tests` passes all 73 tests.

## Files changed

- `backend/services/post_processor.py`: add `import logging` / `logger`, wrap float/int conversions in `_parse_edl` with `try/except (ValueError, IndexError)`.
- `backend/tests/test_parse_edl_malformed.py`: 5 regression tests (N/A field, all-malformed file, non-numeric segment type, short lines, valid baseline).