### PR TITLE
fix: percent-encode credentials in xtream path URL builders

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -1,7 +1,7 @@
 import aiohttp
 from datetime import datetime
 from typing import Optional
-from urllib.parse import urljoin, urlencode
+from urllib.parse import urljoin, urlencode, quote
 
 
 VOD_TIMEOUT = aiohttp.ClientTimeout(total=90)
@@ -164,18 +164,26 @@ class XtreamClient:
         """
         raw_provider_start = (provider_start or "").strip()
         date_str = raw_provider_start or start_time.strftime("%Y-%m-%d:%H-%M")
-        return f"{self.server_url}/timeshift/{self.username}/{self.password}/{duration_minutes}/{date_str}/{stream_id}.ts"
+        u = quote(self.username, safe="")
+        p = quote(self.password, safe="")
+        return f"{self.server_url}/timeshift/{u}/{p}/{duration_minutes}/{date_str}/{stream_id}.ts"
 
     def build_stream_url(self, stream_id: str, extension: str = "ts") -> str:
         """Build live stream URL."""
-        return f"{self.server_url}/live/{self.username}/{self.password}/{stream_id}.{extension}"
+        u = quote(self.username, safe="")
+        p = quote(self.password, safe="")
+        return f"{self.server_url}/live/{u}/{p}/{stream_id}.{extension}"
 
     def build_vod_url(self, vod_id: str, extension: Optional[str] = None) -> str:
         """Build VOD movie URL."""
         ext = (extension or "mp4").lstrip(".") or "mp4"
-        return f"{self.server_url}/movie/{self.username}/{self.password}/{vod_id}.{ext}"
+        u = quote(self.username, safe="")
+        p = quote(self.password, safe="")
+        return f"{self.server_url}/movie/{u}/{p}/{vod_id}.{ext}"
 
     def build_series_url(self, episode_id: str, extension: Optional[str] = None) -> str:
         """Build VOD series episode URL."""
         ext = (extension or "mp4").lstrip(".") or "mp4"
-        return f"{self.server_url}/series/{self.username}/{self.password}/{episode_id}.{ext}"
+        u = quote(self.username, safe="")
+        p = quote(self.password, safe="")
+        return f"{self.server_url}/series/{u}/{p}/{episode_id}.{ext}"

--- a/backend/tests/test_xtream_client_path_encoding.py
+++ b/backend/tests/test_xtream_client_path_encoding.py
@@ -1,0 +1,79 @@
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.xtream_client import XtreamClient
+
+
+class PathUrlEncodingTests(unittest.TestCase):
+    def _client(self, username="user", password="pass"):
+        return XtreamClient("http://provider.test:8080", username, password)
+
+    def _ts(self):
+        return datetime(2024, 1, 15, 20, 30)
+
+    # --- hash fragment delimiter ---
+
+    def test_hash_in_password_encoded_timeshift(self):
+        url = self._client(password="p@ss#word").build_timeshift_url("123", self._ts(), 60)
+        self.assertIn("%23", url)
+        self.assertNotIn("#", url.split("//", 1)[1])
+
+    def test_hash_in_username_encoded_timeshift(self):
+        url = self._client(username="us#er").build_timeshift_url("123", self._ts(), 60)
+        self.assertIn("%23", url)
+        self.assertNotIn("#", url.split("//", 1)[1])
+
+    def test_hash_in_password_encoded_stream(self):
+        url = self._client(password="p#ss").build_stream_url("99")
+        self.assertIn("%23", url)
+        self.assertNotIn("#", url.split("//", 1)[1])
+
+    def test_hash_in_password_encoded_vod(self):
+        url = self._client(password="p#ss").build_vod_url("42")
+        self.assertIn("%23", url)
+        self.assertNotIn("#", url.split("//", 1)[1])
+
+    def test_hash_in_password_encoded_series(self):
+        url = self._client(password="p#ss").build_series_url("7", "mkv")
+        self.assertIn("%23", url)
+        self.assertNotIn("#", url.split("//", 1)[1])
+
+    # --- other problematic chars ---
+
+    def test_question_mark_in_password_encoded(self):
+        url = self._client(password="pass?word").build_stream_url("1")
+        self.assertIn("%3F", url)
+        self.assertNotIn("?", url.split("//", 1)[1])
+
+    def test_slash_in_password_encoded(self):
+        url = self._client(password="pass/word").build_timeshift_url("5", self._ts(), 30)
+        self.assertIn("%2F", url)
+
+    def test_space_in_username_encoded(self):
+        url = self._client(username="my user").build_vod_url("10")
+        self.assertIn("%20", url)
+
+    # --- normal credentials pass through intact ---
+
+    def test_normal_credentials_unchanged(self):
+        url = self._client(username="myuser", password="secret123").build_stream_url("55")
+        self.assertIn("/myuser/", url)
+        self.assertIn("/secret123/", url)
+
+    def test_timeshift_date_preserved(self):
+        url = self._client().build_timeshift_url("77", self._ts(), 90)
+        self.assertIn("2024-01-15:20-30", url)
+
+    def test_timeshift_provider_start_preserved(self):
+        url = self._client().build_timeshift_url("77", self._ts(), 90, provider_start="2024-01-15:20-30")
+        self.assertIn("2024-01-15:20-30", url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Before: if your IPTV provider password contained a special character like `#`, every catchup download would silently fail. The `#` acts as a URL fragment delimiter, so aiohttp would strip everything after it before sending the request. The provider received a truncated credential and returned a 401 or 404 error. Mustarrd reported a generic download failure with no indication that the credential was the cause.

After: passwords and usernames containing `#`, `?`, `/`, spaces, or any other URL-special character are safely percent-encoded in the stream URL. `p@ss#word` becomes `p%40ss%23word` in the path, which the provider receives and decodes correctly.

## What changed

**Backend (`backend/services/xtream_client.py`):** Added `quote` to the `urllib.parse` import. Applied `quote(..., safe='')` to `self.username` and `self.password` in all four path-segment URL builders: `build_timeshift_url`, `build_stream_url`, `build_vod_url`, `build_series_url`. The `_build_api_url` method already used `urlencode` and was not affected.

## How it was tested

Full backend suite: 265 tests, all pass.

11 new regression tests in `test_xtream_client_path_encoding.py` cover:
- `#` in password and username across all four builders (the primary bug)
- `?`, `/`, and space in credentials
- Normal credentials pass through unchanged
- `build_timeshift_url` date string is preserved unmodified

## Before

Password `p@ss#word` sent to provider as: `.../timeshift/user/p@ss` (truncated at `#`). Provider returns 401. Download marked FAILED with no useful error message.

## After

Password `p@ss#word` sent as: `.../timeshift/user/p%40ss%23word`. Provider receives the full credential.