### PR TITLE
docs: add changelog entries for PRs #73, #74, #76, #77, #78, #80, and #82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Fixed: Downloading from Browse now checks available disk space before starting
+
+**What you would notice:** Settings lets you configure a minimum free disk space threshold (default 25 GB). That limit protected scheduled recordings but was ignored for manual downloads you started by clicking Download in Browse. If your disk was nearly full, the download would start, run until your storage ran out, leave a partial file behind, and show a cryptic error like "No space left on device." Now Browse checks free space before queuing the download. If there is not enough room, you see a clear message straight away: "Not enough disk space to start this download. 5.0 GB free, 25 GB required." No partial file is written.
+
+**What changed:** The manual download endpoint now performs the same free-space check that scheduled recordings already used, and returns a clear error instead of letting the download fail mid-transfer.
+
+---
+
 ### Fixed: Enabling ComSkip can no longer be silently undone by a second settings change
 
 **What you would notice:** ComSkip requires transcoding to be on and remux-only mode to be off in order to cut commercials. Previously, if you made two separate settings changes, for example first enabling ComSkip and then separately disabling transcoding, Mustarrd would save the invalid combination without warning. ComSkip would run and mark the commercial segments, but the file would not actually be cut, leaving all commercials in the final recording with no error message. Both settings are now kept consistent: if ComSkip is on, transcoding stays on and remux-only stays off, no matter the order of your changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Fixed: Enabling ComSkip can no longer be silently undone by a second settings change
+
+**What you would notice:** ComSkip requires transcoding to be on and remux-only mode to be off in order to cut commercials. Previously, if you made two separate settings changes, for example first enabling ComSkip and then separately disabling transcoding, Mustarrd would save the invalid combination without warning. ComSkip would run and mark the commercial segments, but the file would not actually be cut, leaving all commercials in the final recording with no error message. Both settings are now kept consistent: if ComSkip is on, transcoding stays on and remux-only stays off, no matter the order of your changes.
+
+**What changed:** The settings enforcement now checks the full final state after all changes are applied, not just the fields in the current request.
+
+---
+
+### Improved: Scheduled recording cards now have clearer time labels
+
+**What you would notice:** On the Scheduled Recordings page, each recording card used to show "Slot" and "Expected start" for the time fields, which were confusing. "Slot" is internal jargon, and there was a duplicate time line on the card. The times are now labeled clearly: "Airs: [start time] - [end time] ([show duration])" shows when the program airs, and "Download starts: [time] ([recording duration])" shows when Mustarrd will begin downloading, including any padding you set.
+
+**What changed:** Two time labels on schedule cards were rewritten and one duplicate line was removed.
+
+---
+
+### Fixed: Searching the program guide no longer shows programs you cannot download
+
+**What you would notice:** When you searched across all channels in Browse, programs that your provider had marked as not available for catchup would still appear in the results. Clicking them to start a download did nothing, with no error or explanation. These programs are now hidden from search results, so you only see what you can actually download.
+
+**What changed:** The search results now exclude past programs your provider has flagged as unavailable for catchup. Future programs (for scheduling) are still included regardless of this flag.
+
+---
+
+### Fixed: Browse and the program guide no longer crash on certain IPTV providers
+
+**What you would notice:** On some IPTV providers, opening Browse or waiting for the program guide to refresh would produce a server error and channels would not load at all. These providers send their channel and category lists in an unusual format that Mustarrd was not prepared to handle. Browse and the program guide now work correctly on these providers.
+
+**What changed:** Mustarrd now handles both the standard and the unusual format that some providers use when sending channel and category lists.
+
+---
+
+### Improved: Browse now shows clearer messages when no channels are found
+
+**What you would notice:** When you open Browse and no channels have loaded yet, it now says "No channels available yet." When you search and nothing matches what you typed, it now says "No channels match your search." Previously both states showed the same generic message, making it hard to tell whether something was wrong or you simply had an empty result.
+
+**What changed:** Two distinct messages were written: one for the empty state and one for empty search results.
+
+---
+
+### Fixed: Corrupt or incomplete guide data from your provider no longer silently stales your program guide
+
+**What you would notice:** If your provider sent back a corrupt or incomplete compressed guide file (which can happen during a provider restart or a network hiccup mid-transfer), Mustarrd would mark the account as unhealthy and stop refreshing the guide with no explanation. The guide would sit stale indefinitely. Mustarrd now handles the bad data gracefully and treats it as an empty response, so the guide continues refreshing on the next cycle.
+
+**What changed:** The compressed guide data handler now catches decompression errors instead of letting them crash the guide refresh job.
+
+---
+
 ### Fixed: Scheduled recordings no longer get stuck showing "Failed" after a successful retry
 
 **What you would notice:** If a download briefly failed and then automatically retried and finished successfully, the Schedules page could still show the recording as permanently Failed, with no way to clear it. Reloading the page would not help. The recording was actually fine on disk, but the status display was wrong and would stay wrong forever.


### PR DESCRIPTION
## Summary

Adds plain-English changelog entries for seven merged PRs that were not yet documented.

- **PR #73** (Fix _maybe_decompress crash on corrupt gzip XMLTV): corrupt or truncated guide data from a provider no longer stales the program guide silently.
- **PR #74** (Design: clarify Browse empty state messages): two distinct messages for no-channels and no-search-results states.
- **PR #76** (Fix AttributeError on dict response from get_live_streams): Browse and the guide no longer crash on providers that send an unusual channel list format.
- **PR #77** (Filter non-catchup programs from EPG search): programs the provider has marked as unavailable for catchup no longer appear in search results.
- **PR #78** (Design: clarify scheduled recording card time labels): "Slot" and "Expected start" replaced with "Airs:" and "Download starts:" labels.
- **PR #80** (Fix ComSkip constraints bypassed by separate PUT /settings requests): a second settings request can no longer silently leave ComSkip enabled with transcoding off, which had caused commercials to remain in recordings.
- **PR #82** (Fix min_free_space_gb not enforced for ad-hoc downloads): clicking Download in Browse now checks free space first and returns a clear error instead of failing mid-transfer with a cryptic message.

## Test plan

- Read each new entry and confirm it matches the merged code change.
- Confirm no em dashes appear in any new text.
- No code changes in this PR.