### PR TITLE
Fix glob escaping so ComSkip temp files clean up on bracket channel names

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import aiohttp
 import aiofiles
+import glob as glob_module
 import logging
 import os
 import shutil
@@ -901,6 +902,9 @@ class DownloadManager:
             original_file = Path(original_path)
             base_dir = original_file.parent
             stem = original_file.stem
+            # Escape glob special chars ([, ], ?) in the stem so channel names like
+            # "[BBC HD]" don't silently fail to match or accidentally match unrelated files.
+            escaped_stem = glob_module.escape(stem)
             completed_real = os.path.realpath(os.path.abspath(completed_path))
 
             if delete_original and original_path != completed_path and original_file.exists():
@@ -909,18 +913,18 @@ class DownloadManager:
             # Only remove known ComSkip/FFmpeg working files.
             # .xml/.srt/.ass/.vtt are user subtitle/metadata files, never ComSkip outputs.
             patterns = [
-                f"{stem}_seg*.ts",
-                f"{stem}.concat.txt",
-                f"{stem}.edl",
-                f"{stem}.txt",
-                f"{stem}.logo",
-                f"{stem}.csv",
-                f"{stem}.vdr",
+                f"{escaped_stem}_seg*.ts",
+                f"{escaped_stem}.concat.txt",
+                f"{escaped_stem}.edl",
+                f"{escaped_stem}.txt",
+                f"{escaped_stem}.logo",
+                f"{escaped_stem}.csv",
+                f"{escaped_stem}.vdr",
             ]
             if not keep_logs:
                 patterns.extend([
-                    f"{stem}.log",
-                    f"{stem}.*.ffmpeg.log",
+                    f"{escaped_stem}.log",
+                    f"{escaped_stem}.*.ffmpeg.log",
                 ])
 
             for pattern in patterns:

--- a/backend/tests/test_cleanup_bracket_filenames.py
+++ b/backend/tests/test_cleanup_bracket_filenames.py
@@ -1,0 +1,105 @@
+"""
+Regression test: _cleanup_working_files must delete ComSkip temp files
+even when the filename stem contains glob special characters like '[' and ']'.
+
+Common real-world IPTV channel names include brackets: [BBC], [HD], [US].
+sanitize_filename does not strip '[' or ']' (they are valid Linux filename chars),
+so stems like '[BBC] Doctor Who - 2024-01-15' reach _cleanup_working_files.
+
+Path.glob() treats '[...]' as a character class, so the cleanup patterns silently
+fail to match their targets, leaving ComSkip temp files on disk indefinitely.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from services.file_namer import file_namer
+
+
+class CleanupBracketFilenamesTest(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_sanitize_preserves_brackets(self):
+        """sanitize_filename must leave '[' and ']' in the output (they are valid Linux chars)."""
+        result = file_namer.sanitize_filename("[BBC] Doctor Who - S01E01")
+        self.assertIn("[", result, "sanitize_filename strips '['; test precondition changed")
+        self.assertIn("]", result, "sanitize_filename strips ']'; test precondition changed")
+
+    def test_cleanup_removes_comskip_files_when_stem_contains_brackets(self):
+        """ComSkip temp files are deleted even when the stem contains '[' or ']'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stem = "[BBC] Doctor Who - 2024-01-15"
+            ts_file = os.path.join(tmpdir, f"{stem}.ts")
+            completed_path = os.path.join(tmpdir, f"{stem}.mkv")
+
+            Path(ts_file).write_bytes(b"\x00")
+
+            temp_files = {
+                "edl":  Path(tmpdir) / f"{stem}.edl",
+                "txt":  Path(tmpdir) / f"{stem}.txt",
+                "log":  Path(tmpdir) / f"{stem}.log",
+                "csv":  Path(tmpdir) / f"{stem}.csv",
+                "logo": Path(tmpdir) / f"{stem}.logo",
+                "vdr":  Path(tmpdir) / f"{stem}.vdr",
+            }
+            for f in temp_files.values():
+                f.write_text("placeholder")
+
+            seg_file = Path(tmpdir) / f"{stem}_seg001.ts"
+            seg_file.write_text("segment")
+
+            self.manager._cleanup_working_files(
+                original_path=ts_file,
+                completed_path=completed_path,
+                keep_logs=False,
+                delete_original=True,
+            )
+
+            for label, path in temp_files.items():
+                self.assertFalse(
+                    path.exists(),
+                    f"ComSkip temp file '{label}' was not cleaned up for stem with brackets: {path.name}",
+                )
+
+            self.assertFalse(
+                seg_file.exists(),
+                f"Segment file was not cleaned up for stem with brackets: {seg_file.name}",
+            )
+
+    def test_cleanup_does_not_delete_unrelated_files_with_similar_names(self):
+        """Cleanup must not accidentally delete unrelated files that happen to match a mangled glob."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stem = "[BBC] Show - 2024-01-15"
+            ts_file = os.path.join(tmpdir, f"{stem}.ts")
+            completed_path = os.path.join(tmpdir, f"{stem}.mkv")
+            Path(ts_file).write_bytes(b"\x00")
+
+            # '[BBC]' as a broken glob character class matches 'B' or 'C', so a file
+            # starting with 'B' followed by ' Show - 2024-01-15.edl' would be incorrectly
+            # deleted without glob.escape().
+            unrelated = Path(tmpdir) / "B Show - 2024-01-15.edl"
+            unrelated.write_text("unrelated file -- must not be deleted")
+
+            self.manager._cleanup_working_files(
+                original_path=ts_file,
+                completed_path=completed_path,
+                keep_logs=False,
+                delete_original=True,
+            )
+
+            self.assertTrue(
+                unrelated.exists(),
+                "Cleanup deleted an unrelated file because of bad glob pattern escaping",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

ComSkip/FFmpeg working files (`.edl`, `.txt`, `.log`, etc.) were silently left on disk after processing when a channel name contained `[` or `]` -- for example `[BBC HD]` or `[US]`.

These characters are valid in Linux filenames and pass through `sanitize_filename` unchanged. The problem was in `_cleanup_working_files`: it built glob patterns by splicing the raw stem directly into strings like `f"{stem}.edl"`, then called `Path.glob(pattern)`. Python's `glob` treats `[BBC]` as a character class (matching `B` or `C`), so the pattern silently matched nothing and the files were never deleted.

**Fix:** call `glob.escape(stem)` before building patterns. The literal `*` appended for segment files stays a wildcard; only `[`, `]`, and `?` in the stem are escaped.

## Before

```
/downloads/[BBC] Doctor Who - 2024-01-15.edl   <-- left on disk forever
/downloads/[BBC] Doctor Who - 2024-01-15.txt   <-- left on disk forever
/downloads/[BBC] Doctor Who - 2024-01-15_seg001.ts  <-- left on disk
```

After a recording with a bracket channel name, the working directory would accumulate stale ComSkip temp files indefinitely.

## After

All temp files matching the bracket stem are deleted normally. An unrelated file like `B Show - 2024-01-15.edl` (which the broken character-class glob could have accidentally matched) is left untouched.

## Tests

- `test_cleanup_removes_comskip_files_when_stem_contains_brackets`: creates real temp files under a bracketed stem and asserts all are deleted
- `test_cleanup_does_not_delete_unrelated_files_with_similar_names`: asserts a file only matching the old broken pattern is not deleted
- Full suite: 227 tests, all pass

## Note

This replaces PR #81, which was branched off an older version of main and contained unrelated gzip changes that have since merged. This branch is a clean rebase from current main with only the bracket-glob fix.