### PR TITLE
fix: plain-English error messages on failed downloads

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -21,6 +21,34 @@ from services.plex_service import plex_service
 logger = logging.getLogger(__name__)
 
 
+def _friendly_error(e: Exception) -> str:
+    """Translate a download exception into a short, user-readable string."""
+    import errno
+    if isinstance(e, asyncio.TimeoutError):
+        return "Connection timed out. The provider took too long to respond."
+    if isinstance(e, aiohttp.ClientConnectorError):
+        return "Cannot reach the provider. Check the server URL in your account settings."
+    if isinstance(e, aiohttp.ServerDisconnectedError):
+        return "Provider disconnected unexpectedly. Try again later."
+    if isinstance(e, aiohttp.ClientError):
+        return "Network error connecting to provider. Try again later."
+    if isinstance(e, OSError) and e.errno == errno.ENOSPC:
+        return "Not enough disk space. Free up space and retry."
+    msg = str(e)
+    if not msg:
+        return "Download failed for an unknown reason. Check the logs for details."
+    if msg.startswith("HTTP 401") or msg.startswith("HTTP 403"):
+        return "Invalid credentials or not authorized. Check your account settings."
+    if msg.startswith("HTTP 404"):
+        return "Recording not found on provider. The catchup window may have expired."
+    if msg.startswith("HTTP 5"):
+        return "Provider server error. Try again later."
+    if msg.startswith("HTTP "):
+        code = msg.split(":")[0]
+        return f"Provider returned an error ({code}). Try again later."
+    return msg
+
+
 class DownloadManager:
     def __init__(self):
         self._queue: asyncio.Queue = asyncio.Queue()
@@ -635,7 +663,7 @@ class DownloadManager:
                 download = result.scalar_one_or_none()
                 if download:
                     download.status = DownloadStatus.FAILED.value
-                    download.error_message = str(e)
+                    download.error_message = _friendly_error(e)
                     await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
                     try:
@@ -782,7 +810,7 @@ class DownloadManager:
                 download = result.scalar_one_or_none()
                 if download:
                     download.status = DownloadStatus.FAILED.value
-                    download.error_message = str(e)
+                    download.error_message = _friendly_error(e)
                     await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
 

--- a/backend/tests/test_disk_full.py
+++ b/backend/tests/test_disk_full.py
@@ -110,9 +110,9 @@ class DiskFullTests(unittest.IsolatedAsyncioTestCase):
                 "Download must be marked FAILED on ENOSPC.",
             )
             self.assertIn(
-                "28",
-                download.error_message or "",
-                "error_message must reference errno 28.",
+                "disk space",
+                (download.error_message or "").lower(),
+                "error_message must mention disk space.",
             )
 
             # Partial file must be gone. This assertion FAILS on the current codebase.

--- a/backend/tests/test_friendly_error.py
+++ b/backend/tests/test_friendly_error.py
@@ -1,0 +1,82 @@
+import asyncio
+import errno
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import aiohttp
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import _friendly_error
+
+
+class FriendlyErrorTests(unittest.TestCase):
+    def test_timeout_error(self):
+        msg = _friendly_error(asyncio.TimeoutError())
+        self.assertIn("timed out", msg.lower())
+
+    def test_client_connector_error(self):
+        err = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=OSError("Connection refused")
+        )
+        msg = _friendly_error(err)
+        self.assertIn("cannot reach", msg.lower())
+
+    def test_server_disconnected_error(self):
+        msg = _friendly_error(aiohttp.ServerDisconnectedError())
+        self.assertIn("disconnected", msg.lower())
+
+    def test_generic_aiohttp_client_error(self):
+        msg = _friendly_error(aiohttp.ClientError("some network error"))
+        self.assertIn("network error", msg.lower())
+
+    def test_http_401(self):
+        msg = _friendly_error(Exception("HTTP 401: Unauthorized"))
+        self.assertIn("credentials", msg.lower())
+
+    def test_http_403(self):
+        msg = _friendly_error(Exception("HTTP 403: Forbidden"))
+        self.assertIn("credentials", msg.lower())
+
+    def test_http_404(self):
+        msg = _friendly_error(Exception("HTTP 404: Not Found"))
+        self.assertIn("not found", msg.lower())
+
+    def test_http_503(self):
+        msg = _friendly_error(Exception("HTTP 503: Service Unavailable"))
+        self.assertIn("server error", msg.lower())
+
+    def test_http_other(self):
+        msg = _friendly_error(Exception("HTTP 429: Too Many Requests"))
+        self.assertIn("HTTP 429", msg)
+
+    def test_disk_full(self):
+        err = OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+        msg = _friendly_error(err)
+        self.assertIn("disk space", msg.lower())
+
+    def test_empty_exception_string(self):
+        msg = _friendly_error(Exception(""))
+        self.assertIn("unknown reason", msg.lower())
+
+    def test_already_friendly_message_passes_through(self):
+        friendly = (
+            "Provider returned an empty response. "
+            "The catchup window for this program may have expired."
+        )
+        msg = _friendly_error(Exception(friendly))
+        self.assertEqual(msg, friendly)
+
+    def test_missing_file_message_passes_through(self):
+        original = "Missing input file for post-processing."
+        msg = _friendly_error(Exception(original))
+        self.assertEqual(msg, original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Before: a failed recording shows a red FAILED badge with a raw technical message like "HTTP 403: Forbidden" or, worse, nothing at all (asyncio.TimeoutError produces an empty string). A non-technical operator has no idea whether to fix their username, check their internet, or wait.

After: the same failed recording shows a short plain-English explanation: "Invalid credentials or not authorized. Check your account settings." or "Connection timed out. The provider took too long to respond."

## What changed

Added `_friendly_error(e)` in `backend/services/download_manager.py`. It maps the exception types that actually reach the two `except Exception as e` blocks to user-readable strings:

- `asyncio.TimeoutError`: "Connection timed out. The provider took too long to respond."
- `aiohttp.ClientConnectorError`: "Cannot reach the provider. Check the server URL in your account settings."
- `aiohttp.ServerDisconnectedError`: "Provider disconnected unexpectedly. Try again later."
- Other `aiohttp.ClientError`: "Network error connecting to provider. Try again later."
- `OSError(ENOSPC)`: "Not enough disk space. Free up space and retry."
- `HTTP 401/403`: "Invalid credentials or not authorized. Check your account settings."
- `HTTP 404`: "Recording not found on provider. The catchup window may have expired."
- `HTTP 5xx`: "Provider server error. Try again later."
- Other `HTTP N`: "Provider returned an error (HTTP N). Try again later."
- Empty string: "Download failed for an unknown reason. Check the logs for details."
- All other exceptions: pass through unchanged (already-friendly strings like "Provider returned an empty response. The catchup window for this program may have expired." are kept as-is).

Both `_execute_download` and `_execute_post_process` now call `_friendly_error(e)` instead of `str(e)`. No frontend changes needed: the UI already shows `error_message` in a red Alert under the FAILED badge.

## How it was tested

13 unit tests in `test_friendly_error.py` cover each mapped case plus pass-through. `test_disk_full.py` updated to assert "disk space" in message instead of errno "28". 278 tests, all pass.

## Before

EastEnders shows raw "HTTP 403: Forbidden". No action the user can take.

## After

Coronation Street: "Invalid credentials or not authorized. Check your account settings." Great British Bake Off: "Connection timed out. The provider took too long to respond."

See screenshots in #design.