### PR TITLE
docs: add changelog entries for PRs #84 and #100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Red badge on the Downloads menu item shows how many recordings have failed
+
+**What you would notice:** Before this change, there was no way to know a recording had failed without manually opening the Downloads page. You might not notice a failed recording for days. A small red badge now appears on the Downloads item in the sidebar as soon as a recording permanently fails. The badge shows the number of failures since you last visited Downloads. Opening the Downloads page clears the badge. The existing yellow badge that shows how many downloads are currently in progress continues to work alongside it.
+
+**What changed:** A new backend endpoint counts permanent failures since a given time. The frontend reads a stored timestamp of your last Downloads visit and uses it to request the count. The badge updates automatically each time the page loads.
+
+---
+
+### Fixed: Catchup programs now show correctly on providers that omit archive flags from individual guide entries
+
+**What you would notice:** On some IPTV providers, channels are configured to allow catchup, but individual program entries in the guide do not carry their own "has archive" flag. Before this fix, Mustarrd treated those programs as unavailable for download: the yellow catchup border did not appear, and clicking the program gave no download option. The Catchup page could appear completely empty even when catchup was fully working. Programs on these providers now correctly show the catchup border and can be downloaded.
+
+**What changed:** When a program entry from the live guide does not include its own archive flag, Mustarrd now falls back to the archive setting of the channel itself. This matches how the program guide background refresh already handled the same situation. Providers that do include per-program archive flags are not affected.
+
+---
+
 ### Fixed: Failed downloads now show a plain-English reason instead of a technical error
 
 **What you would notice:** When a download failed, the error shown in the Downloads history was often a raw Python exception or an empty string that gave no useful information. You might see something like `<class 'asyncio.TimeoutError'>` or nothing at all. Failed downloads now show a short, readable message: "Connection timed out," "Not enough disk space," "Provider refused the request (403)," "Server not reachable," and so on. The message appears in the Downloads list next to the failed item.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Then open **http://localhost:4177** in your browser.
 ### Monitor Downloads
 
 - Go to the **Downloads** page to see active downloads with progress bars
+- A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - Failed downloads can be retried from the same page
 - Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries stay so you can retry them)


### PR DESCRIPTION
## What a user would notice

CHANGELOG now covers the two most recent feature and bug-fix merges:

- **PR #84** (Downloads failure badge): New red badge on the Downloads sidebar item that counts permanent failures since your last visit. README Monitor Downloads section updated to describe it.
- **PR #100** (live EPG archive flag fallback): Catchup programs now show correctly on providers that omit the archive flag from individual guide entries.

## What changed

- `CHANGELOG.md`: two new entries under 2026-06-07, above the existing PR #99 entry
- `README.md`: one bullet added to the Monitor Downloads section describing the failure badge

## How it was tested

Entries verified against merged PR descriptions and code. No em dashes. No code changed.