### PR TITLE
Add changelog entries for PRs #25, #28, #29, #30, #31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,46 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Improved: Scheduled Recordings page now explains what it is for and how to schedule a show
+
+**What you would notice:** When you open Scheduled Recordings and the list is empty, the page now shows a brief description explaining that scheduled recordings let you set programs to download automatically when they air. It also tells you to go to Browse, find an upcoming show, and click Schedule to set one up. The "Go to Browse" button is now also orange, matching other primary action buttons in the app.
+
+**What changed:** A short description and instructions were added to the Scheduled Recordings empty state. The "Go to Browse" button was changed from a faded style to the standard orange button.
+
+---
+
+### Fixed: Browse showed no catchup-available channels on some providers
+
+**What you would notice:** On certain IPTV providers, the Browse page loaded your channel list but none of the channels showed the mustard-yellow border that indicates catchup is available. The page appeared to offer nothing to download even when your plan included full catchup access.
+
+**What changed:** Some providers send the catchup flag for a channel as the text "1" instead of the number 1. Mustarrd now accepts both formats. Channels with catchup available now highlight correctly regardless of how the provider sends the flag.
+
+---
+
+### Improved: Downloads page empty state is clearer and easier to act on
+
+**What you would notice:** When you open Downloads and nothing has been downloaded yet, the "Go to Browse" button is now orange and easy to spot. Before this change it appeared in a faded olive color that blended into the background and looked like it might be disabled. A short note now explains that this is where your completed downloads will appear.
+
+**What changed:** The "Go to Browse" button on the empty Downloads page now uses the standard orange button style, and a one-line explanation was added below the page heading.
+
+---
+
+### Fixed: Programs with missing timestamps no longer crash with a server error
+
+**What you would notice:** Some IPTV providers leave start and end times out of certain entries in their program guide. If you clicked on one of those entries in Browse, Mustarrd returned a generic server error with no explanation. It now shows a clear message saying the program has no valid time information.
+
+**What changed:** Mustarrd now returns a readable error message when a program in the guide has no valid start or end time, instead of crashing with an internal server error.
+
+---
+
+### Fixed: Retrying a cancelled download no longer leaves it stuck as Pending forever
+
+**What you would notice:** If you cancelled a download and then clicked Retry, the download would show as Pending and never start. The only way to get it moving was to restart Mustarrd.
+
+**What changed:** When a download is cancelled, Mustarrd marks it internally so the download worker knows to stop processing it. The Retry action was not clearing that mark, so the worker silently ignored the download after it was re-queued. Retrying now clears the mark correctly so the download starts.
+
+---
+
 ## 2026-04-29
 
 ### Fixed: Show times now display in the channel's local time


### PR DESCRIPTION
## What this PR does

Adds plain-English changelog entries for five PRs that merged to main since the last Scribe run.

## Entries added

- **PR #25** (Improved): Scheduled Recordings empty state now explains what the page is for and how to schedule a show. The Go to Browse button is now orange.
- **PR #28** (Fixed): Browse now correctly highlights channels with catchup available on providers that send the catchup flag as text ("1") instead of a number (1).
- **PR #29** (Improved): Downloads empty state button is now orange and includes a one-line explanation of what the page is for.
- **PR #30** (Fixed): Programs with missing timestamps in the guide no longer crash Mustarrd with a server error. A clear message is returned instead.
- **PR #31** (Fixed): Cancelling a download and clicking Retry no longer leaves the download stuck as Pending forever.

No changelog entries for PR #26 (internal CI workflow), PR #27 (design spec only), or PR #32 (regression tests only).

## What was checked

- No em dashes in any added text.
- README and Unraid template reviewed: no updates needed for these PRs.
- README line 106 (filename templates) still intentionally left as-is, waiting on the fix PR.

## How it was tested

Diff reviewed against each PR's commit message and code change to confirm entries are accurate. All entries written for a non-technical Unraid user.