### PR TITLE
Fix authenticate() accepting auth=0 and get_epg() returning None for null listings

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -43,6 +43,8 @@ class XtreamClient:
             data = await response.json()
             if "user_info" not in data:
                 raise Exception("Invalid response from server")
+            if not data["user_info"].get("auth", 1):
+                raise Exception("Invalid credentials")
             return data
 
     async def get_live_categories(self) -> list:
@@ -71,7 +73,7 @@ class XtreamClient:
             if response.status != 200:
                 raise Exception(f"Failed to get EPG: HTTP {response.status}")
             data = await response.json()
-            return data.get("epg_listings", [])
+            return data.get("epg_listings") or []
 
     async def get_short_epg(self, stream_id: str, limit: int = 10) -> list:
         """Get short EPG (current + upcoming) for a channel."""
@@ -81,7 +83,7 @@ class XtreamClient:
             if response.status != 200:
                 raise Exception(f"Failed to get short EPG: HTTP {response.status}")
             data = await response.json()
-            return data.get("epg_listings", [])
+            return data.get("epg_listings") or []
 
     async def get_xmltv(self) -> bytes:
         """Get XMLTV guide data."""

--- a/backend/tests/test_xtream_client_auth_null.py
+++ b/backend/tests/test_xtream_client_auth_null.py
@@ -1,0 +1,97 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.xtream_client import XtreamClient
+
+
+def _mock_session(json_data, status=200):
+    """Return a patched _get_session that yields a response with the given JSON."""
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=cm)
+    get_session = AsyncMock(return_value=session)
+    return get_session
+
+
+def _client():
+    return XtreamClient("http://provider.test:8080", "user", "pass")
+
+
+class AuthenticateAuthFlagTests(unittest.IsolatedAsyncioTestCase):
+    async def test_auth_zero_raises_invalid_credentials(self):
+        client = _client()
+        client._get_session = _mock_session({"user_info": {"auth": 0, "status": "Disabled"}})
+        with self.assertRaises(Exception) as ctx:
+            await client.authenticate()
+        self.assertIn("Invalid credentials", str(ctx.exception))
+
+    async def test_auth_one_succeeds(self):
+        client = _client()
+        data = {"user_info": {"auth": 1, "username": "user"}, "server_info": {}}
+        client._get_session = _mock_session(data)
+        result = await client.authenticate()
+        self.assertEqual(result["user_info"]["auth"], 1)
+
+    async def test_auth_key_absent_treated_as_valid(self):
+        """Providers that omit the auth field are not rejected."""
+        client = _client()
+        data = {"user_info": {"username": "user"}, "server_info": {}}
+        client._get_session = _mock_session(data)
+        result = await client.authenticate()
+        self.assertIn("user_info", result)
+
+    async def test_missing_user_info_raises(self):
+        client = _client()
+        client._get_session = _mock_session({})
+        with self.assertRaises(Exception) as ctx:
+            await client.authenticate()
+        self.assertIn("Invalid response", str(ctx.exception))
+
+
+class GetEpgNullListingsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_epg_null_listings_returns_empty_list(self):
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": None})
+        self.assertEqual(await client.get_epg("1"), [])
+
+    async def test_get_epg_absent_listings_returns_empty_list(self):
+        client = _client()
+        client._get_session = _mock_session({})
+        self.assertEqual(await client.get_epg("1"), [])
+
+    async def test_get_epg_real_listings_passed_through(self):
+        client = _client()
+        entries = [{"id": "1", "title": "News"}]
+        client._get_session = _mock_session({"epg_listings": entries})
+        self.assertEqual(await client.get_epg("1"), entries)
+
+    async def test_get_short_epg_null_listings_returns_empty_list(self):
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": None})
+        self.assertEqual(await client.get_short_epg("1"), [])
+
+    async def test_get_short_epg_absent_listings_returns_empty_list(self):
+        client = _client()
+        client._get_session = _mock_session({})
+        self.assertEqual(await client.get_short_epg("1"), [])
+
+    async def test_get_short_epg_real_listings_passed_through(self):
+        client = _client()
+        entries = [{"id": "2", "title": "Sports"}]
+        client._get_session = _mock_session({"epg_listings": entries})
+        self.assertEqual(await client.get_short_epg("1"), entries)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

**Bug 1:** Adding an IPTV account with wrong credentials could show "account saved" with no error. Many providers return HTTP 200 with `{"user_info": {"auth": 0}}` for bad credentials. Mustarrd accepted this as success, saved the account, and fired an EPG refresh that silently failed. The user saw an empty Browse page with no explanation.

**Bug 2:** On providers that return `{"epg_listings": null}` (key present but null value) for channels with no EPG configured, navigating to that channel in Browse crashed with HTTP 500, or silently showed an empty program list depending on the code path hit.

## What changed

**Fix 1** (`backend/services/xtream_client.py:46`): After parsing the provider response in `authenticate()`, check `user_info.get("auth", 1)`. If it is falsy (0 or absent-and-defaulted-false), raise "Invalid credentials". Providers that omit the `auth` field entirely are not affected.

```python
# Before
if "user_info" not in data:
    raise Exception("Invalid response from server")
return data  # auth=0 accepted silently

# After
if "user_info" not in data:
    raise Exception("Invalid response from server")
if not data["user_info"].get("auth", 1):
    raise Exception("Invalid credentials")
return data
```

**Fix 2** (`backend/services/xtream_client.py:74,84`): Change `data.get("epg_listings", [])` to `data.get("epg_listings") or []` in both `get_epg()` and `get_short_epg()`. Python's `.get(key, default)` only uses the default when the key is absent; when the key is present but `null`, it returns `None`. The `or []` form covers both cases.

```python
# Before
return data.get("epg_listings", [])  # returns None when key=null

# After
return data.get("epg_listings") or []  # returns [] for null or absent
```

## How it was tested

Ten new unit tests in `backend/tests/test_xtream_client_auth_null.py`:

- `auth=0` raises "Invalid credentials"
- `auth=1` succeeds and returns the full response
- missing `auth` key is treated as valid (provider compatibility)
- missing `user_info` key still raises "Invalid response from server"
- `get_epg()` returns `[]` for `null` listings
- `get_epg()` returns `[]` when listings key absent
- `get_epg()` passes real listings through unchanged
- `get_short_epg()` returns `[]` for `null` listings
- `get_short_epg()` returns `[]` when listings key absent
- `get_short_epg()` passes real listings through unchanged

Full suite: 92/92 passing.

**Before (authenticate, bad credentials):**
```
Provider returns {"user_info": {"auth": 0, "status": "Disabled"}}
Result: account saved as active, EPG refresh fires and returns nothing, Browse empty.
```

**After:**
```
Provider returns {"user_info": {"auth": 0, "status": "Disabled"}}
Result: Exception("Invalid credentials") raised, account not saved, user sees error.
```

**Before (get_epg, null listings):**
```
Provider returns {"epg_listings": null}
Result: TypeError: 'NoneType' is not iterable, HTTP 500.
```

**After:**
```
Provider returns {"epg_listings": null}
Result: empty list returned, Browse shows no programs for that channel, no crash.
```