### PR TITLE
[Design] Red failure badge on Downloads nav item

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -198,9 +198,10 @@ async def get_failed_download_count(
     query = select(func.count()).select_from(Download).where(Download.status == DownloadStatus.FAILED.value)
     if not auth.is_admin:
         query = query.where(Download.requested_by_user_id == auth.user_id)
+    query = query.where(Download.completed_at.is_not(None))
     if since is not None:
         cutoff = datetime.utcfromtimestamp(since / 1000.0)
-        query = query.where(Download.created_at >= cutoff)
+        query = query.where(Download.completed_at >= cutoff)
     result = await session.execute(query)
     return {"count": result.scalar() or 0}
 

--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -2,13 +2,14 @@ import asyncio
 import mimetypes
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel, conint
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, delete as sql_delete
+from sqlalchemy import func, select, delete as sql_delete
 from typing import Optional
 
 from auth import (
@@ -185,6 +186,23 @@ async def _attach_requested_by(
             }
         )
     return rows
+
+
+@router.get("/failed-count")
+async def get_failed_download_count(
+    auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+    since: Optional[float] = Query(default=None),
+):
+    """Count permanently failed downloads since a given Unix timestamp in milliseconds."""
+    query = select(func.count()).select_from(Download).where(Download.status == DownloadStatus.FAILED.value)
+    if not auth.is_admin:
+        query = query.where(Download.requested_by_user_id == auth.user_id)
+    if since is not None:
+        cutoff = datetime.utcfromtimestamp(since / 1000.0)
+        query = query.where(Download.created_at >= cutoff)
+    result = await session.execute(query)
+    return {"count": result.scalar() or 0}
 
 
 @router.get("")

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1311,6 +1311,7 @@ class DownloadManager:
                 download.progress = 0
                 download.downloaded_bytes = 0
                 download.error_message = None
+                download.completed_at = None
                 await session.commit()
 
                 self._cancelled.discard(download_id)

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -526,6 +526,8 @@ class DownloadManager:
                         continue
 
                     download.status = DownloadStatus.FAILED.value
+                    if not download.completed_at:
+                        download.completed_at = datetime.utcnow()
                     download.error_message = "Recovery failed: missing input file for post-processing."
                     await self._sync_schedule_status(session, download.id, DownloadStatus.FAILED.value)
                     await self._broadcast_log(download.id, download.error_message, level="error")
@@ -663,6 +665,8 @@ class DownloadManager:
                 download = result.scalar_one_or_none()
                 if download:
                     download.status = DownloadStatus.FAILED.value
+                    if not download.completed_at:
+                        download.completed_at = datetime.utcnow()
                     download.error_message = _friendly_error(e)
                     await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
@@ -810,6 +814,8 @@ class DownloadManager:
                 download = result.scalar_one_or_none()
                 if download:
                     download.status = DownloadStatus.FAILED.value
+                    if not download.completed_at:
+                        download.completed_at = datetime.utcnow()
                     download.error_message = _friendly_error(e)
                     await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()

--- a/backend/tests/test_download_manager_completed_at.py
+++ b/backend/tests/test_download_manager_completed_at.py
@@ -1,0 +1,109 @@
+"""
+Tests that permanently failed downloads get completed_at stamped.
+
+The failure badge counts downloads where completed_at >= last visit.
+If a failure path forgets to stamp completed_at, the badge silently undercounts.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+class DownloadManagerCompletedAtTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def _make_session(self, download):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = download
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def ctx():
+            yield mock_session
+
+        return ctx
+
+    def test_execute_download_failure_stamps_completed_at(self):
+        """Network error during download must stamp completed_at on the FAILED record.
+
+        Without this, the failure badge cannot count the download because the
+        query filters on completed_at IS NOT NULL.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = output_path
+            mock_download.source_url = "http://provider/timeshift/user/pass/60/2026-01-01:00-00/1.ts"
+            mock_download.progress = 0.0
+            mock_download.downloaded_bytes = 0
+            mock_download.completed_at = None
+
+            async def fail_download(url, path, download_id, session):
+                raise Exception("Connection reset by peer")
+
+            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
+                with patch.object(self.manager, "_download_file", fail_download):
+                    with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                        with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                            asyncio.run(self.manager._execute_download(1))
+
+            self.assertEqual(mock_download.status, DownloadStatus.FAILED.value)
+            self.assertIsNotNone(
+                mock_download.completed_at,
+                "FAILED download must have completed_at stamped so the failure badge can count it",
+            )
+
+    def test_execute_post_process_failure_stamps_completed_at(self):
+        """Post-processing error must stamp completed_at on the FAILED record.
+
+        Without this, a download that completes the transfer but fails FFmpeg
+        is invisible to the failure badge.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, "show.ts")
+            with open(input_path, "wb") as f:
+                f.write(b"\x00" * 1024)
+
+            mock_download = MagicMock()
+            mock_download.id = 2
+            mock_download.status = DownloadStatus.PROCESSING.value
+            mock_download.output_path = input_path
+            mock_download.progress = 0.0
+            mock_download.completed_at = None
+
+            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
+                with patch.object(self.manager, "_needs_post_processing", return_value=True):
+                    with patch.object(self.manager, "_post_process", side_effect=Exception("FFmpeg exit 1")):
+                        with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
+                            with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
+                                with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                                    with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                                        asyncio.run(self.manager._execute_post_process(2))
+
+            self.assertEqual(mock_download.status, DownloadStatus.FAILED.value)
+            self.assertIsNotNone(
+                mock_download.completed_at,
+                "Post-processing failure must stamp completed_at so the failure badge counts it",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_failed_count_endpoint.py
+++ b/backend/tests/test_failed_count_endpoint.py
@@ -1,10 +1,11 @@
 """
 Tests for GET /api/downloads/failed-count.
 
-Returns {"count": N} where N is the number of permanently FAILED downloads,
-optionally filtered to those created at or after a given Unix timestamp in
-milliseconds (the `since` query parameter).  A non-admin user sees only their
-own downloads.
+Returns {"count": N} where N is the number of permanently FAILED downloads
+that have completed_at set and, optionally, completed_at >= a cutoff derived
+from the `since` query parameter (a Unix timestamp in milliseconds).
+
+A non-admin user sees only their own downloads.
 """
 import asyncio
 import sys
@@ -85,11 +86,17 @@ class FailedCountTests(unittest.TestCase):
         stmt = captured.get("stmt")
         self.assertIsNotNone(stmt)
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-        self.assertIn(DownloadStatus.FAILED.value, compiled)
-        self.assertNotIn(DownloadStatus.COMPLETED.value, compiled)
-        self.assertNotIn(DownloadStatus.PENDING.value, compiled)
+        self.assertIn(f"'{DownloadStatus.FAILED.value}'", compiled)
+        self.assertNotIn(f"'{DownloadStatus.COMPLETED.value}'", compiled)
+        self.assertNotIn(f"'{DownloadStatus.PENDING.value}'", compiled)
 
-    def test_since_param_adds_created_at_filter(self):
+    def test_since_param_adds_completed_at_filter(self):
+        """The cutoff must filter by completed_at, not created_at.
+
+        Downloads enqueued before the user last visited Downloads but failing
+        afterward must still show in the badge. created_at is the enqueue time;
+        completed_at is the failure time.
+        """
         from api.downloads import get_failed_download_count
         session, captured = self._capture_session()
         auth = self._make_admin_auth()
@@ -98,11 +105,15 @@ class FailedCountTests(unittest.TestCase):
         stmt = captured.get("stmt")
         self.assertIsNotNone(stmt)
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-        # The cutoff should be present as a datetime value in the query
-        expected_cutoff = datetime.utcfromtimestamp(since_ms / 1000.0)
-        self.assertIn(str(expected_cutoff.year), compiled)
+        self.assertIn("completed_at", compiled.lower())
+        self.assertNotIn("created_at", compiled.lower())
 
-    def test_no_since_param_omits_date_filter(self):
+    def test_no_since_param_still_filters_completed_at_not_null(self):
+        """Without a since cutoff, query must still require completed_at IS NOT NULL.
+
+        FAILED rows with no completed_at are legacy rows where failure time was
+        not stamped. Excluding them keeps the badge count reliable.
+        """
         from api.downloads import get_failed_download_count
         session, captured = self._capture_session()
         auth = self._make_admin_auth()
@@ -110,8 +121,7 @@ class FailedCountTests(unittest.TestCase):
         stmt = captured.get("stmt")
         self.assertIsNotNone(stmt)
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-        # No year-like date filter when since is absent
-        self.assertNotIn("created_at", compiled.lower().replace("downloads.created_at", "PLACEHOLDER"))
+        self.assertIn("completed_at", compiled.lower())
 
     def test_non_admin_query_scoped_to_user(self):
         from api.downloads import get_failed_download_count

--- a/backend/tests/test_failed_count_endpoint.py
+++ b/backend/tests/test_failed_count_endpoint.py
@@ -1,0 +1,128 @@
+"""
+Tests for GET /api/downloads/failed-count.
+
+Returns {"count": N} where N is the number of permanently FAILED downloads,
+optionally filtered to those created at or after a given Unix timestamp in
+milliseconds (the `since` query parameter).  A non-admin user sees only their
+own downloads.
+"""
+import asyncio
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import DownloadStatus
+
+
+class FailedCountTests(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_admin_auth(self):
+        auth = MagicMock()
+        auth.is_admin = True
+        auth.user_id = 1
+        return auth
+
+    def _make_user_auth(self, user_id=2):
+        auth = MagicMock()
+        auth.is_admin = False
+        auth.user_id = user_id
+        return auth
+
+    def _make_session(self, count):
+        scalar_result = MagicMock()
+        scalar_result.scalar = MagicMock(return_value=count)
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=scalar_result)
+        return session
+
+    def _capture_session(self):
+        captured = {}
+        scalar_result = MagicMock()
+        scalar_result.scalar = MagicMock(return_value=0)
+
+        async def capture_execute(query, *args, **kwargs):
+            captured["stmt"] = query
+            return scalar_result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        return session, captured
+
+    def test_returns_count_for_admin(self):
+        from api.downloads import get_failed_download_count
+        session = self._make_session(count=3)
+        auth = self._make_admin_auth()
+        result = self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        self.assertEqual(result["count"], 3)
+
+    def test_returns_zero_when_no_failures(self):
+        from api.downloads import get_failed_download_count
+        session = self._make_session(count=0)
+        auth = self._make_admin_auth()
+        result = self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        self.assertEqual(result["count"], 0)
+
+    def test_none_scalar_treated_as_zero(self):
+        from api.downloads import get_failed_download_count
+        session = self._make_session(count=None)
+        auth = self._make_admin_auth()
+        result = self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        self.assertEqual(result["count"], 0)
+
+    def test_query_targets_only_failed_status(self):
+        from api.downloads import get_failed_download_count
+        session, captured = self._capture_session()
+        auth = self._make_admin_auth()
+        self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn(DownloadStatus.FAILED.value, compiled)
+        self.assertNotIn(DownloadStatus.COMPLETED.value, compiled)
+        self.assertNotIn(DownloadStatus.PENDING.value, compiled)
+
+    def test_since_param_adds_created_at_filter(self):
+        from api.downloads import get_failed_download_count
+        session, captured = self._capture_session()
+        auth = self._make_admin_auth()
+        since_ms = 1700000000000.0  # 2023-11-14 22:13:20 UTC in ms
+        self._run(get_failed_download_count(auth=auth, session=session, since=since_ms))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        # The cutoff should be present as a datetime value in the query
+        expected_cutoff = datetime.utcfromtimestamp(since_ms / 1000.0)
+        self.assertIn(str(expected_cutoff.year), compiled)
+
+    def test_no_since_param_omits_date_filter(self):
+        from api.downloads import get_failed_download_count
+        session, captured = self._capture_session()
+        auth = self._make_admin_auth()
+        self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        # No year-like date filter when since is absent
+        self.assertNotIn("created_at", compiled.lower().replace("downloads.created_at", "PLACEHOLDER"))
+
+    def test_non_admin_query_scoped_to_user(self):
+        from api.downloads import get_failed_download_count
+        session, captured = self._capture_session()
+        auth = self._make_user_auth(user_id=42)
+        self._run(get_failed_download_count(auth=auth, session=session, since=None))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn("42", compiled, "user_id filter must appear for non-admin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_retry_cancelled_flag.py
+++ b/backend/tests/test_retry_cancelled_flag.py
@@ -97,6 +97,33 @@ class RetryCancelledFlagTests(unittest.IsolatedAsyncioTestCase):
             "retry_download must clear stale _cancelled flag for FAILED downloads too.",
         )
 
+    async def test_retry_clears_completed_at(self):
+        """
+        retry_download must set completed_at = None so that a re-failure after
+        retry stamps a fresh completed_at.
+
+        Without this, a download that fails at T1, is retried, then fails again
+        at T2 keeps completed_at=T1. The failure badge uses completed_at >= last
+        visit, so if last visit is between T1 and T2 the re-failure is invisible.
+        """
+        from datetime import datetime
+
+        manager = DownloadManager()
+        dl_id = 9
+
+        download = _make_cancelled_download(dl_id)
+        download.status = DownloadStatus.FAILED.value
+        download.completed_at = datetime(2020, 1, 1)
+
+        with patch("services.download_manager.async_session_maker", _make_session_maker(download)):
+            result = await manager.retry_download(dl_id)
+
+        self.assertTrue(result)
+        self.assertIsNone(
+            download.completed_at,
+            "retry_download must clear completed_at so a re-failure stamps a fresh timestamp.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -104,6 +104,18 @@ function App() {
     enabled: Boolean(authStatus?.authenticated),
   })
 
+  // Fetch failed download count for nav badge (clears when user visits Downloads)
+  const { data: failedCountData } = useQuery({
+    queryKey: ['downloads', 'failed-count'],
+    queryFn: () => {
+      const since = localStorage.getItem('mustarrd_downloads_visited')
+      return downloadsApi.failedCount(since ? Number(since) : null)
+    },
+    refetchInterval: 60000,
+    enabled: Boolean(authStatus?.authenticated),
+  })
+  const failedDownloadsCount = failedCountData?.count ?? 0
+
   const { data: epgStatus } = useQuery({
     queryKey: ['epg', 'status'],
     queryFn: epgApi.status,
@@ -290,6 +302,7 @@ function App() {
       label: 'Downloads',
       to: '/downloads',
       badge: activeDownloads > 0 ? activeDownloads : null,
+      failedBadge: failedDownloadsCount > 0 ? failedDownloadsCount : null,
       authOnly: true,
     },
     { icon: IconCalendar, label: 'Scheduled', to: '/scheduled', authOnly: true },
@@ -385,25 +398,49 @@ function App() {
               label={item.label}
               leftSection={<item.icon size={20} />}
               rightSection={
-                item.badge ? (
-                  <Box
-                    style={{
-                      minWidth: 20,
-                      height: 20,
-                      borderRadius: '50%',
-                      background: '#f59f00',
-                      color: '#1a1b1e',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 11,
-                      fontWeight: 700,
-                      lineHeight: 1,
-                      padding: '0 5px',
-                    }}
-                  >
-                    {item.badge}
-                  </Box>
+                (item.badge || item.failedBadge) ? (
+                  <Group gap={4} wrap="nowrap">
+                    {item.failedBadge ? (
+                      <Box
+                        style={{
+                          minWidth: 20,
+                          height: 20,
+                          borderRadius: '50%',
+                          background: '#fa5252',
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 11,
+                          fontWeight: 700,
+                          lineHeight: 1,
+                          padding: '0 5px',
+                        }}
+                      >
+                        {item.failedBadge}
+                      </Box>
+                    ) : null}
+                    {item.badge ? (
+                      <Box
+                        style={{
+                          minWidth: 20,
+                          height: 20,
+                          borderRadius: '50%',
+                          background: '#f59f00',
+                          color: '#1a1b1e',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 11,
+                          fontWeight: 700,
+                          lineHeight: 1,
+                          padding: '0 5px',
+                        }}
+                      >
+                        {item.badge}
+                      </Box>
+                    ) : null}
+                  </Group>
                 ) : null
               }
               style={{ borderRadius: 8, marginBottom: 4 }}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -108,8 +108,12 @@ function App() {
   const { data: failedCountData } = useQuery({
     queryKey: ['downloads', 'failed-count'],
     queryFn: () => {
-      const since = localStorage.getItem('mustarrd_downloads_visited')
-      return downloadsApi.failedCount(since ? Number(since) : null)
+      let since = localStorage.getItem('mustarrd_downloads_visited')
+      if (!since) {
+        since = String(Date.now())
+        localStorage.setItem('mustarrd_downloads_visited', since)
+      }
+      return downloadsApi.failedCount(Number(since))
     },
     refetchInterval: 60000,
     enabled: Boolean(authStatus?.authenticated),

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -128,6 +128,10 @@ export const downloadsApi = {
   previewFilename: (data) => request('/downloads/preview-filename', { method: 'POST', body: data }),
   diskSpace: () => request('/downloads/disk-space'),
   clearFinished: () => request('/downloads/finished', { method: 'DELETE' }),
+  failedCount: (since) => {
+    const params = since != null ? `?since=${since}` : ''
+    return request(`/downloads/failed-count${params}`)
+  },
 }
 
 // Schedules

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -364,6 +364,11 @@ export default function Downloads() {
   })
 
   useEffect(() => {
+    localStorage.setItem('mustarrd_downloads_visited', String(Date.now()))
+    queryClient.invalidateQueries({ queryKey: ['downloads', 'failed-count'] })
+  }, [queryClient])
+
+  useEffect(() => {
     const ws = createDownloadWebSocket((data) => {
       if (data.type === 'progress') {
         setLocalProgress((prev) => ({


### PR DESCRIPTION
## What a user would notice

Before: the Downloads sidebar item gave no signal when recordings failed permanently. An operator checking in once a week had no way to know two shows failed silently until they clicked into Downloads.

After: a red badge appears on Downloads showing the count of failed recordings since the user last visited. Visiting Downloads clears the badge. The existing yellow active-downloads badge still appears alongside for in-progress recordings.

## What changed

**Backend:** Added `GET /downloads/failed-count?since=<ms>` endpoint. It counts FAILED downloads where `completed_at >= since` (the timestamp the user last visited Downloads). The `completed_at` column is now stamped on every failure path in `download_manager.py` (recovery, download exception, post-process exception). When a failed download is retried, `completed_at` is cleared so a subsequent failure gets a fresh timestamp and the badge correctly lights again.

**Frontend:** On each page load, reads a `mustarrd_downloads_visited` timestamp from localStorage and passes it to the endpoint as `since`. Shows a red badge for the returned count. When the user visits Downloads, `mustarrd_downloads_visited` is updated to now, resetting the count. On first load (no key in localStorage), the key is seeded to now so only failures that happen after the app is first opened are shown.

## How it was tested

Full backend suite passes (288 tests), including:
- 7 tests covering the `/downloads/failed-count` endpoint (admin counts all FAILED; non-admin scoped to own rows; `completed_at IS NOT NULL` guard; `completed_at >= cutoff` filter).
- Integration tests that drive `_execute_download` and `_execute_post_process` through real failure paths and assert `completed_at` is set on the resulting FAILED record.
- `test_retry_clears_completed_at` verifying `completed_at` is reset to None on retry.

Badge verified manually in browser at desktop and mobile widths.

## Rebase note (2026-06-07)

Rebased on main after PR #99 merged. The one conflict was in `download_manager.py`: the two failure paths now use `_friendly_error(e)` (from PR #99) instead of `str(e)`, keeping the plain-English error messages while still stamping `completed_at` for the badge. 288 tests pass.

## Before

Downloads nav item. No failure signal.

## After

Red "2" badge on Downloads when 2 recordings have failed since last visit. Badge clears when user visits Downloads.

See screenshots in #design.