### PR TITLE
Add changelog entries for PRs #64 and #66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Fixed: The "Enable transcoding" toggle in Settings now works
+
+**What you would notice:** If you had "Enable transcoding" turned off in Settings, Mustarrd was ignoring that setting and running every catchup download through ffmpeg anyway. Your files were being transcoded to MKV even though you had transcoding disabled. Downloads now respect the setting: with transcoding off, Mustarrd saves the raw .ts file directly to your completed folder.
+
+**What changed:** The download process was not checking the transcoding toggle before deciding whether to run ffmpeg. It now checks the setting first and skips the transcode step entirely when transcoding is disabled.
+
+---
+
+### Fixed: The "Keep original file after transcode" toggle in Settings now works
+
+**What you would notice:** If you had enabled transcoding and set "Delete original file after transcode" to off in Settings, Mustarrd was ignoring that setting and always deleting the original .ts file after transcoding finished. Users who wanted to keep the raw stream alongside the transcoded MKV were not getting it. The original .ts file is now kept or deleted based on your setting.
+
+**What changed:** After transcoding, the cleanup step was unconditionally deleting the original .ts file without checking your setting. It now checks the setting before deleting, so the original file is only removed if you have chosen to delete it.
+
+---
+
 ### Improved: Downloads page now shows how much free space is left on your recording drive
 
 **What you would notice:** At the top of the Downloads page there is now a badge showing how much disk space is available on your recording drive. The badge turns red when space drops below the minimum you configured in Settings. If your recording drive is missing or not mounted (which can happen on Unraid after an array restart or if a share path changes), the badge shows "Recording drive not found" in orange instead of reporting a wrong number from the wrong disk.


### PR DESCRIPTION
## What changed

Two plain-English changelog entries for the 2026-06-07 section:

- **PR #66** (transcode_enabled=False ignored): Documents that the Enable transcoding toggle in Settings now works. Before the fix, every catchup download was run through ffmpeg even when transcoding was disabled.
- **PR #64** (delete_original_after_transcode=False ignored): Documents that the Keep original file after transcode toggle in Settings now works. Before the fix, the original .ts was always deleted after transcoding regardless of the setting.

Both entries are written for an Unraid user who does not code: plain English, no em dashes, no jargon.

## What a user would notice

The changelog is current through all merged PRs as of 2026-06-07.

## How it was tested

Diff verified against the merged PR descriptions and code changes in #64 and #66. Docs only, no behavior changes.