### PR TITLE
Add changelog entries for PRs #60 and #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Downloads page now shows how much free space is left on your recording drive
+
+**What you would notice:** At the top of the Downloads page there is now a badge showing how much disk space is available on your recording drive. The badge turns red when space drops below the minimum you configured in Settings. If your recording drive is missing or not mounted (which can happen on Unraid after an array restart or if a share path changes), the badge shows "Recording drive not found" in orange instead of reporting a wrong number from the wrong disk.
+
+**What changed:** The Downloads page now polls a read-only endpoint every 30 seconds to get current free space from the configured recording drive. No directories are created or modified. The check is read-only.
+
+---
+
+### Fixed: Downloads with unreadable program titles no longer create a hidden file that overwrites itself
+
+**What you would notice:** Some IPTV providers send program titles made entirely of spaces, dots, or other characters that are stripped when building a filename. Previously, Mustarrd would create a hidden file named `.ts` for these programs, and each one would silently overwrite the previous. The file appeared to download successfully but could never be found. Downloads with unreadable titles now save as `unknown-program.ts` instead.
+
+**What changed:** When the cleaned program title comes out empty after stripping illegal characters, Mustarrd now uses `unknown-program` as the filename instead of producing a hidden `.ts` file.
+
+---
+
 ### Fixed: Browse page no longer shows a blank error when loading a channel guide on a fresh install
 
 **What you would notice:** On a fresh install, or immediately after clearing your program database, opening the Browse page for a channel would show a blank error page instead of the guide. Once the guide had been populated at least once, the error stopped. The guide now loads correctly on the very first request.


### PR DESCRIPTION
## What this PR does

Adds two plain-English changelog entries to CHANGELOG.md for the features and fixes that shipped in PRs #60 and #61.

## Entries added

- **PR #61** (disk space badge on Downloads page): Explains that the Downloads page now shows free space on the recording drive, turns red below the configured threshold, and shows "Recording drive not found" on Unraid when the drive is unmounted.
- **PR #60** (sanitize_filename empty string fix): Explains that programs with titles made entirely of stripped characters now save as `unknown-program.ts` instead of a hidden `.ts` file that silently overwrites itself.

## How it was tested

Entries verified against the merged PR diffs and Herald's merge summaries. Docs only, no code changed.

Before: CHANGELOG covered through PR #59 (entries for #50, #51, #54, #55, #58).
After: CHANGELOG current through PR #61.