### PR TITLE
Fix transcode_enabled=False ignored: ffmpeg ran on every catchup download

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -216,7 +216,7 @@ class DownloadManager:
             return False
         if not settings:
             return False
-        return True
+        return settings.transcode_enabled or settings.comskip_enabled
 
     def _processed_output_candidates(self, input_path: str, settings: Optional[AppSettings]) -> list[str]:
         input_file = Path(input_path)
@@ -1022,7 +1022,7 @@ class DownloadManager:
         remux_only = getattr(settings, "remux_only", False)
 
         will_comskip = settings.comskip_enabled and post_processor.comskip_available
-        will_transcode = post_processor.ffmpeg_available
+        will_transcode = settings.transcode_enabled and post_processor.ffmpeg_available
 
         if not will_comskip and not will_transcode:
             return current_path, warnings

--- a/backend/tests/test_transcode_enabled_setting.py
+++ b/backend/tests/test_transcode_enabled_setting.py
@@ -1,0 +1,98 @@
+"""
+Regression test: transcode_enabled=False must bypass ffmpeg post-processing.
+
+Bug: _needs_post_processing() always returned True for non-VOD downloads regardless
+of transcode_enabled/comskip_enabled, and will_transcode in _execute_post_process()
+ignored settings.transcode_enabled entirely. Every catchup download was silently
+remuxed to .mkv even when the user disabled transcoding.
+
+Reproduction:
+  1. Settings > disable transcoding (transcode_enabled=False, comskip_enabled=False).
+  2. Download any catchup recording (ffmpeg installed, standard Docker image).
+  3. Logs show "Remuxing to mkv..." and the file is .mkv, not original .ts.
+
+Expected: transcode_enabled=False skips ffmpeg; raw .ts moves straight to completed.
+Actual:   ffmpeg ran on every catchup download regardless of the setting.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+def _make_settings(transcode_enabled: bool, comskip_enabled: bool):
+    s = MagicMock()
+    s.transcode_enabled = transcode_enabled
+    s.comskip_enabled = comskip_enabled
+    return s
+
+
+def _make_download(is_vod: bool = False):
+    d = MagicMock()
+    d.is_vod = is_vod
+    return d
+
+
+class TranscodeEnabledSettingTests(unittest.TestCase):
+    def setUp(self):
+        self.dm = DownloadManager()
+
+    def test_no_post_processing_when_both_disabled(self):
+        """_needs_post_processing must return False when transcode and comskip are both off.
+
+        Before fix: always returned True, causing ffmpeg to run on every download.
+        After fix: returns False, skipping post-processing entirely.
+        """
+        settings = _make_settings(transcode_enabled=False, comskip_enabled=False)
+        download = _make_download(is_vod=False)
+        self.assertFalse(
+            self.dm._needs_post_processing(download, settings),
+            "_needs_post_processing must return False when transcode_enabled=False "
+            "and comskip_enabled=False; ffmpeg should not run.",
+        )
+
+    def test_post_processing_when_transcode_enabled(self):
+        """_needs_post_processing returns True when transcode_enabled=True (default)."""
+        settings = _make_settings(transcode_enabled=True, comskip_enabled=False)
+        download = _make_download(is_vod=False)
+        self.assertTrue(
+            self.dm._needs_post_processing(download, settings),
+            "_needs_post_processing must return True when transcode_enabled=True.",
+        )
+
+    def test_post_processing_when_comskip_enabled(self):
+        """_needs_post_processing returns True when comskip_enabled=True (needs ffmpeg)."""
+        settings = _make_settings(transcode_enabled=False, comskip_enabled=True)
+        download = _make_download(is_vod=False)
+        self.assertTrue(
+            self.dm._needs_post_processing(download, settings),
+            "_needs_post_processing must return True when comskip_enabled=True "
+            "even if transcode_enabled=False.",
+        )
+
+    def test_vod_never_needs_post_processing(self):
+        """VOD downloads skip post-processing regardless of settings (existing behaviour)."""
+        settings = _make_settings(transcode_enabled=True, comskip_enabled=True)
+        download = _make_download(is_vod=True)
+        self.assertFalse(
+            self.dm._needs_post_processing(download, settings),
+            "VOD downloads must never trigger post-processing.",
+        )
+
+    def test_no_settings_skips_post_processing(self):
+        """_needs_post_processing returns False when settings is None (existing behaviour)."""
+        download = _make_download(is_vod=False)
+        self.assertFalse(
+            self.dm._needs_post_processing(download, None),
+            "_needs_post_processing must return False when settings is None.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user notices

With transcoding **disabled** in Settings, every catchup download still gets remuxed to `.mkv` by ffmpeg. The raw `.ts` file never lands in the completed folder. The user's setting has no effect.

## Root cause

Two places in `backend/services/download_manager.py` ignored `settings.transcode_enabled`:

1. `_needs_post_processing()` (line 219) always returned `True` for non-VOD downloads, so post-processing was always triggered.
2. `will_transcode` (line 1025) checked only whether ffmpeg was installed, not whether the user had enabled transcoding.

With the Docker image shipping ffmpeg by default, every catchup recording silently ran through ffmpeg regardless of settings.

## What changed

- `_needs_post_processing()` now returns `False` when both `transcode_enabled` and `comskip_enabled` are off. The file is moved straight to the completed folder with no ffmpeg involvement.
- `will_transcode` now ANDs `settings.transcode_enabled` with `post_processor.ffmpeg_available`, so the transcode branch is skipped when the user disables it.

## Before

```
# Settings: transcode_enabled=False
[INFO] Remuxing to mkv...
[INFO] Post-processing complete: /completed/Show S01E01.mkv
# Original .ts also deleted
```

## After

```
# Settings: transcode_enabled=False
[INFO] Post-processing disabled; finalized completed output.
# File moves directly: Show S01E01.ts -> /completed/Show S01E01.ts
```

## Tests

5 regression tests in `backend/tests/test_transcode_enabled_setting.py`:
- `transcode_enabled=False, comskip_enabled=False` skips post-processing (was broken)
- `transcode_enabled=True` triggers post-processing (sanity)
- `comskip_enabled=True, transcode_enabled=False` still triggers (comskip needs ffmpeg)
- VOD always skips (existing behaviour preserved)
- `settings=None` skips (existing behaviour preserved)

Full suite: 173/173 pass.

## How to test

1. Install with ffmpeg in PATH (standard Docker image).
2. Settings: uncheck "Enable transcoding".
3. Download any catchup recording.
4. Confirm the completed file is `.ts`, not `.mkv`, and logs show no ffmpeg activity.