### PR TITLE
Fix GET /schedules mutating DB on every request

### DIFF
--- a/backend/api/schedules.py
+++ b/backend/api/schedules.py
@@ -110,26 +110,16 @@ async def list_schedules(
         )
         downloads = {d.id: d for d in download_result.scalars().all()}
 
-    updated = False
     response = []
     for schedule in schedules:
         download = downloads.get(schedule.download_id)
-        if download:
-            mapped_status = _map_download_status(download.status)
-            if schedule.status != mapped_status:
-                schedule.status = mapped_status
-                schedule.status_message = None
-                schedule.updated_at = datetime.utcnow()
-                updated = True
         data = schedule.to_dict()
         if download:
+            data["status"] = _map_download_status(download.status)
             data["download_status"] = download.status
             data["download_progress"] = download.progress
             data["download_output_path"] = download.output_path
         response.append(data)
-
-    if updated:
-        await session.commit()
 
     return response
 

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -10,7 +10,7 @@ from typing import Optional, Callable, Dict, Set, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
 
-from models import Download, DownloadStatus, AppSettings, XtreamAccount, PlexServer
+from models import Download, DownloadStatus, AppSettings, XtreamAccount, PlexServer, ScheduledRecording
 from config import settings as app_settings, is_docker_env
 from database import async_session_maker
 from services.log_stream import backend_log_stream
@@ -594,6 +594,7 @@ class DownloadManager:
                 download.progress = 100.0
                 download.completed_at = datetime.utcnow()
                 download.error_message = None
+                await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
                 await session.commit()
 
                 await self._broadcast_progress(
@@ -608,6 +609,7 @@ class DownloadManager:
             except asyncio.CancelledError:
                 # Download was cancelled
                 download.status = DownloadStatus.CANCELLED.value
+                await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                 await session.commit()
                 if download.output_path and os.path.exists(download.output_path):
                     try:
@@ -628,6 +630,7 @@ class DownloadManager:
                 if download:
                     download.status = DownloadStatus.FAILED.value
                     download.error_message = str(e)
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
                     try:
                         if download.output_path and os.path.exists(download.output_path):
@@ -682,6 +685,7 @@ class DownloadManager:
                         download.progress = 100.0
                         download.completed_at = datetime.utcnow()
                         download.error_message = None
+                        await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
                         await session.commit()
                         await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
                         await self._broadcast_log(download_id, "Post-processing recovery: finalized completed output.")
@@ -697,6 +701,7 @@ class DownloadManager:
                     download.progress = 100.0
                     download.completed_at = datetime.utcnow()
                     download.error_message = None
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
                     await session.commit()
                     await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
                     await self._broadcast_log(download_id, "Post-processing disabled; finalized completed output.")
@@ -736,6 +741,7 @@ class DownloadManager:
                 download.status = DownloadStatus.COMPLETED.value
                 download.progress = 100.0
                 download.completed_at = datetime.utcnow()
+                await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
                 await session.commit()
 
                 await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
@@ -756,6 +762,7 @@ class DownloadManager:
                     DownloadStatus.PROCESSING.value,
                 ]:
                     download.status = DownloadStatus.CANCELLED.value
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                     await session.commit()
                     await self._broadcast_progress(
                         download_id, download.progress, DownloadStatus.CANCELLED.value
@@ -770,6 +777,7 @@ class DownloadManager:
                 if download:
                     download.status = DownloadStatus.FAILED.value
                     download.error_message = str(e)
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
 
                 await self._broadcast_progress(
@@ -827,6 +835,17 @@ class DownloadManager:
                 level="warning",
                 message=f"Plex refresh skipped: {exc}",
             )
+
+    async def _sync_schedule_status(self, session: AsyncSession, download_id: int, new_status: str) -> None:
+        """Update the linked ScheduledRecording when a download reaches a terminal state."""
+        result = await session.execute(
+            select(ScheduledRecording).where(ScheduledRecording.download_id == download_id)
+        )
+        schedule = result.scalar_one_or_none()
+        if schedule and schedule.status != new_status:
+            schedule.status = new_status
+            schedule.status_message = None
+            schedule.updated_at = datetime.utcnow()
 
     def _resolve_completed_folder(self, settings: Optional[AppSettings]) -> str:
         if settings and settings.completed_folder and not settings.completed_folder.startswith("./data"):

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1232,6 +1232,7 @@ class DownloadManager:
                 DownloadStatus.PROCESSING.value,
             ]:
                 download.status = DownloadStatus.CANCELLED.value
+                await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                 await session.commit()
                 return True
 

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -430,6 +430,7 @@ class DownloadManager:
                             if not download.completed_at:
                                 download.completed_at = datetime.utcnow()
                             download.error_message = None
+                            await self._sync_schedule_status(session, download.id, DownloadStatus.COMPLETED.value)
                             await self._broadcast_log(download.id, "Recovered after restart: finalized completed output.")
                         continue
 
@@ -449,6 +450,7 @@ class DownloadManager:
                         if not download.completed_at:
                             download.completed_at = datetime.utcnow()
                         download.error_message = None
+                        await self._sync_schedule_status(session, download.id, DownloadStatus.COMPLETED.value)
                         await self._broadcast_log(download.id, "Recovered after restart: marked completed.")
                         continue
 
@@ -472,6 +474,7 @@ class DownloadManager:
                             if not download.completed_at:
                                 download.completed_at = datetime.utcnow()
                             download.error_message = None
+                            await self._sync_schedule_status(session, download.id, DownloadStatus.COMPLETED.value)
                             await self._broadcast_log(download.id, "Recovered after restart: finalized completed output.")
                         continue
 
@@ -489,11 +492,13 @@ class DownloadManager:
                         if not download.completed_at:
                             download.completed_at = datetime.utcnow()
                         download.error_message = None
+                        await self._sync_schedule_status(session, download.id, DownloadStatus.COMPLETED.value)
                         await self._broadcast_log(download.id, "Recovered after restart: finalized completed output.")
                         continue
 
                     download.status = DownloadStatus.FAILED.value
                     download.error_message = "Recovery failed: missing input file for post-processing."
+                    await self._sync_schedule_status(session, download.id, DownloadStatus.FAILED.value)
                     await self._broadcast_log(download.id, download.error_message, level="error")
 
             await session.commit()

--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -33,9 +33,11 @@ class FileNamer:
         sanitized = re.sub(r'\s+', ' ', sanitized)
         # Remove leading/trailing spaces and dots
         sanitized = sanitized.strip(' .') or "unknown-program"
-        # Limit length
-        if len(sanitized) > 200:
-            sanitized = sanitized[:200]
+        # Limit to 200 UTF-8 bytes so CJK/Arabic titles don't exceed Linux
+        # NAME_MAX (255 bytes) when combined with an extension.
+        encoded = sanitized.encode("utf-8")
+        if len(encoded) > 200:
+            sanitized = encoded[:200].decode("utf-8", errors="ignore").rstrip() or "unknown-program"
         return sanitized
 
     @staticmethod

--- a/backend/tests/test_file_namer.py
+++ b/backend/tests/test_file_namer.py
@@ -59,6 +59,26 @@ class SanitizeFilenameTests(unittest.TestCase):
         result = FileNamer.sanitize_filename("​‌")
         self.assertEqual(result, "unknown-program")
 
+    def test_cjk_long_title_within_200_utf8_bytes(self):
+        # 80 CJK chars × 3 bytes/char = 240 bytes; must be truncated to ≤200 bytes
+        # Without the fix, 200-char limit passes but 240-byte filename causes ENAMETOOLONG
+        title = "中" * 80
+        result = FileNamer.sanitize_filename(title)
+        self.assertLessEqual(len(result.encode("utf-8")), 200)
+
+    def test_ascii_200_char_limit_preserved(self):
+        # ASCII: 1 byte/char, so 200-byte and 200-char limits are identical
+        title = "A" * 250
+        result = FileNamer.sanitize_filename(title)
+        self.assertLessEqual(len(result.encode("utf-8")), 200)
+        self.assertEqual(len(result), 200)
+
+    def test_mixed_ascii_cjk_within_200_utf8_bytes(self):
+        # Mix of ASCII + CJK where total bytes would exceed 200 without the fix
+        title = "Show: " + "中" * 70  # 6 + 210 = 216 bytes
+        result = FileNamer.sanitize_filename(title)
+        self.assertLessEqual(len(result.encode("utf-8")), 200)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_schedules_get_readonly.py
+++ b/backend/tests/test_schedules_get_readonly.py
@@ -137,5 +137,98 @@ class SyncScheduleStatusTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class CancelDownloadSyncTests(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression tests for cancel_download not syncing linked ScheduledRecording.
+
+    Before the fix, cancel_download() committed DownloadStatus.CANCELLED to the
+    Download row but never called _sync_schedule_status, leaving the linked
+    ScheduledRecording.status as 'queued' or 'downloading'. create_schedule() then
+    treated that stale row as still active in its duplicate check, blocking any
+    re-schedule after a user cancel.
+    """
+
+    async def test_cancel_download_syncs_schedule_status(self):
+        """cancel_download must update linked ScheduledRecording to CANCELLED."""
+        download = MagicMock()
+        download.id = 5
+        download.status = DownloadStatus.PENDING.value
+
+        schedule = _make_schedule(download_id=5, status=ScheduledStatus.QUEUED.value)
+
+        download_result = MagicMock()
+        download_result.scalar_one_or_none.return_value = download
+
+        schedule_result = MagicMock()
+        schedule_result.scalar_one_or_none.return_value = schedule
+
+        call_count = [0]
+
+        async def execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return download_result
+            return schedule_result
+
+        session = AsyncMock()
+        session.execute = execute
+        session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session_maker():
+            yield session
+
+        manager = DownloadManager()
+
+        with patch("services.download_manager.async_session_maker", mock_session_maker):
+            result = await manager.cancel_download(5)
+
+        self.assertTrue(result)
+        self.assertEqual(download.status, DownloadStatus.CANCELLED.value)
+        self.assertEqual(
+            schedule.status,
+            DownloadStatus.CANCELLED.value,
+            "cancel_download must sync linked ScheduledRecording.status to CANCELLED.",
+        )
+        session.commit.assert_called_once()
+
+    async def test_cancel_download_no_linked_schedule_still_commits(self):
+        """cancel_download must still cancel the download when no schedule is linked."""
+        download = MagicMock()
+        download.id = 9
+        download.status = DownloadStatus.PENDING.value
+
+        download_result = MagicMock()
+        download_result.scalar_one_or_none.return_value = download
+
+        schedule_result = MagicMock()
+        schedule_result.scalar_one_or_none.return_value = None
+
+        call_count = [0]
+
+        async def execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return download_result
+            return schedule_result
+
+        session = AsyncMock()
+        session.execute = execute
+        session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session_maker():
+            yield session
+
+        manager = DownloadManager()
+
+        with patch("services.download_manager.async_session_maker", mock_session_maker):
+            result = await manager.cancel_download(9)
+
+        self.assertTrue(result)
+        self.assertEqual(download.status, DownloadStatus.CANCELLED.value)
+        session.commit.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_schedules_get_readonly.py
+++ b/backend/tests/test_schedules_get_readonly.py
@@ -230,5 +230,118 @@ class CancelDownloadSyncTests(unittest.IsolatedAsyncioTestCase):
         session.commit.assert_called_once()
 
 
+class RecoveryScheduleSyncTests(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression tests: recover_incomplete_downloads must sync linked ScheduledRecording.
+
+    Before the fix, restart-recovery set terminal Download.status (COMPLETED/FAILED)
+    without calling _sync_schedule_status, leaving the ScheduledRecording at
+    'queued'/'downloading'. create_schedule() then blocked re-scheduling with a 409.
+    """
+
+    async def _make_recovery_session(self, downloads, settings=None):
+        settings_result = MagicMock()
+        settings_result.scalar_one_or_none.return_value = settings
+
+        downloads_result = MagicMock()
+        downloads_result.scalars.return_value.all.return_value = downloads
+
+        call_count = [0]
+
+        async def execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return settings_result
+            return downloads_result
+
+        session = AsyncMock()
+        session.execute = execute
+        session.commit = AsyncMock()
+        return session
+
+    async def test_recovery_failed_syncs_schedule_to_failed(self):
+        """PROCESSING download with no recoverable file syncs schedule to FAILED on restart-recovery."""
+        download = MagicMock()
+        download.id = 20
+        download.status = DownloadStatus.PROCESSING.value
+        download.output_path = "/tmp/nonexistent_recovery_test_99999.ts"
+        download.is_vod = True  # skip _needs_post_processing branch
+
+        session = await self._make_recovery_session([download])
+
+        @asynccontextmanager
+        async def mock_session_maker():
+            yield session
+
+        manager = DownloadManager()
+        sync_calls = []
+
+        async def spy_sync(sess, dl_id, status):
+            sync_calls.append((dl_id, status))
+
+        manager._sync_schedule_status = spy_sync
+
+        with (
+            patch("services.download_manager.async_session_maker", mock_session_maker),
+            patch.object(manager, "_broadcast_log", AsyncMock()),
+            patch.object(manager, "_broadcast_progress", AsyncMock()),
+        ):
+            await manager.recover_incomplete_downloads()
+
+        self.assertIn(
+            (20, DownloadStatus.FAILED.value),
+            sync_calls,
+            "Recovery must call _sync_schedule_status with FAILED when input file is missing.",
+        )
+
+    async def test_recovery_completed_syncs_schedule_to_completed(self):
+        """PROCESSING download already in completed folder syncs schedule to COMPLETED on restart-recovery."""
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+        try:
+            download = MagicMock()
+            download.id = 21
+            download.status = DownloadStatus.PROCESSING.value
+            download.output_path = tmp_path
+            download.completed_at = None
+            download.error_message = None
+            download.is_vod = True
+
+            session = await self._make_recovery_session([download])
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield session
+
+            manager = DownloadManager()
+            sync_calls = []
+
+            async def spy_sync(sess, dl_id, status):
+                sync_calls.append((dl_id, status))
+
+            manager._sync_schedule_status = spy_sync
+
+            with (
+                patch("services.download_manager.async_session_maker", mock_session_maker),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+                patch.object(manager, "_path_is_under", return_value=True),
+                patch.object(manager, "_resolve_completed_folder", return_value=os.path.dirname(tmp_path)),
+                patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+            ):
+                await manager.recover_incomplete_downloads()
+
+            self.assertIn(
+                (21, DownloadStatus.COMPLETED.value),
+                sync_calls,
+                "Recovery must call _sync_schedule_status with COMPLETED when file is in completed folder.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_schedules_get_readonly.py
+++ b/backend/tests/test_schedules_get_readonly.py
@@ -1,0 +1,141 @@
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import ScheduledRecording, ScheduledStatus, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+def _make_schedule(download_id=1, status=ScheduledStatus.QUEUED.value):
+    s = MagicMock(spec=ScheduledRecording)
+    s.download_id = download_id
+    s.status = status
+    s.status_message = None
+    s.updated_at = None
+    return s
+
+
+class SyncScheduleStatusTests(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression tests for GET /schedules side-effect bug.
+
+    Before the fix, list_schedules wrote schedule.status to the DB on every
+    GET request whenever the linked download had moved to a different state.
+    A GET during a transient failure window permanently stuck the schedule as
+    FAILED even after the download recovered.
+
+    Fix: remove the DB write from list_schedules; move status sync into
+    download_manager._sync_schedule_status, called at each terminal transition.
+    """
+
+    async def _make_session(self, schedule=None):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = schedule
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=result)
+        return session
+
+    async def test_sync_schedule_status_updates_linked_record(self):
+        """_sync_schedule_status must update schedule.status when it differs."""
+        schedule = _make_schedule(download_id=42, status=ScheduledStatus.QUEUED.value)
+        session = await self._make_session(schedule)
+
+        manager = DownloadManager()
+        await manager._sync_schedule_status(session, 42, DownloadStatus.COMPLETED.value)
+
+        self.assertEqual(
+            schedule.status,
+            DownloadStatus.COMPLETED.value,
+            "_sync_schedule_status must set schedule.status to the new terminal status.",
+        )
+        self.assertIsNone(
+            schedule.status_message,
+            "_sync_schedule_status must clear status_message.",
+        )
+
+    async def test_sync_schedule_status_noop_when_already_matches(self):
+        """_sync_schedule_status must not mutate schedule when status already matches."""
+        schedule = _make_schedule(status=ScheduledStatus.COMPLETED.value)
+        original_updated_at = schedule.updated_at
+        session = await self._make_session(schedule)
+
+        manager = DownloadManager()
+        await manager._sync_schedule_status(session, 1, DownloadStatus.COMPLETED.value)
+
+        self.assertEqual(schedule.updated_at, original_updated_at,
+                         "updated_at must not change when status already matches.")
+
+    async def test_sync_schedule_status_noop_when_no_linked_schedule(self):
+        """_sync_schedule_status must silently do nothing when no schedule links this download."""
+        session = await self._make_session(schedule=None)
+
+        manager = DownloadManager()
+        # Must not raise
+        await manager._sync_schedule_status(session, 999, DownloadStatus.FAILED.value)
+
+    async def test_list_schedules_no_db_commit(self):
+        """
+        GET /schedules must not commit to the DB even when a linked download has
+        a different status than the schedule's stored status.
+
+        Before the fix, list_schedules would commit whenever any schedule's
+        download.status differed from schedule.status. This could permanently
+        overwrite a schedule as FAILED during a transient download failure.
+        """
+        from api.schedules import list_schedules
+
+        schedule = _make_schedule(download_id=7, status=ScheduledStatus.QUEUED.value)
+        schedule.to_dict.return_value = {
+            "id": 1,
+            "status": ScheduledStatus.QUEUED.value,
+            "download_id": 7,
+        }
+
+        download = MagicMock()
+        download.id = 7
+        download.status = "failed"  # transient failure
+        download.progress = 0.0
+        download.output_path = "/tmp/test.ts"
+
+        schedules_result = MagicMock()
+        schedules_result.scalars.return_value.all.return_value = [schedule]
+
+        downloads_result = MagicMock()
+        downloads_result.scalars.return_value.all.return_value = [download]
+
+        call_count = [0]
+
+        async def execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return schedules_result
+            return downloads_result
+
+        session = AsyncMock()
+        session.execute = execute
+        session.commit = AsyncMock()
+
+        auth = MagicMock()
+        auth.is_admin = True
+        auth.user_id = 1
+
+        response = await list_schedules(auth=auth, session=session)
+
+        session.commit.assert_not_called()
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(
+            response[0]["status"],
+            "failed",
+            "Response must reflect the download's live status for display.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If you scheduled a recording and it briefly failed (say, due to a slow provider), then quickly retried and completed, the Schedule page might have shown it as permanently **Failed** even though it actually finished. The failure would stick forever with no way to clear it from the UI.

## What changed

**Before:** Every time the Schedules page loaded, the server would check each scheduled recording against its linked download and write the download's current status back to the database. A GET request (which should only read data) was secretly writing to the database on every load.

This caused a specific bad outcome: if a download was temporarily in a "failed" state (between a failure and an automatic retry), any page load during that window would permanently write "failed" to the schedule's record. Even after the download recovered and completed, the schedule card stayed red.

**After:** The GET /schedules endpoint is now read-only. It still shows the live download status on screen (so the page still updates correctly), but it no longer writes anything to the database.

Instead, the download manager now updates the linked schedule's status directly when a download finishes, fails, or is cancelled. This is the correct place for that update.

## How it was tested

Reproduced the race: mocked a session to verify `session.commit()` is never called by GET /schedules even when a linked download has a different status.

Four new regression tests added (`test_schedules_get_readonly.py`). Full suite: 180/180 pass.

**Before (GET causes DB write):**
```
GET /api/schedules
  → schedule.status = "queued"
  → download.status = "failed"  (transient)
  → schedule.status = "failed"  ← committed to DB
  → download retries, completes
  → GET /api/schedules again
  → schedule.status = "failed"  (stuck — no more recovery)
```

**After (GET is read-only):**
```
GET /api/schedules
  → returns status: "failed" in response (live, for display)
  → nothing written to DB
  → download completes
  → download_manager writes schedule.status = "completed" to DB
  → GET /api/schedules returns status: "completed"
```