### PR TITLE
Add changelog entries for PRs #45, #47, and #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-06
 
+### Improved: Each account in Settings now shows whether it can reach your provider
+
+**What you would notice:** In Settings > Accounts, each account card now shows a colored status indicator next to the account name. A green dot labeled "Connected" means Mustarrd successfully connected during the last program guide refresh. A red dot labeled "Unreachable" means the last attempt failed. New accounts show "Not checked yet" until the first program guide refresh runs. A note shows how long ago the last check completed.
+
+**What changed:** Mustarrd now records whether each program guide refresh attempt succeeded or failed. Two new fields on each account track the result and the time it was last checked. The Accounts page reads those fields and shows the status indicator without making any extra network calls.
+
+---
+
+### Improved: Setting up your first account is now simpler
+
+**What you would notice:** On a fresh install with no accounts configured, the Accounts page now shows only an "Add Your First Account" button in the center of the screen. The "Force EPG Refresh" button and an "Add Account" button in the header are hidden until you have at least one account saved. Once you have an account, the header shows "Add Another Account" and "Force EPG Refresh" as before.
+
+**What changed:** The header buttons on the Accounts page now appear or disappear based on whether any accounts are configured. This removes confusing options on first-time setup when there is nothing to refresh yet.
+
+---
+
 ### Fixed: Logging in now works when your admin account uses a username other than "admin"
 
 **What you would notice:** If you set up Mustarrd with a custom admin username (anything other than the default "admin"), you would be unable to log in. The login form would reject your credentials even when the password was correct. Login now works for any admin username.


### PR DESCRIPTION
## What changed

Added plain-English changelog entries for three features that shipped in the last iteration but had no user-facing documentation yet.

## Entries added

**PR #47 + PR #45: Connection status badge on the Accounts page**
- Settings > Accounts now shows a colored dot (Connected / Unreachable / Not checked yet) per account
- Timestamp shows how long ago the last check ran
- No new setup steps required

**PR #52: Simplified first-account flow on the Accounts page**
- Fresh install shows only "Add Your First Account" in the center; header buttons hidden until an account exists
- Once accounts exist, "Add Account" becomes "Add Another Account" and "Force EPG Refresh" appears

## Testing

Docs only. No code changed. Entries verified against PR descriptions and merged commit messages.