### PR TITLE
Add connection status badge to Accounts page

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -14,6 +14,7 @@ import {
   Loader,
   Alert,
   NumberInput,
+  Box,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
@@ -32,6 +33,18 @@ import {
 import dayjs from 'dayjs'
 
 import { accountsApi, channelsApi, epgApi, settingsApi } from '../../api'
+
+function timeAgo(dateStr) {
+  if (!dateStr) return null
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
 
 function getGuideOffsetLabel(account) {
   const offset = Number(account?.guide_offset_hours || 0)
@@ -195,6 +208,42 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
             {isExpired ? 'Expired' : `Expires ${dayjs(account.expiration_date).format('MMM D, YYYY')}`}
           </Badge>
         )}
+      </Group>
+
+      <Group mt="xs" gap={6} align="center">
+        <Box
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            flexShrink: 0,
+            backgroundColor:
+              account.last_connection_ok === true
+                ? 'var(--mantine-color-green-6)'
+                : account.last_connection_ok === false
+                ? 'var(--mantine-color-red-6)'
+                : 'var(--mantine-color-gray-5)',
+          }}
+        />
+        <Text
+          size="xs"
+          c={
+            account.last_connection_ok === true
+              ? 'green'
+              : account.last_connection_ok === false
+              ? 'red'
+              : 'dimmed'
+          }
+        >
+          {account.last_connection_ok === true
+            ? 'Connected'
+            : account.last_connection_ok === false
+            ? 'Unreachable'
+            : 'Not checked yet'}
+          {account.last_connection_checked_at
+            ? ` · ${timeAgo(account.last_connection_checked_at)}`
+            : ''}
+        </Text>
       </Group>
     </Card>
   )


### PR DESCRIPTION
## What a user will notice

Each account card in Settings > Accounts now shows a small colored dot with a label:

- **Green dot + "Connected"** after a successful EPG refresh
- **Red dot + "Unreachable"** after a failed EPG refresh (network error, bad credentials, etc.)
- **Gray dot + "Not checked yet"** for accounts that have never had an EPG refresh

When a check has run, the label also shows how long ago it happened, for example "Connected · 5m ago" or "Unreachable · 2h ago".

Before this, a user whose provider went offline would see an empty Browse with no indication of why. Now they can check Accounts and immediately see which provider is unreachable.

## What changed

Added a dot indicator and status text row to each account card in `frontend/src/components/settings/AccountsSection.jsx`. The badge reads `last_connection_ok` and `last_connection_checked_at` from the account API response.

**Note:** This PR is the frontend half. The backend fields (`last_connection_ok`, `last_connection_checked_at`) are added to the accounts table and written after each EPG refresh in a separate backend PR (Clementine). Until that PR merges, all accounts show "Not checked yet", which is the correct graceful fallback.

## How it was tested

Code verified against the spec. The component handles all three states correctly:
- `last_connection_ok === true`: green dot, "Connected", timestamp
- `last_connection_ok === false`: red dot, "Unreachable", timestamp
- `last_connection_ok === null / undefined`: gray dot, "Not checked yet", no timestamp

Full green/red screenshots will follow once Clementine's backend PR adds the fields. The "Not checked yet" state is visible immediately on the current build.

## WIP

Regular PRs: 1/6. Design PRs: 1/3 (PR #43).