### PR TITLE
Catch zlib.error in _maybe_decompress for corrupt gzip XMLTV bodies

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -3,6 +3,7 @@ import base64
 import gzip
 import io
 import logging
+import zlib
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, Optional
 from xml.etree.ElementTree import Element
@@ -479,7 +480,7 @@ class EPGIngestManager:
         if data[:2] == b"\x1f\x8b":
             try:
                 return gzip.decompress(data)
-            except (gzip.BadGzipFile, EOFError, OSError):
+            except (gzip.BadGzipFile, EOFError, OSError, zlib.error):
                 return b""
         return data
 

--- a/backend/tests/test_epg_zlib_error.py
+++ b/backend/tests/test_epg_zlib_error.py
@@ -1,0 +1,77 @@
+"""
+Regression test for _maybe_decompress raising uncaught zlib.error on XMLTV
+data with a valid gzip header but corrupt deflate body.
+
+gzip.BadGzipFile and EOFError are raised when the gzip HEADER is malformed
+or truncated. zlib.error is raised when the header is valid but the compressed
+body is corrupt or truncated after the header. Both failure modes reach the
+user the same way: the entire EPG refresh fails, the connection badge goes red,
+and the guide goes stale silently.
+
+The fix for gzip.BadGzipFile (PR #73) caught (gzip.BadGzipFile, EOFError,
+OSError) but did NOT include zlib.error. A provider that sends a complete,
+valid gzip header followed by garbage compressed data (e.g. from a mid-write
+server restart, network corruption after the gzip frame begins, or a proxy
+injecting an HTML error body after the gzip magic bytes) will still crash
+_maybe_decompress after PR #73 is merged.
+
+Expected behaviour after fix: _maybe_decompress catches zlib.error alongside
+BadGzipFile/EOFError and returns b"" so the caller logs a warning rather than
+aborting the refresh entirely.
+"""
+import gzip
+import io
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_corrupt_deflate_body() -> bytes:
+    """Build bytes with a syntactically valid gzip header but a garbage deflate body."""
+    buf = io.BytesIO()
+    # Write a valid 10-byte gzip header: magic, method=8, flags=0, mtime=0, xfl=0, OS=3
+    buf.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03")
+    # Write garbage where the deflate stream should be
+    buf.write(b"\xff\xfe\xfd\xfc" * 20)
+    return buf.getvalue()
+
+
+class MaybeDecompressZlibErrorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = EPGIngestManager()
+
+    def test_corrupt_deflate_body_does_not_raise(self):
+        """_maybe_decompress must not propagate zlib.error on a corrupt deflate body.
+
+        This differs from the BadGzipFile case: the gzip HEADER parses fine,
+        but the deflate stream that follows is garbage. gzip.decompress raises
+        zlib.error (not BadGzipFile) in this case. The fix in PR #73 caught
+        (gzip.BadGzipFile, EOFError, OSError) but omitted zlib.error, so this
+        specific case still aborts the EPG refresh.
+        """
+        corrupt = _make_corrupt_deflate_body()
+        # Verify our fixture actually triggers zlib.error (not BadGzipFile)
+        import zlib
+        with self.assertRaises(zlib.error):
+            gzip.decompress(corrupt)
+        result = self.manager._maybe_decompress(corrupt)
+        self.assertIsInstance(result, bytes)
+        self.assertEqual(result, b"")
+
+    def test_valid_gzip_still_decompresses_after_zlib_fix(self):
+        """_maybe_decompress must still decompress valid gzip after the zlib fix."""
+        payload = b"<?xml version='1.0'?><tv></tv>"
+        compressed = gzip.compress(payload)
+        result = self.manager._maybe_decompress(compressed)
+        self.assertEqual(result, payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

EPG guide data can stop updating silently when a provider sends a gzip-compressed XMLTV response where the header is valid but the compressed data that follows is corrupt or truncated.

PR #73 added a try/except to handle `gzip.BadGzipFile`, `EOFError`, and `OSError`. But there is a fourth case: when the gzip header parses correctly and the error only appears in the compressed body, Python raises `zlib.error`, which is not a subclass of `OSError` and was not caught. The result is an unhandled exception that aborts the entire EPG account refresh, turns the connection badge red, and leaves the guide stale, all with no clear error message.

**Fix:** add `zlib.error` to the except tuple. The caller already handles an empty `b""` return by logging a warning and moving on, so no additional changes are needed.

## Before

A provider sending a valid gzip magic byte sequence followed by garbage content (for example, a proxy that injects an HTML error page after the gzip header, or a server that died mid-write) would cause an unhandled `zlib.error` crash and abort the EPG refresh:

```
zlib.error: Error -3 while decompressing data: invalid block type
  File ".../epg_ingest_manager.py", in _maybe_decompress
    return gzip.decompress(data)
```

## After

`_maybe_decompress` returns `b""` for any of these error cases, and the caller treats that as "no XMLTV data available" and logs a warning instead of failing the account.

## Tests

- `test_corrupt_deflate_body_does_not_raise`: builds a fixture with a syntactically valid gzip header and garbage deflate body, first verifies it actually raises `zlib.error` (not `BadGzipFile`), then confirms `_maybe_decompress` returns `b""` safely
- `test_valid_gzip_still_decompresses_after_zlib_fix`: regression that valid gzip is still decompressed correctly
- Full suite: 226 tests, all pass

## Note

This replaces PR #86, which was branched off the `gremlin/cleanup-bracket-glob-bug` branch (not main) and contained extra files from other PRs. This branch is a clean rebase from current main with only the `zlib.error` fix.