### PR TITLE
Add Clear finished button to Downloads history

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, conint
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, delete as sql_delete
 from typing import Optional
 
 from auth import (
@@ -328,6 +328,22 @@ async def create_download(
     download = await download_manager.queue_download(download)
 
     return (await _attach_requested_by(session, [download.to_dict()], auth))[0]
+
+
+@router.delete("/finished")
+async def clear_finished_downloads(
+    auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Delete all completed and failed download entries."""
+    query = sql_delete(Download).where(
+        Download.status.in_([DownloadStatus.COMPLETED.value, DownloadStatus.FAILED.value])
+    )
+    if not auth.is_admin:
+        query = query.where(Download.requested_by_user_id == auth.user_id)
+    result = await session.execute(query)
+    await session.commit()
+    return {"deleted": result.rowcount}
 
 
 @router.get("/{download_id}")

--- a/backend/tests/test_clear_finished_downloads.py
+++ b/backend/tests/test_clear_finished_downloads.py
@@ -1,0 +1,122 @@
+"""
+Regression tests for DELETE /api/downloads/finished.
+
+The endpoint removes all completed and failed download entries for the
+requesting user and returns {"deleted": N}. It never touches downloads
+that are downloading, pending, processing, or cancelled.
+"""
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import Download, DownloadStatus
+
+
+class ClearFinishedTests(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_download(self, status, user_id=1):
+        d = MagicMock(spec=Download)
+        d.status = status
+        d.requested_by_user_id = user_id
+        return d
+
+    def _make_session(self, rowcount):
+        execute_result = MagicMock()
+        execute_result.rowcount = rowcount
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=execute_result)
+        session.commit = AsyncMock()
+        return session
+
+    def _make_admin_auth(self):
+        auth = MagicMock()
+        auth.is_admin = True
+        auth.user_id = 1
+        return auth
+
+    def _make_user_auth(self, user_id=2):
+        auth = MagicMock()
+        auth.is_admin = False
+        auth.user_id = user_id
+        return auth
+
+    def test_admin_clears_all_completed_and_failed(self):
+        from api.downloads import clear_finished_downloads
+        session = self._make_session(rowcount=5)
+        auth = self._make_admin_auth()
+        result = self._run(clear_finished_downloads(auth=auth, session=session))
+        self.assertEqual(result["deleted"], 5)
+        session.commit.assert_awaited_once()
+
+    def test_returns_zero_when_nothing_to_clear(self):
+        from api.downloads import clear_finished_downloads
+        session = self._make_session(rowcount=0)
+        auth = self._make_admin_auth()
+        result = self._run(clear_finished_downloads(auth=auth, session=session))
+        self.assertEqual(result["deleted"], 0)
+
+    def test_non_admin_scoped_to_own_downloads(self):
+        """Non-admin request must add a user_id filter to the delete query."""
+        from api.downloads import clear_finished_downloads
+        from sqlalchemy import delete as sql_delete
+
+        captured_query = {}
+
+        async def capture_execute(query, *args, **kwargs):
+            captured_query["stmt"] = query
+            result = MagicMock()
+            result.rowcount = 2
+            return result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        session.commit = AsyncMock()
+        auth = self._make_user_auth(user_id=42)
+
+        result = self._run(clear_finished_downloads(auth=auth, session=session))
+        self.assertEqual(result["deleted"], 2)
+
+        stmt = captured_query.get("stmt")
+        self.assertIsNotNone(stmt, "execute was not called")
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn("42", compiled, "user_id filter must be present for non-admin")
+
+    def test_only_completed_and_failed_statuses_targeted(self):
+        """Delete statement must target only completed and failed, not pending/cancelled."""
+        from api.downloads import clear_finished_downloads
+
+        captured_query = {}
+
+        async def capture_execute(query, *args, **kwargs):
+            captured_query["stmt"] = query
+            result = MagicMock()
+            result.rowcount = 0
+            return result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        session.commit = AsyncMock()
+        auth = self._make_admin_auth()
+
+        self._run(clear_finished_downloads(auth=auth, session=session))
+
+        stmt = captured_query.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn(DownloadStatus.COMPLETED.value, compiled)
+        self.assertIn(DownloadStatus.FAILED.value, compiled)
+        self.assertNotIn(DownloadStatus.PENDING.value, compiled)
+        self.assertNotIn(DownloadStatus.DOWNLOADING.value, compiled)
+        self.assertNotIn(DownloadStatus.CANCELLED.value, compiled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -127,6 +127,7 @@ export const downloadsApi = {
   retry: (id) => request(`/downloads/${id}/retry`, { method: 'POST' }),
   previewFilename: (data) => request('/downloads/preview-filename', { method: 'POST', body: data }),
   diskSpace: () => request('/downloads/disk-space'),
+  clearFinished: () => request('/downloads/finished', { method: 'DELETE' }),
 }
 
 // Schedules

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -448,6 +448,23 @@ export default function Downloads() {
     },
   })
 
+  const clearFinishedMutation = useMutation({
+    mutationFn: downloadsApi.clearFinished,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['downloads'] })
+      notifications.show({
+        title: 'History Cleared',
+        message: data.deleted === 0
+          ? 'Nothing to clear'
+          : `Removed ${data.deleted} finished download${data.deleted === 1 ? '' : 's'}`,
+        color: 'green',
+      })
+    },
+    onError: (error) => {
+      notifications.show({ title: 'Error', message: error.message, color: 'red' })
+    },
+  })
+
   const handleOpenFileLocation = async (download) => {
     if (!desktopApi?.openFileLocation) return
     try {
@@ -598,6 +615,18 @@ export default function Downloads() {
             </Card>
           ) : (
             <Stack gap="md">
+              <Group justify="flex-end">
+                <Button
+                  size="xs"
+                  variant="subtle"
+                  color="red"
+                  leftSection={<IconTrash size={14} />}
+                  onClick={() => clearFinishedMutation.mutate()}
+                  loading={clearFinishedMutation.isPending}
+                >
+                  Clear finished
+                </Button>
+              </Group>
               {historyDownloads.map((download) => (
                 <DownloadCard
                   key={download.id}

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -8,6 +8,7 @@ import {
   Badge,
   ActionIcon,
   Menu,
+  Modal,
   Tabs,
   Loader,
   Alert,
@@ -338,6 +339,7 @@ export default function Downloads() {
   const queryClient = useQueryClient()
   const [localProgress, setLocalProgress] = useState({})
   const [localLogs, setLocalLogs] = useState({})
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false)
   const desktopApi = typeof window !== 'undefined' ? window.mustarrdDesktop : null
   const isDesktop = Boolean(desktopApi?.openFileLocation && desktopApi?.playFile)
 
@@ -621,7 +623,7 @@ export default function Downloads() {
                   variant="subtle"
                   color="red"
                   leftSection={<IconTrash size={14} />}
-                  onClick={() => clearFinishedMutation.mutate()}
+                  onClick={() => setClearConfirmOpen(true)}
                   loading={clearFinishedMutation.isPending}
                 >
                   Clear finished
@@ -645,6 +647,32 @@ export default function Downloads() {
           )}
         </Tabs.Panel>
       </Tabs>
+
+      <Modal
+        opened={clearConfirmOpen}
+        onClose={() => setClearConfirmOpen(false)}
+        title="Clear finished downloads?"
+        size="sm"
+      >
+        <Text size="sm">
+          This removes all completed and failed entries from history. Cancelled downloads stay so you can retry them.
+        </Text>
+        <Group justify="flex-end" mt="md">
+          <Button variant="default" onClick={() => setClearConfirmOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            color="red"
+            loading={clearFinishedMutation.isPending}
+            onClick={() => {
+              setClearConfirmOpen(false)
+              clearFinishedMutation.mutate()
+            }}
+          >
+            Clear finished
+          </Button>
+        </Group>
+      </Modal>
     </Stack>
   )
 }


### PR DESCRIPTION
## What changed

A "Clear finished" button in the Downloads history tab lets users bulk-remove completed and failed entries in one step instead of deleting them one at a time.

Clicking the button opens a confirm dialog before anything is deleted. Cancelled downloads are kept so they can be retried. Non-admin users can only clear their own downloads.

## Before

No way to bulk-remove completed or failed entries from download history. Users had to delete entries one at a time.

## After

The History tab shows a "Clear finished" button. Clicking it opens a confirmation dialog: "This removes all completed and failed entries from history. Cancelled downloads stay so you can retry them." with Cancel and Clear finished buttons. On success a notification shows how many entries were removed.

## How it was tested

- `python -m unittest discover -s tests` from `backend/`: 172/172 pass.
- Regression tests in `test_clear_finished_downloads.py` cover: admin clears all, zero rows returns 0, non-admin scoped to own downloads, only COMPLETED/FAILED statuses targeted (not PENDING, DOWNLOADING, CANCELLED).

## Notes

- Disk-space badge (previously bundled in this PR) already shipped in #61. This PR contains only the Clear finished changes.
- Rebased on main to resolve the earlier duplication flagged by Cleo.