### PR TITLE
fix: percent-encode stream/vod/episode IDs in Xtream path URL builders

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -166,24 +166,28 @@ class XtreamClient:
         date_str = raw_provider_start or start_time.strftime("%Y-%m-%d:%H-%M")
         u = quote(self.username, safe="")
         p = quote(self.password, safe="")
-        return f"{self.server_url}/timeshift/{u}/{p}/{duration_minutes}/{date_str}/{stream_id}.ts"
+        sid = quote(str(stream_id), safe="")
+        return f"{self.server_url}/timeshift/{u}/{p}/{duration_minutes}/{date_str}/{sid}.ts"
 
     def build_stream_url(self, stream_id: str, extension: str = "ts") -> str:
         """Build live stream URL."""
         u = quote(self.username, safe="")
         p = quote(self.password, safe="")
-        return f"{self.server_url}/live/{u}/{p}/{stream_id}.{extension}"
+        sid = quote(str(stream_id), safe="")
+        return f"{self.server_url}/live/{u}/{p}/{sid}.{extension}"
 
     def build_vod_url(self, vod_id: str, extension: Optional[str] = None) -> str:
         """Build VOD movie URL."""
         ext = (extension or "mp4").lstrip(".") or "mp4"
         u = quote(self.username, safe="")
         p = quote(self.password, safe="")
-        return f"{self.server_url}/movie/{u}/{p}/{vod_id}.{ext}"
+        vid = quote(str(vod_id), safe="")
+        return f"{self.server_url}/movie/{u}/{p}/{vid}.{ext}"
 
     def build_series_url(self, episode_id: str, extension: Optional[str] = None) -> str:
         """Build VOD series episode URL."""
         ext = (extension or "mp4").lstrip(".") or "mp4"
         u = quote(self.username, safe="")
         p = quote(self.password, safe="")
-        return f"{self.server_url}/series/{u}/{p}/{episode_id}.{ext}"
+        eid = quote(str(episode_id), safe="")
+        return f"{self.server_url}/series/{u}/{p}/{eid}.{ext}"

--- a/backend/tests/test_xtream_client_path_encoding.py
+++ b/backend/tests/test_xtream_client_path_encoding.py
@@ -59,6 +59,29 @@ class PathUrlEncodingTests(unittest.TestCase):
         url = self._client(username="my user").build_vod_url("10")
         self.assertIn("%20", url)
 
+    # --- slash in stream/vod/episode ID ---
+
+    def test_slash_in_stream_id_encoded(self):
+        url = self._client().build_stream_url("123/456")
+        self.assertIn("%2F", url)
+        # encoded id sits between the two surrounding slashes
+        self.assertIn("/123%2F456.ts", url)
+
+    def test_slash_in_timeshift_stream_id_encoded(self):
+        url = self._client().build_timeshift_url("123/456", self._ts(), 60)
+        self.assertIn("%2F", url)
+        self.assertIn("/123%2F456.ts", url)
+
+    def test_slash_in_vod_id_encoded(self):
+        url = self._client().build_vod_url("123/456")
+        self.assertIn("%2F", url)
+        self.assertIn("/123%2F456.mp4", url)
+
+    def test_slash_in_series_id_encoded(self):
+        url = self._client().build_series_url("123/456", "mkv")
+        self.assertIn("%2F", url)
+        self.assertIn("/123%2F456.mkv", url)
+
     # --- normal credentials pass through intact ---
 
     def test_normal_credentials_unchanged(self):


### PR DESCRIPTION
## What a user would notice

If your IPTV provider assigned a stream ID containing a `/` (some reseller panels generate IDs like `abc/123`), every download attempt would silently fail. The URL sent to your provider would be malformed: the server would see the slash as a path separator and interpret the request as hitting a completely different endpoint, returning a 404 or 403 with no clear explanation.

## What changed

PR #97 added percent-encoding for credentials (username and password) in the four Xtream Codes URL builders. This PR extends the same fix to the stream ID, VOD ID, and series episode ID segments in those same builders.

Before (stream URL with ID `123/456`):
```
http://provider:8080/live/user/pass/123/456.ts
                                        ^
                              server sees extra path segment
```

After:
```
http://provider:8080/live/user/pass/123%2F456.ts
```

The fix applies to all four path builders: catchup/timeshift, live stream, VOD movie, and series episode.

## How it was tested

Four new regression tests added to `test_xtream_client_path_encoding.py`, one for each URL builder, asserting that a slash in the ID is encoded as `%2F` and appears correctly in the final URL. Tests failed before the fix and pass after. Full suite: 277/277 pass.

Closes the remaining half of the `[TODO] Password or stream_id with / in path breaks timeshift download URL structure` task (credentials were fixed in #97; IDs fixed here).