### PR TITLE
Fix EPG wipe when provider omits tv_archive_duration; fix tv_no_subtitle template skipped when tv_template set

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -210,12 +210,7 @@ class EPGIngestManager:
                         for stream_id, info in channel_maps["stream_info"].items():
                             archive_days = int(info.get("archive_days") or 0)
                             if archive_days <= 0:
-                                await session.execute(
-                                    delete(EPGProgram).where(
-                                        EPGProgram.account_id == account.id,
-                                        EPGProgram.channel_id == stream_id,
-                                    )
-                                )
+                                # archive window unknown: preserve existing rows
                                 continue
                             channel_cutoff = now_utc - timedelta(days=archive_days)
                             await session.execute(
@@ -440,13 +435,11 @@ class EPGIngestManager:
             start_utc = start_dt.astimezone(timezone.utc)
             end_utc = end_dt.astimezone(timezone.utc)
             archive_days = int(stream_info[stream_id].get("archive_days") or 0)
-            if archive_days <= 0:
-                elem.clear()
-                continue
-            channel_cutoff = now_utc - timedelta(days=archive_days)
-            if end_utc < channel_cutoff:
-                elem.clear()
-                continue
+            if archive_days > 0:
+                channel_cutoff = now_utc - timedelta(days=archive_days)
+                if end_utc < channel_cutoff:
+                    elem.clear()
+                    continue
 
             duration_minutes = int((end_utc - start_utc).total_seconds() / 60)
             if duration_minutes <= 0:

--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -145,7 +145,7 @@ class FileNamer:
                     "title": episode_title, "date": date_str, "channel": channel_name,
                 }
                 custom = s.get("tv_template")
-                if custom:
+                if custom and episode_title:
                     template = custom
                 elif episode_title:
                     template = self._DEFAULT_TEMPLATES["tv"]

--- a/backend/tests/test_epg_archive_duration_missing.py
+++ b/backend/tests/test_epg_archive_duration_missing.py
@@ -1,0 +1,115 @@
+"""
+Regression tests for the EPG wipe caused by missing tv_archive_duration.
+
+When a provider sets tv_archive=1 but omits tv_archive_duration, archive_days
+returns 0. Previously the ingest deleted all EPGProgram rows for those channels
+and skipped inserting new XMLTV programs. Both bugs are now fixed.
+"""
+import sys
+import textwrap
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+from services.epg_service import EPGService
+
+
+class ArchiveDaysForChannelTests(unittest.TestCase):
+    """EPGService.archive_days_for_channel covers common provider edge cases."""
+
+    def test_missing_duration_returns_zero(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive": 1}), 0)
+
+    def test_none_duration_returns_zero(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive": 1, "tv_archive_duration": None}), 0)
+
+    def test_non_numeric_duration_returns_zero(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": "unlimited"}), 0)
+
+    def test_numeric_string_duration_parsed(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": "7"}), 7)
+
+    def test_int_duration_parsed(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 30}), 30)
+
+    def test_negative_duration_clamped_to_zero(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": -5}), 0)
+
+    def test_over_365_clamped(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 999}), 365)
+
+
+class IterProgramsArchiveUnknownTests(unittest.TestCase):
+    """_iter_programs must yield XMLTV programs for channels with archive_days==0."""
+
+    _XMLTV = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <tv>
+          <channel id="ch1">
+            <display-name>Test Channel</display-name>
+          </channel>
+          <programme start="20260601120000 +0000" stop="20260601130000 +0000" channel="ch1">
+            <title>Recent Program</title>
+          </programme>
+          <programme start="20260101120000 +0000" stop="20260101130000 +0000" channel="ch1">
+            <title>Old Program</title>
+          </programme>
+        </tv>
+    """).encode()
+
+    def _make_channel_maps(self, archive_days):
+        return {
+            "stream_by_xmltv_id": {"ch1": "101"},
+            "stream_by_name": {},
+            "stream_info": {
+                "101": {"name": "Test Channel", "has_archive": True, "archive_days": archive_days},
+            },
+        }
+
+    def test_archive_days_zero_yields_all_xmltv_programs(self):
+        """When archive_days==0 (duration missing from provider), all XMLTV programs are inserted."""
+        manager = EPGIngestManager()
+        now = datetime(2026, 6, 7, 0, 0, 0, tzinfo=timezone.utc)
+        channel_maps = self._make_channel_maps(archive_days=0)
+
+        programs = list(manager._iter_programs(self._XMLTV, channel_maps, now))
+
+        titles = {p["title"] for p in programs}
+        self.assertIn("Recent Program", titles)
+        self.assertIn("Old Program", titles)
+
+    def test_archive_days_positive_filters_old_programs(self):
+        """When archive_days is set, programs before the cutoff are excluded (regression guard)."""
+        manager = EPGIngestManager()
+        now = datetime(2026, 6, 7, 0, 0, 0, tzinfo=timezone.utc)
+        channel_maps = self._make_channel_maps(archive_days=7)
+
+        programs = list(manager._iter_programs(self._XMLTV, channel_maps, now))
+
+        titles = {p["title"] for p in programs}
+        self.assertIn("Recent Program", titles)
+        self.assertNotIn("Old Program", titles)
+
+    def test_archive_days_zero_program_fields_populated(self):
+        """Programs yielded for archive_days==0 channels have the expected fields."""
+        manager = EPGIngestManager()
+        now = datetime(2026, 6, 7, 0, 0, 0, tzinfo=timezone.utc)
+        channel_maps = self._make_channel_maps(archive_days=0)
+
+        programs = list(manager._iter_programs(self._XMLTV, channel_maps, now))
+        recent = next(p for p in programs if p["title"] == "Recent Program")
+
+        self.assertEqual(recent["channel_id"], "101")
+        self.assertEqual(recent["channel_name"], "Test Channel")
+        self.assertIn("epg_id", recent)
+        self.assertIn("start_time", recent)
+        self.assertIn("end_time", recent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_filename_templates.py
+++ b/backend/tests/test_filename_templates.py
@@ -70,6 +70,16 @@ class TemplateWiringTests(unittest.TestCase):
         )
         self.assertEqual(result, "Breaking Bad - S01E01.ts")
 
+    def test_tv_no_subtitle_with_default_tv_template_set(self):
+        # AppSettings always ships a default tv_template, so settings will always
+        # have tv_template set. The no-subtitle branch must still be used when
+        # episode_title is empty, even when tv_template is present.
+        settings = {"tv_template": "{show} - S{season:02d}E{episode:02d} - {title}"}
+        result = FileNamer().generate_filename(
+            _prog("Breaking Bad S01E01"), _channel(), "tv_show", settings
+        )
+        self.assertEqual(result, "Breaking Bad - S01E01.ts")
+
     def test_tv_with_subtitle_includes_episode_title(self):
         result = FileNamer().generate_filename(
             _prog("Breaking Bad S01E01 - Pilot"), _channel(), "tv_show"


### PR DESCRIPTION
## What changed and why

Two related filename and EPG reliability fixes.

### Fix 1: EPG wipe when provider omits tv_archive_duration

**What a user would notice:** After every EPG refresh, catchup history would disappear for any channel where the provider sets `tv_archive=1` (archive available) but leaves out `tv_archive_duration`. The app treated a missing duration as "no archive" and deleted all stored program rows, wiping the Browse page for those channels on each refresh.

**What changed:** When `archive_days` comes back as 0 (unknown window), the ingest now preserves existing EPG rows instead of deleting them, and still inserts new XMLTV programs without applying a cutoff filter. Backfill is still skipped since we don't know how far back the provider holds content.

**Before:**
```
# Channel has tv_archive=1 but no tv_archive_duration
archive_days = 0
# → ingest deleted all rows, skipped XMLTV insert → Browse page empty after every refresh
```

**After:**
```
archive_days = 0
# → ingest preserves existing rows, inserts XMLTV programs without cutoff → Browse page stays populated
```

### Fix 2: tv_no_subtitle template ignored when tv_template setting is present

**What a user would notice:** A show like "Breaking Bad S01E01" (episode with no subtitle) would render as `Breaking Bad - S01E01 - .ts` with a trailing dash and space, instead of cleanly `Breaking Bad - S01E01.ts`. This only happened when a custom `tv_template` was saved in settings.

**What changed:** The no-subtitle branch now gates on whether `episode_title` is non-empty, not on whether a `tv_template` setting exists. A present but non-empty `tv_template` no longer hides the `tv_no_subtitle` template.

**Before:**
```
Breaking Bad - S01E01 - .ts   ← trailing separator, ugly filename
```

**After:**
```
Breaking Bad - S01E01.ts      ← clean
```

## How it was tested

- 133 backend unit tests pass (`python -m unittest discover -s tests`)
- New tests added:
  - `test_epg_archive_duration_missing.py`: covers `archive_days_for_channel` edge cases and `_iter_programs` yielding vs. filtering behavior when `archive_days=0`
  - `test_filename_templates.py`: adds `test_tv_no_subtitle_with_default_tv_template_set` covering the previously broken case