### PR TITLE
Add changelog entries for PRs #33 and #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-06
 
+### Fixed: ComSkip commercial removal no longer fails when it produces unusual timing values
+
+**What you would notice:** After a recording finished and ComSkip ran to remove commercials, the download would sometimes end up marked as Failed with a cryptic error message. This happened when ComSkip produced an EDL file (its list of commercial segments) with a timing value it could not compute, such as `N/A`. The rest of the recording was fine but the whole post-processing step was aborted.
+
+**What changed:** Mustarrd now skips over any timing line in ComSkip's output that it cannot read, logs a warning so you can see it happened, and continues processing the rest of the file. A single bad line from ComSkip no longer causes the entire commercial-skip step to fail.
+
+---
+
+### Improved: History tabs now explain what they are for when empty
+
+**What you would notice:** The Downloads page and the Scheduled Recordings page each have a History tab that shows past activity. Before this change, landing on an empty History tab showed a single line saying "No download history yet." or "No schedule history yet." with no further explanation. There was no indication of what would appear there or how to populate it.
+
+**What changed:** Each empty History tab now shows a short description below the heading explaining what the tab is for and what causes entries to appear there. The description is dimmed so it does not distract once the tab has content.
+
+---
+
 ### Fixed: Downloads grabbed the wrong show on many providers
 
 **What you would notice:** When you clicked a program in the guide and started a download, Mustarrd sometimes downloaded a different show, typically one that aired two or more hours away from what you selected. This was most noticeable if your provider uses European or other non-UTC time zones.


### PR DESCRIPTION
## What this PR does

Adds plain-English changelog entries for two PRs that merged to main since the last Scribe run.

## Entries added

- **PR #33** (Fixed): ComSkip commercial removal no longer fails when it produces unusual timing values. When ComSkip outputs a non-numeric EDL timing value (such as `N/A`), Mustarrd now skips that line and continues instead of marking the download as Failed.
- **PR #34** (Improved): History tabs on the Downloads and Scheduled Recordings pages now show a short explanation when empty, so users know what the tab is for and what populates it.

## How it was tested

- Confirmed both entries match the PR descriptions and before/after behavior documented in the original PRs.
- No code changes. CHANGELOG.md only.

## Open PRs at time of this commit

Regular: PR #36 (fix, open), PR #38 (this PR) = 2 of 6.
Design: PR #37 (Pixel, open) = 1 of 3.