### PR TITLE
[Design] Remove confusing Download ID from completed schedule cards

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   Loader,
   Alert,
-  Tooltip,
   Button,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
@@ -161,14 +160,6 @@ function ScheduleCard({
           <Alert color="yellow" variant="light" p="xs">
             <Text size="xs">{schedule.status_message}</Text>
           </Alert>
-        )}
-
-        {schedule.download_status && schedule.download_status === 'completed' && schedule.download_id && (
-          <Tooltip label="Recording completed. View it in Downloads for file details.">
-            <Text size="xs" c="dimmed" truncate>
-              Recording finished. Download ID: {schedule.download_id}
-            </Text>
-          </Tooltip>
         )}
 
         {schedule.download_status === 'completed' && schedule.download_id && (


### PR DESCRIPTION
## What changed

Completed scheduled recordings showed a line reading **Recording finished. Download ID: 1** with a tooltip saying to view the recording in Downloads.

For a non-technical Unraid user this is confusing:
- A raw number like Download ID: 1 means nothing
- The tooltip is invisible on mobile (no hover)
- The Download and Play buttons directly below already tell the user their recording is ready

This PR removes that line and its unused Tooltip import. The COMPLETED badge and the Download/Play buttons are sufficient.

## Before

The card showed Recording finished. Download ID: 1 above the action buttons.

## After

The same card without the confusing line. COMPLETED badge + Download/Play buttons remain.

## How it was tested

- Started the app locally (backend + Vite dev server)
- Inserted a completed scheduled recording into the local DB
- Captured before/after Playwright screenshots at 1280x800 (desktop) and 390x844 (mobile)
- Confirmed the Download ID line is gone and the buttons still appear
- No logic change, no new dependencies