### PR TITLE
[Design] Add context text to History tab empty states

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -567,6 +567,9 @@ export default function Downloads() {
                 <Text c="dimmed" ta="center">
                   No download history yet.
                 </Text>
+                <Text c="dimmed" ta="center" size="sm">
+                  Completed, failed, and cancelled downloads will appear here.
+                </Text>
               </Stack>
             </Card>
           ) : (

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -410,6 +410,9 @@ export default function Scheduled() {
                 <Text c="dimmed" ta="center">
                   No schedule history yet.
                 </Text>
+                <Text c="dimmed" ta="center" size="sm">
+                  Past scheduled recordings that have already aired will appear here.
+                </Text>
               </Stack>
             </Card>
           ) : (

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -411,7 +411,7 @@ export default function Scheduled() {
                   No schedule history yet.
                 </Text>
                 <Text c="dimmed" ta="center" size="sm">
-                  Past scheduled recordings that have already aired will appear here.
+                  Completed, failed, and cancelled scheduled recordings will appear here.
                 </Text>
               </Stack>
             </Card>


### PR DESCRIPTION
## What a user would notice

The Downloads and Scheduled Recordings pages each have a History tab. Before this change, landing on an empty History tab showed only "No download history yet." or "No schedule history yet." with no further explanation. A new user had no way to know what this tab is for or what populates it.

After this change, a second dimmed line appears below each heading:

- **Downloads History:** "Completed, failed, and cancelled downloads will appear here."
- **Scheduled History:** "Completed, failed, and cancelled scheduled recordings will appear here."

## What changed

Two files, six lines added total. No logic changes.

- `frontend/src/pages/Downloads.jsx`: added one `<Text>` element below the empty-state heading
- `frontend/src/pages/Scheduled.jsx`: added one `<Text>` element below the empty-state heading

## How it was tested

App built and run locally. Playwright screenshots taken at 1280px (desktop) and 390px (mobile) for both tabs, before and after. Screenshots posted to #design on Discord.

Before: only the heading line visible.
After: heading + context line, wraps cleanly on mobile.