### PR TITLE
test: failing regression for zlib.error crash in _maybe_decompress

### DIFF
--- a/backend/tests/test_cleanup_bracket_filenames.py
+++ b/backend/tests/test_cleanup_bracket_filenames.py
@@ -1,0 +1,109 @@
+"""
+Regression test: _cleanup_working_files must delete ComSkip temp files
+even when the filename stem contains glob special characters like '[' and ']'.
+
+Common real-world IPTV channel names include brackets: [BBC], [HD], [US].
+sanitize_filename does not strip '[' or ']' (they are valid Linux filename chars),
+so stems like '[BBC] Doctor Who - 2024-01-15' reach _cleanup_working_files.
+
+Path.glob() treats '[...]' as a character class, so the cleanup patterns silently
+fail to match their targets, leaving ComSkip temp files on disk indefinitely.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from services.file_namer import file_namer
+
+
+class CleanupBracketFilenamesTest(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_sanitize_preserves_brackets(self):
+        """sanitize_filename must leave '[' and ']' in the output (they are valid Linux chars)."""
+        result = file_namer.sanitize_filename("[BBC] Doctor Who - S01E01")
+        self.assertIn("[", result, "sanitize_filename strips '['; test precondition changed")
+        self.assertIn("]", result, "sanitize_filename strips ']'; test precondition changed")
+
+    def test_cleanup_removes_comskip_files_when_stem_contains_brackets(self):
+        """ComSkip temp files are deleted even when the stem contains '[' or ']'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stem = "[BBC] Doctor Who - 2024-01-15"
+            ts_file = os.path.join(tmpdir, f"{stem}.ts")
+            completed_path = os.path.join(tmpdir, f"{stem}.mkv")
+
+            # Write the source .ts so the real-file guard passes.
+            Path(ts_file).write_bytes(b"\x00")
+
+            # Files that _cleanup_working_files must delete.
+            temp_files = {
+                "edl":  Path(tmpdir) / f"{stem}.edl",
+                "txt":  Path(tmpdir) / f"{stem}.txt",
+                "log":  Path(tmpdir) / f"{stem}.log",
+                "csv":  Path(tmpdir) / f"{stem}.csv",
+                "logo": Path(tmpdir) / f"{stem}.logo",
+                "vdr":  Path(tmpdir) / f"{stem}.vdr",
+                "xml":  Path(tmpdir) / f"{stem}.xml",
+            }
+            for f in temp_files.values():
+                f.write_text("placeholder")
+
+            # Simulate a segment file.
+            seg_file = Path(tmpdir) / f"{stem}_seg001.ts"
+            seg_file.write_text("segment")
+
+            self.manager._cleanup_working_files(
+                original_path=ts_file,
+                completed_path=completed_path,
+                keep_logs=False,
+                delete_original=True,
+            )
+
+            for label, path in temp_files.items():
+                self.assertFalse(
+                    path.exists(),
+                    f"ComSkip temp file '{label}' was not cleaned up for stem with brackets: {path.name}",
+                )
+
+            self.assertFalse(
+                seg_file.exists(),
+                f"Segment file was not cleaned up for stem with brackets: {seg_file.name}",
+            )
+
+    def test_cleanup_does_not_delete_unrelated_files_with_similar_names(self):
+        """Cleanup must not accidentally delete unrelated files that happen to match a mangled glob."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stem = "[BBC] Show - 2024-01-15"
+            ts_file = os.path.join(tmpdir, f"{stem}.ts")
+            completed_path = os.path.join(tmpdir, f"{stem}.mkv")
+            Path(ts_file).write_bytes(b"\x00")
+
+            # An unrelated file whose name matches what the broken glob currently matches.
+            # '[BBC]' as a glob character class matches 'B' or 'C', so a file starting
+            # with 'B' followed by ' Show - 2024-01-15.edl' would be incorrectly deleted.
+            unrelated = Path(tmpdir) / "B Show - 2024-01-15.edl"
+            unrelated.write_text("unrelated file — must not be deleted")
+
+            self.manager._cleanup_working_files(
+                original_path=ts_file,
+                completed_path=completed_path,
+                keep_logs=False,
+                delete_original=True,
+            )
+
+            self.assertTrue(
+                unrelated.exists(),
+                "Cleanup deleted an unrelated file because of bad glob pattern escaping",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_corrupt_gzip.py
+++ b/backend/tests/test_epg_corrupt_gzip.py
@@ -1,0 +1,63 @@
+"""
+Regression test for _maybe_decompress raising uncaught gzip.BadGzipFile on
+corrupt or truncated XMLTV.gz data from a provider.
+
+When a provider returns a response whose body starts with the gzip magic bytes
+(\x1f\x8b) but the rest of the payload is corrupt or truncated (e.g. a
+mid-transfer network drop, a provider restart, or a proxy that returned an
+HTML error page with a gzip header), gzip.decompress() raises BadGzipFile or
+EOFError. Neither is caught in _maybe_decompress, so the entire EPG refresh
+for that account fails silently. The connection status is marked unhealthy even
+though the provider may be fine; the EPG guide goes stale indefinitely with no
+user-visible error.
+
+Expected behaviour after fix: _maybe_decompress catches the gzip exception and
+returns b"" so the caller can treat it as "no XMLTV data" and log accordingly,
+rather than aborting the refresh.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class MaybeDecompressCorruptGzipTests(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = EPGIngestManager()
+
+    def test_corrupt_gzip_body_does_not_raise(self):
+        """_maybe_decompress must not propagate BadGzipFile on invalid gzip data."""
+        corrupt = b"\x1f\x8b" + b"\x00" * 20
+        # Bug: currently raises gzip.BadGzipFile; expected to return bytes safely
+        result = self.manager._maybe_decompress(corrupt)
+        self.assertIsInstance(result, bytes)
+
+    def test_truncated_gzip_body_does_not_raise(self):
+        """_maybe_decompress must handle data truncated immediately after magic bytes."""
+        truncated = b"\x1f\x8b"
+        result = self.manager._maybe_decompress(truncated)
+        self.assertIsInstance(result, bytes)
+
+    def test_valid_gzip_still_decompresses(self):
+        """_maybe_decompress must still decompress valid gzip data after fix."""
+        import gzip
+        payload = b"<?xml version='1.0'?><tv></tv>"
+        compressed = gzip.compress(payload)
+        result = self.manager._maybe_decompress(compressed)
+        self.assertEqual(result, payload)
+
+    def test_plain_xml_passes_through_unchanged(self):
+        """_maybe_decompress must leave non-gzip data alone."""
+        plain = b"<?xml version='1.0'?><tv></tv>"
+        result = self.manager._maybe_decompress(plain)
+        self.assertEqual(result, plain)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_zlib_error.py
+++ b/backend/tests/test_epg_zlib_error.py
@@ -1,0 +1,78 @@
+"""
+Regression test for _maybe_decompress raising uncaught zlib.error on XMLTV
+data with a valid gzip header but corrupt deflate body.
+
+gzip.BadGzipFile and EOFError are raised when the gzip HEADER is malformed
+or truncated. zlib.error is raised when the header is valid but the compressed
+body is corrupt or truncated after the header. Both failure modes reach the
+user the same way: the entire EPG refresh fails, the connection badge goes red,
+and the guide goes stale silently.
+
+The fix for gzip.BadGzipFile (PR #73) caught (gzip.BadGzipFile, EOFError,
+OSError) but did NOT include zlib.error. A provider that sends a complete,
+valid gzip header followed by garbage compressed data (e.g. from a mid-write
+server restart, network corruption after the gzip frame begins, or a proxy
+injecting an HTML error body after the gzip magic bytes) will still crash
+_maybe_decompress after PR #73 is merged.
+
+Expected behaviour after fix: _maybe_decompress catches zlib.error alongside
+BadGzipFile/EOFError and returns b"" so the caller logs a warning rather than
+aborting the refresh entirely.
+"""
+import gzip
+import io
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_corrupt_deflate_body() -> bytes:
+    """Build bytes with a syntactically valid gzip header but a garbage deflate body."""
+    buf = io.BytesIO()
+    # Write a valid 10-byte gzip header: magic, method=8, flags=0, mtime=0, xfl=0, OS=3
+    buf.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03")
+    # Write garbage where the deflate stream should be
+    buf.write(b"\xff\xfe\xfd\xfc" * 20)
+    return buf.getvalue()
+
+
+class MaybeDecompressZlibErrorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = EPGIngestManager()
+
+    def test_corrupt_deflate_body_does_not_raise(self):
+        """_maybe_decompress must not propagate zlib.error on a corrupt deflate body.
+
+        This differs from the BadGzipFile case: the gzip HEADER parses fine,
+        but the deflate stream that follows is garbage. gzip.decompress raises
+        zlib.error (not BadGzipFile) in this case. The fix in PR #73 caught
+        (gzip.BadGzipFile, EOFError, OSError) but omitted zlib.error, so this
+        specific case still aborts the EPG refresh.
+        """
+        corrupt = _make_corrupt_deflate_body()
+        # Verify our fixture actually triggers zlib.error (not BadGzipFile)
+        import zlib
+        with self.assertRaises(zlib.error):
+            gzip.decompress(corrupt)
+        # Bug: currently propagates zlib.error; expected to return bytes safely
+        result = self.manager._maybe_decompress(corrupt)
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result, b"")
+
+    def test_valid_gzip_still_decompresses_after_zlib_fix(self):
+        """_maybe_decompress must still decompress valid gzip after the zlib fix."""
+        payload = b"<?xml version='1.0'?><tv></tv>"
+        compressed = gzip.compress(payload)
+        result = self.manager._maybe_decompress(compressed)
+        self.assertEqual(result, payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`_maybe_decompress` in `epg_ingest_manager.py` raises `zlib.error` when a provider sends gzip data with a **valid header** but a **corrupt deflate body**. This is distinct from `gzip.BadGzipFile` (malformed header) and `EOFError` (truncated header). The fix for those two in PR #73 caught `(gzip.BadGzipFile, EOFError, OSError)` but omitted `zlib.error`, so this failure mode will persist after #73 is merged.

**What a user would notice:** EPG refresh silently fails for the affected account. The connection badge goes red. The program guide goes stale with no explanation. The only log entry is the raw `zlib.error` message.

**Trigger conditions:** Provider restarts mid-transmission after the gzip frame opens; network corruption after the gzip magic bytes; a reverse proxy that inserts an HTML error page after the gzip header.

## Reproduction

```python
from services.epg_ingest_manager import EPGIngestManager
m = EPGIngestManager()
# valid 10-byte gzip header, then garbage deflate body
m._maybe_decompress(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" + b"\xff\xfe\xfd\xfc" * 20)
# zlib.error: Error -3 while decompressing data: invalid block type
```

## Fix direction (maintainer only)

Add `zlib.error` to the exception list in `_maybe_decompress`:

```python
import zlib

def _maybe_decompress(self, data: bytes) -> bytes:
    if data[:2] == b"\x1f\x8b":
        try:
            return gzip.decompress(data)
        except (gzip.BadGzipFile, EOFError, OSError, zlib.error):
            return b""
    return data
```

## Test

`backend/tests/test_epg_zlib_error.py` — 1 failing test (`test_corrupt_deflate_body_does_not_raise`), 1 passing sanity check.