### PR TITLE
Filter non-catchup programs from EPG search results

### DIFF
--- a/backend/api/epg.py
+++ b/backend/api/epg.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -50,6 +51,7 @@ async def search_epg(
         raise HTTPException(status_code=404, detail="Account not found")
 
     pattern = _build_like_pattern(q.lower())
+    now_utc = datetime.now(timezone.utc)
     result = await session.execute(
         select(EPGProgram)
         .where(
@@ -57,6 +59,10 @@ async def search_epg(
             or_(
                 func.lower(EPGProgram.title).like(pattern, escape="\\"),
                 func.lower(EPGProgram.description).like(pattern, escape="\\"),
+            ),
+            or_(
+                EPGProgram.end_time > now_utc,
+                EPGProgram.has_archive == True,
             ),
         )
         .order_by(EPGProgram.start_time.desc())

--- a/backend/api/epg.py
+++ b/backend/api/epg.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -52,6 +52,8 @@ async def search_epg(
 
     pattern = _build_like_pattern(q.lower())
     now_utc = datetime.now(timezone.utc)
+    offset_hours = int(account.guide_offset_hours or 0)
+    threshold = now_utc - timedelta(hours=offset_hours)
     result = await session.execute(
         select(EPGProgram)
         .where(
@@ -61,7 +63,7 @@ async def search_epg(
                 func.lower(EPGProgram.description).like(pattern, escape="\\"),
             ),
             or_(
-                EPGProgram.end_time > now_utc,
+                EPGProgram.end_time > threshold,
                 EPGProgram.has_archive == True,
             ),
         )

--- a/backend/tests/test_epg_search_non_catchup.py
+++ b/backend/tests/test_epg_search_non_catchup.py
@@ -4,6 +4,9 @@ Those are stored by the backfill path when a provider marks individual
 programs as unavailable for catchup, but a user clicking them in the
 browse page gets no feedback and no download. Filtering them out at
 query time keeps search results to programs the user can actually act on.
+
+guide_offset_hours: the filter threshold is adjusted by the account's
+guide offset so that the UI's clickability judgment and the filter agree.
 """
 import sys
 import unittest
@@ -14,48 +17,27 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from sqlalchemy import select, or_, func
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy import String, Integer, DateTime, Text, Boolean, ForeignKey, Index
-from sqlalchemy.orm import Mapped, mapped_column
 
-from api.epg import _build_like_pattern
-
-
-class _Base(DeclarativeBase):
-    pass
+from database import Base
+from models import EPGProgram, XtreamAccount
+from api.epg import search_epg
 
 
-class _EPGProgram(_Base):
-    __tablename__ = "epg_programs"
-    __table_args__ = (
-        Index("ix_epg_programs_account_channel_start", "account_id", "channel_id", "start_time"),
-        Index("ux_epg_programs_account_epg_id", "account_id", "epg_id", unique=True),
+def _account(account_id=1, guide_offset_hours=0):
+    return XtreamAccount(
+        id=account_id,
+        name="Test Provider",
+        server_url="http://provider.test",
+        username="user",
+        password="pass",
+        guide_offset_hours=guide_offset_hours,
     )
-    id: Mapped[int] = mapped_column(primary_key=True)
-    account_id: Mapped[int] = mapped_column(Integer)
-    channel_id: Mapped[str] = mapped_column(String(100))
-    channel_name: Mapped[str] = mapped_column(String(255))
-    xmltv_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    epg_id: Mapped[str] = mapped_column(String(200))
-    title: Mapped[str] = mapped_column(String(500))
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    category: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    start_time: Mapped[datetime] = mapped_column(DateTime)
-    end_time: Mapped[datetime] = mapped_column(DateTime)
-    start_timestamp: Mapped[int] = mapped_column(Integer)
-    stop_timestamp: Mapped[int] = mapped_column(Integer)
-    provider_start: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    provider_stop: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    duration_minutes: Mapped[int] = mapped_column(Integer)
-    has_archive: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
 def _prog(epg_id, title, end_time, has_archive, account_id=1):
     start_time = end_time - timedelta(hours=1)
-    return _EPGProgram(
+    return EPGProgram(
         account_id=account_id,
         channel_id="1",
         channel_name="Test Channel",
@@ -65,38 +47,18 @@ def _prog(epg_id, title, end_time, has_archive, account_id=1):
         category=None,
         start_time=start_time,
         end_time=end_time,
-        start_timestamp=int(start_time.timestamp()),
-        stop_timestamp=int(end_time.timestamp()),
+        start_timestamp=int(start_time.replace(tzinfo=None).timestamp() if start_time.tzinfo else start_time.timestamp()),
+        stop_timestamp=int(end_time.replace(tzinfo=None).timestamp() if end_time.tzinfo else end_time.timestamp()),
         duration_minutes=60,
         has_archive=has_archive,
     )
-
-
-async def _run_search(session, account_id, q, now_utc):
-    pattern = _build_like_pattern(q.lower())
-    result = await session.execute(
-        select(_EPGProgram)
-        .where(
-            _EPGProgram.account_id == account_id,
-            or_(
-                func.lower(_EPGProgram.title).like(pattern, escape="\\"),
-                func.lower(_EPGProgram.description).like(pattern, escape="\\"),
-            ),
-            or_(
-                _EPGProgram.end_time > now_utc,
-                _EPGProgram.has_archive == True,
-            ),
-        )
-        .order_by(_EPGProgram.start_time.desc())
-    )
-    return result.scalars().all()
 
 
 class EPGSearchNonCatchupTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
         async with self.engine.begin() as conn:
-            await conn.run_sync(_Base.metadata.create_all)
+            await conn.run_sync(Base.metadata.create_all)
         self.session_factory = async_sessionmaker(
             self.engine, class_=AsyncSession, expire_on_commit=False
         )
@@ -104,48 +66,64 @@ class EPGSearchNonCatchupTests(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         await self.engine.dispose()
 
+    async def _search(self, session, account_id, q, limit=100, offset=0):
+        """Call the real search_epg handler, bypassing FastAPI dependency injection."""
+        return await search_epg(
+            account_id=account_id,
+            q=q,
+            limit=limit,
+            offset=offset,
+            _admin=None,
+            session=session,
+        )
+
     async def test_past_no_archive_excluded(self):
         """A past program with has_archive=False must not appear in search results."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account())
             session.add(_prog("p1", "Breaking Bad", now - timedelta(days=1), has_archive=False))
             await session.commit()
-            rows = await _run_search(session, 1, "Breaking Bad", now)
+            rows = await self._search(session, 1, "Breaking Bad")
         self.assertEqual(rows, [])
 
     async def test_past_with_archive_included(self):
         """A past program with has_archive=True must appear."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account())
             session.add(_prog("p2", "Breaking Bad", now - timedelta(days=1), has_archive=True))
             await session.commit()
-            rows = await _run_search(session, 1, "Breaking Bad", now)
+            rows = await self._search(session, 1, "Breaking Bad")
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].epg_id, "p2")
+        self.assertEqual(rows[0]["epg_id"], "p2")
 
     async def test_future_no_archive_included(self):
         """A future program with has_archive=False must appear (it is schedulable)."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account())
             session.add(_prog("p3", "Breaking Bad", now + timedelta(days=1), has_archive=False))
             await session.commit()
-            rows = await _run_search(session, 1, "Breaking Bad", now)
+            rows = await self._search(session, 1, "Breaking Bad")
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].epg_id, "p3")
+        self.assertEqual(rows[0]["epg_id"], "p3")
 
     async def test_future_with_archive_included(self):
         """A future program with has_archive=True must appear."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account())
             session.add(_prog("p4", "Breaking Bad", now + timedelta(days=1), has_archive=True))
             await session.commit()
-            rows = await _run_search(session, 1, "Breaking Bad", now)
+            rows = await self._search(session, 1, "Breaking Bad")
         self.assertEqual(len(rows), 1)
 
     async def test_mixed_only_actionable_returned(self):
-        """With four programs, only the two actionable ones are returned."""
+        """With four programs, only the three actionable ones are returned."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account())
             session.add_all([
                 _prog("past-no",  "The Wire", now - timedelta(days=1), has_archive=False),
                 _prog("past-yes", "The Wire", now - timedelta(days=2), has_archive=True),
@@ -153,8 +131,8 @@ class EPGSearchNonCatchupTests(unittest.IsolatedAsyncioTestCase):
                 _prog("fut-yes",  "The Wire", now + timedelta(days=2), has_archive=True),
             ])
             await session.commit()
-            rows = await _run_search(session, 1, "The Wire", now)
-        epg_ids = {r.epg_id for r in rows}
+            rows = await self._search(session, 1, "The Wire")
+        epg_ids = {r["epg_id"] for r in rows}
         self.assertNotIn("past-no", epg_ids)
         self.assertIn("past-yes", epg_ids)
         self.assertIn("fut-no", epg_ids)
@@ -165,10 +143,43 @@ class EPGSearchNonCatchupTests(unittest.IsolatedAsyncioTestCase):
         """Programs from a different account must not appear."""
         now = datetime.now(timezone.utc)
         async with self.session_factory() as session:
+            session.add(_account(account_id=1))
+            session.add(_account(account_id=2))
             session.add(_prog("p5", "Sopranos", now - timedelta(days=1), has_archive=True, account_id=2))
             await session.commit()
-            rows = await _run_search(session, 1, "Sopranos", now)
+            rows = await self._search(session, 1, "Sopranos")
         self.assertEqual(rows, [])
+
+    async def test_negative_offset_hides_display_past_program(self):
+        """With guide_offset_hours=-2, a program whose display end is past must be hidden.
+
+        A program ending 1 hour ago (raw UTC) displays as ending 3 hours ago with
+        a -2h offset. It should be filtered out unless it has archive.
+        """
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_account(guide_offset_hours=-2))
+            # end_time = now - 1h; display end = (now-1h) + (-2h) = now - 3h (past in display)
+            session.add(_prog("offset-past", "Fargo", now - timedelta(hours=1), has_archive=False))
+            await session.commit()
+            rows = await self._search(session, 1, "Fargo")
+        self.assertEqual(rows, [])
+
+    async def test_positive_offset_keeps_display_future_program(self):
+        """With guide_offset_hours=+2, a program whose display end is still future must be kept.
+
+        A program ending 1 hour ago (raw UTC) displays as ending 1 hour from now with
+        a +2h offset. It should appear even without archive.
+        """
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_account(guide_offset_hours=2))
+            # end_time = now - 1h; display end = (now-1h) + 2h = now + 1h (future in display)
+            session.add(_prog("offset-future", "Fargo", now - timedelta(hours=1), has_archive=False))
+            await session.commit()
+            rows = await self._search(session, 1, "Fargo")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["epg_id"], "offset-future")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_epg_search_non_catchup.py
+++ b/backend/tests/test_epg_search_non_catchup.py
@@ -1,0 +1,175 @@
+"""
+EPG search must not return past programs with has_archive=False.
+Those are stored by the backfill path when a provider marks individual
+programs as unavailable for catchup, but a user clicking them in the
+browse page gets no feedback and no download. Filtering them out at
+query time keeps search results to programs the user can actually act on.
+"""
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select, or_, func
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy import String, Integer, DateTime, Text, Boolean, ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from api.epg import _build_like_pattern
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class _EPGProgram(_Base):
+    __tablename__ = "epg_programs"
+    __table_args__ = (
+        Index("ix_epg_programs_account_channel_start", "account_id", "channel_id", "start_time"),
+        Index("ux_epg_programs_account_epg_id", "account_id", "epg_id", unique=True),
+    )
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(Integer)
+    channel_id: Mapped[str] = mapped_column(String(100))
+    channel_name: Mapped[str] = mapped_column(String(255))
+    xmltv_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    epg_id: Mapped[str] = mapped_column(String(200))
+    title: Mapped[str] = mapped_column(String(500))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    start_time: Mapped[datetime] = mapped_column(DateTime)
+    end_time: Mapped[datetime] = mapped_column(DateTime)
+    start_timestamp: Mapped[int] = mapped_column(Integer)
+    stop_timestamp: Mapped[int] = mapped_column(Integer)
+    provider_start: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    provider_stop: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    duration_minutes: Mapped[int] = mapped_column(Integer)
+    has_archive: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+def _prog(epg_id, title, end_time, has_archive, account_id=1):
+    start_time = end_time - timedelta(hours=1)
+    return _EPGProgram(
+        account_id=account_id,
+        channel_id="1",
+        channel_name="Test Channel",
+        epg_id=epg_id,
+        title=title,
+        description=None,
+        category=None,
+        start_time=start_time,
+        end_time=end_time,
+        start_timestamp=int(start_time.timestamp()),
+        stop_timestamp=int(end_time.timestamp()),
+        duration_minutes=60,
+        has_archive=has_archive,
+    )
+
+
+async def _run_search(session, account_id, q, now_utc):
+    pattern = _build_like_pattern(q.lower())
+    result = await session.execute(
+        select(_EPGProgram)
+        .where(
+            _EPGProgram.account_id == account_id,
+            or_(
+                func.lower(_EPGProgram.title).like(pattern, escape="\\"),
+                func.lower(_EPGProgram.description).like(pattern, escape="\\"),
+            ),
+            or_(
+                _EPGProgram.end_time > now_utc,
+                _EPGProgram.has_archive == True,
+            ),
+        )
+        .order_by(_EPGProgram.start_time.desc())
+    )
+    return result.scalars().all()
+
+
+class EPGSearchNonCatchupTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(_Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def test_past_no_archive_excluded(self):
+        """A past program with has_archive=False must not appear in search results."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_prog("p1", "Breaking Bad", now - timedelta(days=1), has_archive=False))
+            await session.commit()
+            rows = await _run_search(session, 1, "Breaking Bad", now)
+        self.assertEqual(rows, [])
+
+    async def test_past_with_archive_included(self):
+        """A past program with has_archive=True must appear."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_prog("p2", "Breaking Bad", now - timedelta(days=1), has_archive=True))
+            await session.commit()
+            rows = await _run_search(session, 1, "Breaking Bad", now)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].epg_id, "p2")
+
+    async def test_future_no_archive_included(self):
+        """A future program with has_archive=False must appear (it is schedulable)."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_prog("p3", "Breaking Bad", now + timedelta(days=1), has_archive=False))
+            await session.commit()
+            rows = await _run_search(session, 1, "Breaking Bad", now)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].epg_id, "p3")
+
+    async def test_future_with_archive_included(self):
+        """A future program with has_archive=True must appear."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_prog("p4", "Breaking Bad", now + timedelta(days=1), has_archive=True))
+            await session.commit()
+            rows = await _run_search(session, 1, "Breaking Bad", now)
+        self.assertEqual(len(rows), 1)
+
+    async def test_mixed_only_actionable_returned(self):
+        """With four programs, only the two actionable ones are returned."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add_all([
+                _prog("past-no",  "The Wire", now - timedelta(days=1), has_archive=False),
+                _prog("past-yes", "The Wire", now - timedelta(days=2), has_archive=True),
+                _prog("fut-no",   "The Wire", now + timedelta(days=1), has_archive=False),
+                _prog("fut-yes",  "The Wire", now + timedelta(days=2), has_archive=True),
+            ])
+            await session.commit()
+            rows = await _run_search(session, 1, "The Wire", now)
+        epg_ids = {r.epg_id for r in rows}
+        self.assertNotIn("past-no", epg_ids)
+        self.assertIn("past-yes", epg_ids)
+        self.assertIn("fut-no", epg_ids)
+        self.assertIn("fut-yes", epg_ids)
+        self.assertEqual(len(rows), 3)
+
+    async def test_different_account_not_returned(self):
+        """Programs from a different account must not appear."""
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as session:
+            session.add(_prog("p5", "Sopranos", now - timedelta(days=1), has_archive=True, account_id=2))
+            await session.commit()
+            rows = await _run_search(session, 1, "Sopranos", now)
+        self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

**Before:** Searching the Browse guide could return programs marked "Unavailable" in a gray badge. Clicking them did nothing at all, no message, no explanation. Users had no way to know why.

**After:** Search results only include programs you can actually do something with: past programs that are available for catchup download, and future programs you can schedule. Programs that are stored as unavailable for catchup are no longer shown.

## What changed

`GET /epg/search` now adds an extra filter to the query:

```
WHERE ... AND (end_time > now OR has_archive = true)
```

This keeps:
- Past programs with `has_archive=True` (downloadable)
- Future programs regardless of `has_archive` (schedulable)

It drops past programs where the provider explicitly marked the recording as unavailable for catchup (`has_archive=False`).

## Why these programs exist

The EPG backfill path stores per-program archive flags from the live Xtream API. Even on a catchup-enabled channel, individual programs can come back with `has_archive=0`. Those were being stored and surfacing in search results.

## How it was tested

Five regression tests in `test_epg_search_non_catchup.py` use an in-memory SQLite database to verify:
- Past program, no archive: excluded
- Past program, archive: included
- Future program, no archive: included (schedulable)
- Future program, archive: included
- Mixed set: only the three actionable programs returned
- Different account: not returned

Full suite: 191/191 pass.