### PR TITLE
fix: pass content_type=None to all response.json() calls in xtream_client

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -40,7 +40,7 @@ class XtreamClient:
         async with session.get(url) as response:
             if response.status != 200:
                 raise Exception(f"Authentication failed: HTTP {response.status}")
-            data = await response.json()
+            data = await response.json(content_type=None)
             if "user_info" not in data:
                 raise Exception("Invalid response from server")
             if not data["user_info"].get("auth", 1):
@@ -54,7 +54,7 @@ class XtreamClient:
         async with session.get(url) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get categories: HTTP {response.status}")
-            data = await response.json()
+            data = await response.json(content_type=None)
             return list(data.values()) if isinstance(data, dict) else data
 
     async def get_live_streams(self, category_id: Optional[str] = None) -> list:
@@ -64,7 +64,7 @@ class XtreamClient:
         async with session.get(url) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get streams: HTTP {response.status}")
-            data = await response.json()
+            data = await response.json(content_type=None)
             return list(data.values()) if isinstance(data, dict) else data
 
     async def get_epg(self, stream_id: str) -> list:
@@ -74,7 +74,7 @@ class XtreamClient:
         async with session.get(url) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get EPG: HTTP {response.status}")
-            data = await response.json()
+            data = await response.json(content_type=None)
             return data.get("epg_listings") or []
 
     async def get_short_epg(self, stream_id: str, limit: int = 10) -> list:
@@ -84,7 +84,7 @@ class XtreamClient:
         async with session.get(url) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get short EPG: HTTP {response.status}")
-            data = await response.json()
+            data = await response.json(content_type=None)
             return data.get("epg_listings") or []
 
     async def get_xmltv(self) -> bytes:
@@ -103,7 +103,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get VOD categories: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     async def get_vod_streams(self, category_id: Optional[str] = None) -> list:
         """Get VOD (movies) streams."""
@@ -112,7 +112,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get VOD streams: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     async def get_vod_info(self, vod_id: str) -> dict:
         """Get VOD (movie) details."""
@@ -121,7 +121,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get VOD info: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     async def get_series_categories(self) -> list:
         """Get series categories."""
@@ -130,7 +130,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get series categories: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     async def get_series(self, category_id: Optional[str] = None) -> list:
         """Get series list."""
@@ -139,7 +139,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get series: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     async def get_series_info(self, series_id: str) -> dict:
         """Get series details (seasons + episodes)."""
@@ -148,7 +148,7 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get series info: HTTP {response.status}")
-            return await response.json()
+            return await response.json(content_type=None)
 
     def build_timeshift_url(
         self,

--- a/backend/tests/test_xtream_client_content_type.py
+++ b/backend/tests/test_xtream_client_content_type.py
@@ -1,0 +1,134 @@
+"""
+Regression for: Providers serving JSON as text/plain break all API calls.
+
+aiohttp >= 3.11 enforces content_type='application/json' by default.
+PHP-based Xtream panels commonly return text/plain or text/html even for valid JSON.
+All response.json() calls must pass content_type=None to accept any content-type.
+
+Each test asserts that response.json was called with content_type=None.
+If any call site loses the argument, the test fails.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.xtream_client import XtreamClient
+
+
+def _mock_session_with_spy(json_data, status=200):
+    """Return a session mock where response.json is a spy we can inspect."""
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=cm)
+    get_session = AsyncMock(return_value=session)
+    return get_session, response
+
+
+def _client():
+    return XtreamClient("http://provider.test:8080", "user", "pass")
+
+
+def _assert_content_type_none(response_mock, method_name):
+    """Assert response.json was called with content_type=None."""
+    response_mock.json.assert_called_once()
+    kwargs = response_mock.json.call_args.kwargs
+    assert kwargs.get("content_type") is None and "content_type" in kwargs, (
+        f"{method_name}: response.json() called without content_type=None. "
+        f"Providers returning text/plain will raise ContentTypeError."
+    )
+
+
+class ContentTypeNoneTests(unittest.IsolatedAsyncioTestCase):
+    """Each API method must call response.json(content_type=None)."""
+
+    async def test_authenticate_passes_content_type_none(self):
+        client = _client()
+        data = {"user_info": {"auth": 1}, "server_info": {}}
+        get_session, resp = _mock_session_with_spy(data)
+        client._get_session = get_session
+        await client.authenticate()
+        _assert_content_type_none(resp, "authenticate")
+
+    async def test_get_live_categories_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([{"category_id": "1"}])
+        client._get_session = get_session
+        await client.get_live_categories()
+        _assert_content_type_none(resp, "get_live_categories")
+
+    async def test_get_live_streams_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([])
+        client._get_session = get_session
+        await client.get_live_streams()
+        _assert_content_type_none(resp, "get_live_streams")
+
+    async def test_get_epg_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy({"epg_listings": []})
+        client._get_session = get_session
+        await client.get_epg("1")
+        _assert_content_type_none(resp, "get_epg")
+
+    async def test_get_short_epg_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy({"epg_listings": []})
+        client._get_session = get_session
+        await client.get_short_epg("1")
+        _assert_content_type_none(resp, "get_short_epg")
+
+    async def test_get_vod_categories_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([])
+        client._get_session = get_session
+        await client.get_vod_categories()
+        _assert_content_type_none(resp, "get_vod_categories")
+
+    async def test_get_vod_streams_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([])
+        client._get_session = get_session
+        await client.get_vod_streams()
+        _assert_content_type_none(resp, "get_vod_streams")
+
+    async def test_get_vod_info_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy({"info": {}})
+        client._get_session = get_session
+        await client.get_vod_info("42")
+        _assert_content_type_none(resp, "get_vod_info")
+
+    async def test_get_series_categories_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([])
+        client._get_session = get_session
+        await client.get_series_categories()
+        _assert_content_type_none(resp, "get_series_categories")
+
+    async def test_get_series_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy([])
+        client._get_session = get_session
+        await client.get_series()
+        _assert_content_type_none(resp, "get_series")
+
+    async def test_get_series_info_passes_content_type_none(self):
+        client = _client()
+        get_session, resp = _mock_session_with_spy({"info": {}, "episodes": {}})
+        client._get_session = get_session
+        await client.get_series_info("7")
+        _assert_content_type_none(resp, "get_series_info")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

On some IPTV providers (especially older or budget PHP panels), opening Browse, loading the program guide, or adding an account would fail completely with a generic error. No channels would load, and EPG refreshes would log errors and leave the guide stale. The provider was returning valid data, but Mustarrd was rejecting it because of the HTTP header the server sent.

## What changed

aiohttp 3.11 enforces `Content-Type: application/json` by default when parsing JSON responses. PHP-based Xtream panels commonly return `text/plain` or `text/html` even for valid JSON. Passing `content_type=None` to `response.json()` disables this check and accepts any content-type as long as the body is valid JSON.

All 11 `response.json()` call sites in `xtream_client.py` now pass `content_type=None`.

## Before

Provider returns `Content-Type: text/plain`. aiohttp raises:
```
ContentTypeError: Actual content-type header is 'text/plain'
```
Caught by generic exception handler, surfaces as "Failed to load channels from provider" or HTTP 400/500. No indication that the content-type header is the cause.

## After

`response.json(content_type=None)` accepts any content-type. Browse loads correctly, EPG refreshes complete, account validation works.

## How it was tested

11 regression tests in `test_xtream_client_content_type.py`, one per call site. Each test asserts that `response.json` was called with `content_type=None`. If any call site loses the argument, the corresponding test fails and the breakage is caught before it ships.

Full suite: 254 tests, all pass.