### PR TITLE
Fix _cleanup_comskip_outputs deleting user subtitle files

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -906,6 +906,8 @@ class DownloadManager:
             if delete_original and original_path != completed_path and original_file.exists():
                 original_file.unlink()
 
+            # Only remove known ComSkip/FFmpeg working files.
+            # .xml/.srt/.ass/.vtt are user subtitle/metadata files, never ComSkip outputs.
             patterns = [
                 f"{stem}_seg*.ts",
                 f"{stem}.concat.txt",
@@ -914,10 +916,6 @@ class DownloadManager:
                 f"{stem}.logo",
                 f"{stem}.csv",
                 f"{stem}.vdr",
-                f"{stem}.xml",
-                f"{stem}.srt",
-                f"{stem}.ass",
-                f"{stem}.vtt",
             ]
             if not keep_logs:
                 patterns.extend([

--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -1410,17 +1410,12 @@ class PostProcessor:
                 input_file.with_suffix(".logo"),
                 input_file.with_suffix(".csv"),
                 input_file.with_suffix(".vdr"),
-                input_file.with_suffix(".xml"),
-                input_file.with_suffix(".srt"),
-                input_file.with_suffix(".ass"),
-                input_file.with_suffix(".vtt"),
             ]
             if edl_path:
                 edl_file = Path(edl_path)
                 candidates.append(edl_file)
                 if edl_file.stem != input_file.stem:
-                    for suffix in [".txt", ".log", ".logo", ".csv", ".vdr", ".xml",
-                                   ".srt", ".ass", ".vtt"]:
+                    for suffix in [".txt", ".log", ".logo", ".csv", ".vdr"]:
                         candidates.append(edl_file.with_suffix(suffix))
             for path in candidates:
                 if path.exists():

--- a/backend/tests/test_cleanup_working_files.py
+++ b/backend/tests/test_cleanup_working_files.py
@@ -1,0 +1,102 @@
+"""
+Regression test: _cleanup_working_files must not delete user subtitle/metadata files.
+
+Bug: download_manager._cleanup_working_files included .xml, .srt, .ass, .vtt in its
+cleanup pattern list. On a normal ComSkip + transcode completion the completed-download
+path calls this helper, silently deleting subtitle files that users had placed alongside
+their recordings.
+
+Fix: those four extensions are removed from the pattern list. Only actual ComSkip/FFmpeg
+working files (.edl, .txt, .logo, .csv, .vdr, _seg*.ts, .concat.txt, .log) are removed.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+class CleanupWorkingFilesSubtitleTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, self.tmp)
+
+    def _make(self, name: str) -> Path:
+        p = Path(self.tmp) / name
+        p.write_text("dummy")
+        return p
+
+    def test_subtitle_files_survive_completed_download_cleanup(self):
+        """User subtitle files next to a completed recording must not be deleted."""
+        original = self._make("Show.S01E01.ts")
+        completed = self._make("Show.S01E01.mkv")
+        srt = self._make("Show.S01E01.srt")
+        vtt = self._make("Show.S01E01.vtt")
+        ass = self._make("Show.S01E01.ass")
+        xml = self._make("Show.S01E01.xml")
+
+        self.manager._cleanup_working_files(
+            str(original), str(completed), keep_logs=True, delete_original=False
+        )
+
+        self.assertTrue(srt.exists(), ".srt must not be deleted (user subtitle)")
+        self.assertTrue(vtt.exists(), ".vtt must not be deleted (user subtitle)")
+        self.assertTrue(ass.exists(), ".ass must not be deleted (user subtitle)")
+        self.assertTrue(xml.exists(), ".xml must not be deleted (user metadata)")
+
+    def test_comskip_working_files_still_cleaned(self):
+        """ComSkip/FFmpeg working files are still removed by _cleanup_working_files."""
+        original = self._make("Show.ts")
+        completed = self._make("Show.mkv")
+        edl = self._make("Show.edl")
+        txt = self._make("Show.txt")
+        logo = self._make("Show.logo")
+        csv = self._make("Show.csv")
+        vdr = self._make("Show.vdr")
+        seg = self._make("Show_seg001.ts")
+        concat = self._make("Show.concat.txt")
+
+        self.manager._cleanup_working_files(
+            str(original), str(completed), keep_logs=True, delete_original=False
+        )
+
+        for f, name in [
+            (edl, ".edl"), (txt, ".txt"), (logo, ".logo"),
+            (csv, ".csv"), (vdr, ".vdr"), (seg, "_seg*.ts"), (concat, ".concat.txt"),
+        ]:
+            self.assertFalse(f.exists(), f"{name} should be cleaned up")
+
+    def test_log_cleaned_when_keep_logs_false(self):
+        """.log is removed when keep_logs=False."""
+        original = self._make("Show.ts")
+        completed = self._make("Show.mkv")
+        log = self._make("Show.log")
+
+        self.manager._cleanup_working_files(
+            str(original), str(completed), keep_logs=False, delete_original=False
+        )
+
+        self.assertFalse(log.exists(), ".log should be cleaned up when keep_logs=False")
+
+    def test_log_survives_when_keep_logs_true(self):
+        """.log is kept when keep_logs=True."""
+        original = self._make("Show.ts")
+        completed = self._make("Show.mkv")
+        log = self._make("Show.log")
+
+        self.manager._cleanup_working_files(
+            str(original), str(completed), keep_logs=True, delete_original=False
+        )
+
+        self.assertTrue(log.exists(), ".log must not be deleted when keep_logs=True")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_comskip_cleanup_subtitles.py
+++ b/backend/tests/test_comskip_cleanup_subtitles.py
@@ -1,0 +1,86 @@
+"""
+Regression test for _cleanup_comskip_outputs deleting user subtitle files.
+
+Bug: .srt, .vtt, .ass, and .xml files were included in the ComSkip cleanup
+candidate list. ComSkip never generates these formats; users place subtitle
+files alongside recordings. All four were silently deleted after any ComSkip
+post-processing run, with no way to recover them.
+
+Fix: only .edl, .txt, .log, .logo, .csv, .vdr are ComSkip outputs. The other
+extensions are removed from the cleanup list.
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_subtitle_test", MODULE_PATH)
+POST_PROCESSOR_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(POST_PROCESSOR_MODULE)
+
+PostProcessor = POST_PROCESSOR_MODULE.PostProcessor
+
+
+class ComskipCleanupSubtitleProtectionTests(unittest.TestCase):
+    def setUp(self):
+        self.processor = PostProcessor()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, self.tmp)
+
+    def _make_file(self, name: str) -> Path:
+        p = Path(self.tmp) / name
+        p.write_text("dummy")
+        return p
+
+    def test_subtitle_files_survive_cleanup(self):
+        """User subtitle files next to the recording must not be deleted."""
+        original = self._make_file("Show.S01E01.ts")
+        edl = self._make_file("Show.S01E01.edl")
+        srt = self._make_file("Show.S01E01.srt")
+        vtt = self._make_file("Show.S01E01.vtt")
+        ass = self._make_file("Show.S01E01.ass")
+        xml = self._make_file("Show.S01E01.xml")
+
+        self.processor._cleanup_comskip_outputs(str(original), str(edl))
+
+        self.assertFalse(edl.exists(), ".edl should be cleaned up (ComSkip output)")
+        self.assertTrue(srt.exists(), ".srt must not be deleted (user subtitle)")
+        self.assertTrue(vtt.exists(), ".vtt must not be deleted (user subtitle)")
+        self.assertTrue(ass.exists(), ".ass must not be deleted (user subtitle)")
+        self.assertTrue(xml.exists(), ".xml must not be deleted (user metadata)")
+
+    def test_comskip_outputs_still_cleaned(self):
+        """Real ComSkip output files are still removed after the fix."""
+        original = self._make_file("Show.ts")
+        edl = self._make_file("Show.edl")
+        txt = self._make_file("Show.txt")
+        log = self._make_file("Show.log")
+        logo = self._make_file("Show.logo")
+        csv = self._make_file("Show.csv")
+        vdr = self._make_file("Show.vdr")
+
+        self.processor._cleanup_comskip_outputs(str(original), str(edl))
+
+        for f, name in [(edl, ".edl"), (txt, ".txt"), (log, ".log"),
+                        (logo, ".logo"), (csv, ".csv"), (vdr, ".vdr")]:
+            self.assertFalse(f.exists(), f"{name} should be cleaned up")
+
+    def test_probe_sibling_subtitles_survive_cleanup(self):
+        """Subtitle files alongside the _comskip_input probe must not be deleted."""
+        original = self._make_file("Show.ts")
+        probe_edl = self._make_file("Show_comskip_input.edl")
+        probe_srt = self._make_file("Show_comskip_input.srt")
+        probe_xml = self._make_file("Show_comskip_input.xml")
+
+        self.processor._cleanup_comskip_outputs(str(original), str(probe_edl))
+
+        self.assertFalse(probe_edl.exists(), "probe .edl should be cleaned up")
+        self.assertTrue(probe_srt.exists(), "probe .srt must not be deleted")
+        self.assertTrue(probe_xml.exists(), "probe .xml must not be deleted")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

After any ComSkip post-processing run, Mustarrd was silently deleting `.srt`, `.vtt`, `.ass`, and `.xml` files placed next to the recording. ComSkip never generates these formats. They ended up in two separate cleanup lists by mistake.

The fix removes those four extensions from both:
- `PostProcessor._cleanup_comskip_outputs` (the ComSkip-specific path)
- `DownloadManager._cleanup_working_files` (the completed-download path called for every transcode/remux finish)

Only actual ComSkip/FFmpeg working files are deleted: `.edl`, `.txt`, `.log`, `.logo`, `.csv`, `.vdr`, `_seg*.ts`, `.concat.txt`.

## Who is affected

Any user with ComSkip enabled who places subtitle files (downloaded from a subtitle site) in the same folder as their recordings. After post-processing completed, those subtitle files vanished with no warning and no way to recover them.

## Before

```
# Place Show.S01E01.srt next to Show.S01E01.ts, run ComSkip + transcode
$ ls after_post_processing/
Show.S01E01.mkv          # transcoded recording
# Show.S01E01.srt gone -- silently deleted
```

## After

```
$ ls after_post_processing/
Show.S01E01.mkv          # transcoded recording
Show.S01E01.srt          # subtitle file preserved
```

## How it was tested

- `backend/tests/test_comskip_cleanup_subtitles.py`: subtitle/metadata files survive `_cleanup_comskip_outputs`; real ComSkip outputs are still removed; probe-sibling path also correct.
- `backend/tests/test_cleanup_working_files.py` (new): subtitle/metadata files survive `_cleanup_working_files`; ComSkip working files still cleaned; `.log` behaviour with `keep_logs` true/false.
- Full suite: 224 tests, all pass.