### PR TITLE
Fix sanitize_filename empty string producing hidden .ts file

### DIFF
--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -32,7 +32,7 @@ class FileNamer:
         # Remove multiple spaces
         sanitized = re.sub(r'\s+', ' ', sanitized)
         # Remove leading/trailing spaces and dots
-        sanitized = sanitized.strip(' .')
+        sanitized = sanitized.strip(' .') or "unknown-program"
         # Limit length
         if len(sanitized) > 200:
             sanitized = sanitized[:200]

--- a/backend/tests/test_file_namer.py
+++ b/backend/tests/test_file_namer.py
@@ -37,6 +37,28 @@ class SanitizeFilenameTests(unittest.TestCase):
         self.assertNotIn('\\', result)
         self.assertNotIn('?', result)
 
+    def test_all_dots_returns_fallback(self):
+        # "..." strips to "" -> was producing hidden file ".ts"; must return fallback instead
+        result = FileNamer.sanitize_filename("...")
+        self.assertEqual(result, "unknown-program")
+
+    def test_all_spaces_returns_fallback(self):
+        result = FileNamer.sanitize_filename("   ")
+        self.assertEqual(result, "unknown-program")
+
+    def test_all_control_chars_returns_fallback(self):
+        result = FileNamer.sanitize_filename("\x00\x00")
+        self.assertEqual(result, "unknown-program")
+
+    def test_dots_and_spaces_returns_fallback(self):
+        result = FileNamer.sanitize_filename(".. ..")
+        self.assertEqual(result, "unknown-program")
+
+    def test_invisible_unicode_only_returns_fallback(self):
+        # Zero-width space + zero-width non-joiner -> stripped -> fallback
+        result = FileNamer.sanitize_filename("​‌")
+        self.assertEqual(result, "unknown-program")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What a user would notice

If a download had a title made entirely of dots, spaces, or invisible characters (possible with malformed EPG data from some providers), the app would write the file to a hidden file named `.ts` in the download folder. A second download with the same bad title would silently overwrite the first. Both would show as COMPLETED with no error.

## What changed

One line in `backend/services/file_namer.py`: when sanitizing a filename produces an empty string, fall back to `"unknown-program"` instead of an empty string. The downloaded file is now named `unknown-program.ts` rather than `.ts`.

**Before:**
```python
sanitize_filename("...")    # -> ""  ->  filename ".ts"  (hidden file, overwritten each time)
sanitize_filename("   ")    # -> ""  ->  filename ".ts"
sanitize_filename("\x00\x00") # -> ""  ->  filename ".ts"
```

**After:**
```python
sanitize_filename("...")    # -> "unknown-program"  ->  filename "unknown-program.ts"
sanitize_filename("   ")    # -> "unknown-program"  ->  filename "unknown-program.ts"
sanitize_filename("\x00\x00") # -> "unknown-program"  ->  filename "unknown-program.ts"
```

## How tested

5 new regression tests added to `backend/tests/test_file_namer.py` covering dots-only, spaces-only, control-char-only, mixed dots/spaces, and invisible-Unicode-only inputs. Full suite: 150 tests pass.

```
test_all_dots_returns_fallback ... ok
test_all_spaces_returns_fallback ... ok
test_all_control_chars_returns_fallback ... ok
test_dots_and_spaces_returns_fallback ... ok
test_invisible_unicode_only_returns_fallback ... ok
```