### PR TITLE
Add changelog entries for PRs #36, #37, and #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-06
 
+### Fixed: Play and Download no longer fail after you change your download folder in Settings
+
+**What you would notice:** If you ever changed your download or completed folder in Settings (common on Unraid when pointing Mustarrd at a NAS share), clicking Play or Download on any recording would fail with a "403 Forbidden" error. The recording existed on disk but Mustarrd refused to serve it. This happened whether the recording was made before or after the folder change.
+
+**What changed:** Mustarrd now accepts files from both the original default folder and any folder you configured in Settings. Previously it only checked the built-in default location, which meant any custom folder was blocked. Recordings in your old folder keep working after you switch to a new one.
+
+---
+
+### Improved: First-time setup now shows the password minimum length upfront
+
+**What you would notice:** On a fresh install, the Password field on the setup screen now shows "Minimum 8 characters" below it. Before this change, there was no hint. If you typed a short password and clicked Save, you got an error message after the fact. The requirement is now visible before you click anything.
+
+**What changed:** A short note was added below the Password field on the setup and invite-link screens. No other screens are affected and no behavior changed.
+
+---
+
 ### Fixed: ComSkip commercial removal no longer fails when it produces unusual timing values
 
 **What you would notice:** After a recording finished and ComSkip ran to remove commercials, the download would sometimes end up marked as Failed with a cryptic error message. This happened when ComSkip produced an EDL file (its list of commercial segments) with a timing value it could not compute, such as `N/A`. The rest of the recording was fine but the whole post-processing step was aborted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Fixed: Searching the program guide with special characters no longer returns wrong results
+
+**What you would notice:** If you typed a `%` sign or multiple underscores into the program guide search box, you got completely wrong results. Searching just `%` returned every program in the database regardless of what you were looking for. Searching a string of underscores like `_____` could cause a slow, unresponsive search. Any literal search that happened to contain these characters was broken.
+
+**What changed:** Mustarrd now treats `%` and `_` as plain text when you type them in the search box, rather than as special database wildcard characters. Search results now match what you actually typed.
+
+---
+
 ### Fixed: ComSkip commercial removal no longer fails when it produces unusual timing values
 
 **What you would notice:** After a recording finished and ComSkip ran to remove commercials, the download would sometimes end up marked as Failed with a cryptic error message. This happened when ComSkip produced an EDL file (its list of commercial segments) with a timing value it could not compute, such as `N/A`. The rest of the recording was fine but the whole post-processing step was aborted.


### PR DESCRIPTION
## What this does

Adds three plain-English changelog entries that were missing after recent merges.

**PR #36** — Fixed: Play and Download no longer fail after you change your download folder in Settings. Covers the 403 Forbidden error users saw when Mustarrd only checked the default folder path.

**PR #37** — Improved: First-time setup now shows the password minimum length upfront. Covers the "Minimum 8 characters" hint added below the Password field.

**PR #40** — Fixed: Searching the program guide with special characters no longer returns wrong results. Covers the escaped `%` and `_` wildcard fix so literal search works correctly.

## How it was tested

Reviewed CHANGELOG on main, confirmed all three entries were absent, drafted entries matched to what a non-technical Unraid user would notice, and ran a CHANGELOG diff to confirm no em dashes and no formatting issues.

## Before / After

Before: main CHANGELOG had no entries for these three merged PRs.

After: Three new entries at the top of the 2026-06-06 section, each explaining what the user would notice and what changed.