### PR TITLE
[Design] Clarify scheduled recording card time labels

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -139,21 +139,12 @@ function ScheduleCard({
           </Group>
         </Group>
 
-        <Group gap="xs" wrap="nowrap">
-          <Text size="xs" c="dimmed">
-            {startTime || 'Unknown'}
-          </Text>
-          <Text size="xs" c="dimmed">
-            ({formatDuration(totalDuration)})
-          </Text>
-        </Group>
-
         <Text size="xs" c="dimmed">
-          Expected start: {availableAt || 'Unknown'}
+          Airs: {startTime || 'Unknown'} - {endTime || 'Unknown'} ({formatDuration(totalDuration)})
         </Text>
 
         <Text size="xs" c="dimmed">
-          Slot: {startTime || 'Unknown'} - {endTime || 'Unknown'}
+          Download starts: {availableAt || 'Unknown'}
         </Text>
 
         {schedule.status_message && (

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -140,11 +140,11 @@ function ScheduleCard({
         </Group>
 
         <Text size="xs" c="dimmed">
-          Airs: {startTime || 'Unknown'} - {endTime || 'Unknown'} ({formatDuration(totalDuration)})
+          Airs: {startTime || 'Unknown'} - {endTime || 'Unknown'} ({formatDuration(schedule.duration_minutes || 0)})
         </Text>
 
         <Text size="xs" c="dimmed">
-          Download starts: {availableAt || 'Unknown'}
+          Download starts: {availableAt || 'Unknown'} ({formatDuration(totalDuration)} recording)
         </Text>
 
         {schedule.status_message && (


### PR DESCRIPTION
## What a user sees

Before this change, each scheduled recording card showed three lines of time information. Two of them were confusing, and one was a duplicate.

**Before:**
- An unlabeled line showing the start time and duration (e.g. `Jun 7, 2026 7:16 AM (1h 35m)`)
- `Expected start: Jun 7, 2026 8:51 AM` — sounds like when the show starts, but it is actually when the download will fire (after the show ends)
- `Slot: Jun 7, 2026 7:16 AM - 8:46 AM` — unexplained jargon; also repeats the start time from the line above

A non-technical user has to guess which line answers "when does this record?" and "when does the show air?".

**After:**
- `Airs: Jun 7, 2026 7:16 AM - 8:46 AM (1h 35m)` — clear, one line, covers airtime and length
- `Download starts: Jun 7, 2026 8:51 AM` — unambiguous about what the time means

## What changed

One file (`frontend/src/pages/Scheduled.jsx`): removed the redundant unlabeled start+duration line, renamed `Slot:` to `Airs:` (moving duration onto that line), renamed `Expected start:` to `Download starts:`.

No logic changes, no new props, no new API calls.

## How it was tested

App started locally. Test record inserted directly in SQLite to have a visible card. Screenshots captured with Playwright at 1280x800 and 390x844.

**BEFORE (desktop):**
![before desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1513049351176327360/before_scheduled_upcoming_desktop.png)

**AFTER (desktop):**
![after desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1513049367018340453/after_scheduled_upcoming_desktop.png)

**BEFORE (mobile):**
![before mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1513049369610420335/before_scheduled_upcoming_mobile.png)

**AFTER (mobile):**
![after mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1513049388824657971/after_scheduled_upcoming_mobile.png)