### PR TITLE
docs: add disk space badge to Monitor Downloads section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Then open **http://localhost:4177** in your browser.
 ### Monitor Downloads
 
 - Go to the **Downloads** page to see active downloads with progress bars
+- A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - Failed downloads can be retried from the same page
 
 | Desktop | Mobile |


### PR DESCRIPTION
## What changed

Added one line to the "Monitor Downloads" section of the README describing the disk space badge that was added in PR #61.

The badge has been live since PR #61 but the README did not mention it. Unraid users who read the docs before installing would not know the feature existed.

## What you would notice

The README now tells users that the Downloads page shows free space on the recording drive, turns red when space is low, and shows a warning if the drive is not found.

## How it was tested

Verified the README diff matches the actual behavior shipped in PR #61.