### PR TITLE
Add changelog entries for PRs #50, #51, #54, #55, and #58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+## 2026-06-07
+
+### Fixed: Program guide no longer goes blank when your provider does not include a catchup window length
+
+**What you would notice:** On some IPTV providers, the program guide would go completely blank after a refresh. The Browse page would show no programs even though your channels were still listed. Mustarrd now keeps your existing program guide data in this case.
+
+**What changed:** When a provider sends channel information without a catchup window length, Mustarrd was treating the missing value as zero and deleting all stored program guide entries for that channel. It now treats a missing catchup window as "unknown" and keeps whatever program data is already stored.
+
+---
+
+### Fixed: TV episode filenames no longer end with a trailing dash when a custom filename template is set
+
+**What you would notice:** If you had customized the TV filename template in Settings, episodes with no subtitle would produce filenames with a trailing separator, for example "Breaking Bad - S01E01 - .ts" instead of "Breaking Bad - S01E01.ts". This only happened when a custom template was saved in Settings; the default template was not affected.
+
+**What changed:** The filename builder was not checking whether an episode title existed before applying a custom template. It now checks first, and falls back to the no-subtitle format when no episode title is available.
+
+---
+
+### Fixed: Hidden characters from RTL-language providers no longer appear in filenames or break Plex and Jellyfin matching
+
+**What you would notice:** If your IPTV provider is Arabic, Hebrew, Persian, or another right-to-left language, channel names and program titles may contain invisible formatting characters that are not visible to you but are present in the text. These characters ended up in your filenames, causing files to appear invisible or fail to match in Plex and Jellyfin. Filenames are now cleaned of these characters before the file is saved.
+
+**What changed:** Seven invisible Unicode characters (including zero-width space, directional marks, and soft hyphen) are now stripped from channel names and program titles before they reach the filename. They are removed rather than replaced with spaces so that words remain joined correctly.
+
+---
+
 ## 2026-06-06
 
 ### Improved: Each account in Settings now shows whether it can reach your provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Fixed: Browse page no longer shows a blank error when loading a channel guide on a fresh install
+
+**What you would notice:** On a fresh install, or immediately after clearing your program database, opening the Browse page for a channel would show a blank error page instead of the guide. Once the guide had been populated at least once, the error stopped. The guide now loads correctly on the very first request.
+
+**What changed:** Some IPTV providers send timestamps in milliseconds instead of seconds. The channel guide page was not prepared to handle millisecond timestamps and crashed with an internal server error. It now converts them automatically, matching how the program guide importer already handled the same format.
+
+---
+
+### Fixed: Scheduled recordings older than your provider's catchup window no longer fail silently
+
+**What you would notice:** If Mustarrd restarted (or recovered from a disk-full pause) while a scheduled recording was waiting, any recording whose program had already passed the catchup window would be dispatched anyway. The download would fail with a raw provider error and no explanation. It now fails immediately with a plain message explaining that the catchup window has passed.
+
+**What changed:** The scheduler now checks whether a pending recording is still within the provider's catchup window before attempting to download it. If the window has passed, the recording is marked as failed with an explanation instead of being sent to a download that cannot succeed.
+
+---
+
+### Fixed: Pre- and post-recording padding can no longer be set to an unreasonably large value
+
+**What you would notice:** In Schedule settings, you can add extra minutes before and after a recording to avoid clipping. Previously there was no upper limit, so entering a very large number (such as 10000 minutes) was accepted silently and would lock a download slot for days. Padding is now capped at 120 minutes.
+
+**What changed:** The scheduler now rejects pre- and post-padding values above 120 minutes with a validation error instead of accepting them.
+
+---
+
 ### Fixed: Program guide no longer goes blank when your provider does not include a catchup window length
 
 **What you would notice:** On some IPTV providers, the program guide would go completely blank after a refresh. The Browse page would show no programs even though your channels were still listed. Mustarrd now keeps your existing program guide data in this case.


### PR DESCRIPTION
## What a user would notice

Five entries added to the changelog under a new 2026-06-07 section.

## What changed

- **PR #58 (millisecond timestamps):** Browse page no longer shows a blank error on a fresh install when providers send ms timestamps.
- **PR #51 (stale dispatch + padding bounds):** Stale scheduled recordings now fail with a plain-English message. Pre/post padding capped at 120 minutes.
- **PR #50 (EPG wipe fix):** Program guide no longer goes blank when a provider omits catchup window length. Also covers the trailing-dash TV filename bug with custom templates.
- **PR #54 (invisible Unicode):** Hidden characters from RTL-language providers no longer corrupt filenames or break Plex and Jellyfin matching.
- **PR #55 (mobile screenshots):** Design/docs-only change. No changelog entry added since it has no user-visible app behavior change.

## How tested

- No em dashes anywhere in new entries.
- Entries written for a non-technical Unraid operator: plain English, what you would notice, what changed.