### PR TITLE
Fix POST /auth/login always failing for non-default admin usernames

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -348,9 +348,12 @@ async def login_auth_legacy(
     request: Request,
     session: AsyncSession = Depends(get_session),
 ):
-    # Compatibility wrapper: logs in admin user "admin" if present.
+    # Compatibility wrapper: finds the active admin by role, not by name.
+    admin = await get_admin_user(session)
+    if not admin:
+        raise HTTPException(status_code=401, detail="Authentication failed")
     return await login_credentials(
-        CredentialsLoginPayload(username="admin", password=payload.password),
+        CredentialsLoginPayload(username=admin.username, password=payload.password),
         request,
         session,
     )

--- a/backend/tests/test_legacy_login_admin_username.py
+++ b/backend/tests/test_legacy_login_admin_username.py
@@ -1,0 +1,75 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from api.auth import login_auth_legacy, PasswordPayload
+
+
+def _make_user(username):
+    user = MagicMock()
+    user.username = username
+    return user
+
+
+def _make_request():
+    return MagicMock()
+
+
+class LegacyLoginAdminUsernameTests(unittest.IsolatedAsyncioTestCase):
+    async def test_custom_admin_username_passed_to_login_credentials(self):
+        """Admin with username 'tyler' can log in via the legacy endpoint."""
+        payload = PasswordPayload(password="Test1234!")
+        request = _make_request()
+        session = MagicMock()
+
+        admin_user = _make_user("tyler")
+
+        with (
+            patch("api.auth.get_admin_user", new=AsyncMock(return_value=admin_user)),
+            patch("api.auth.login_credentials", new=AsyncMock(return_value={"status": "authenticated"})) as mock_login,
+        ):
+            result = await login_auth_legacy(payload, request, session)
+
+        self.assertEqual(result["status"], "authenticated")
+        call_payload = mock_login.call_args[0][0]
+        self.assertEqual(call_payload.username, "tyler")
+        self.assertEqual(call_payload.password, "Test1234!")
+
+    async def test_no_admin_user_returns_401(self):
+        """Legacy endpoint returns 401 when no admin user exists."""
+        payload = PasswordPayload(password="Test1234!")
+        request = _make_request()
+        session = MagicMock()
+
+        with patch("api.auth.get_admin_user", new=AsyncMock(return_value=None)):
+            with self.assertRaises(HTTPException) as ctx:
+                await login_auth_legacy(payload, request, session)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    async def test_default_admin_username_still_works(self):
+        """Admin with the default username 'admin' continues to work."""
+        payload = PasswordPayload(password="Test1234!")
+        request = _make_request()
+        session = MagicMock()
+
+        admin_user = _make_user("admin")
+
+        with (
+            patch("api.auth.get_admin_user", new=AsyncMock(return_value=admin_user)),
+            patch("api.auth.login_credentials", new=AsyncMock(return_value={"status": "authenticated"})) as mock_login,
+        ):
+            result = await login_auth_legacy(payload, request, session)
+
+        call_payload = mock_login.call_args[0][0]
+        self.assertEqual(call_payload.username, "admin")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Any operator who chose a custom admin username during setup (for example, "tyler" instead of the default "admin") got a permanent 401 "Authentication failed" error when logging in, even with the correct password. The only workaround was to use the separate `/auth/login-credentials` endpoint, which most frontends and integrations don't expose to the user. There was no error message to explain what was wrong.

## What changed

`POST /auth/login` (the legacy single-password login endpoint) hardcoded `username="admin"` when it called the internal `login_credentials` helper. If the admin's real username was anything else, the lookup failed and returned 401.

Fix: the endpoint now calls `get_admin_user()` to find the active admin by role, then passes their real username to `login_credentials`. If no admin exists, it returns 401 immediately.

```python
# Before
return await login_credentials(
    CredentialsLoginPayload(username="admin", password=payload.password),
    ...
)

# After
admin = await get_admin_user(session)
if not admin:
    raise HTTPException(status_code=401, detail="Authentication failed")
return await login_credentials(
    CredentialsLoginPayload(username=admin.username, password=payload.password),
    ...
)
```

## How it was tested

Three regression tests in `backend/tests/test_legacy_login_admin_username.py`:

- Custom username "tyler": legacy endpoint passes "tyler" to `login_credentials`, not "admin"
- No admin user: returns 401 immediately
- Default username "admin": still works as before

Full suite: 94/94 passing.

**Before:**
```
POST /api/auth/login {"password": "Test1234!"}
Admin username: "tyler"
Result: 401 Authentication failed
```

**After:**
```
POST /api/auth/login {"password": "Test1234!"}
Admin username: "tyler"
Result: 200 authenticated
```