### PR TITLE
fix: cap pre/post padding at 120 minutes in DownloadCreate

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -103,8 +103,8 @@ class DownloadCreate(BaseModel):
     channel_name: str
     program: dict  # EPG program data
     custom_filename: Optional[str] = None
-    pre_padding_minutes: Optional[conint(ge=0)] = 0
-    post_padding_minutes: Optional[conint(ge=0)] = 0
+    pre_padding_minutes: Optional[conint(ge=0, le=120)] = 0
+    post_padding_minutes: Optional[conint(ge=0, le=120)] = 0
 
 
 class FilenamePreview(BaseModel):

--- a/backend/tests/test_download_padding_bounds.py
+++ b/backend/tests/test_download_padding_bounds.py
@@ -1,0 +1,62 @@
+import sys
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from api.downloads import DownloadCreate
+
+
+class DownloadPaddingBoundsTests(unittest.TestCase):
+    """
+    Regression tests for unbounded pre/post padding on DownloadCreate.
+
+    pre_padding_minutes and post_padding_minutes must be capped at 120 so
+    a malformed request cannot produce a multi-day padded duration passed
+    to FFmpeg.
+    """
+
+    _VALID_PROGRAM = {
+        "start_timestamp": 1000000000,
+        "stop_timestamp": 1000003600,
+        "title": "Test Show",
+    }
+
+    def _make(self, **kwargs):
+        return DownloadCreate(
+            account_id=1,
+            channel_id="101",
+            channel_name="Test",
+            program=self._VALID_PROGRAM,
+            **kwargs,
+        )
+
+    def test_pre_padding_upper_bound_enforced(self):
+        """pre_padding_minutes above 120 must raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            self._make(pre_padding_minutes=10000)
+
+    def test_post_padding_upper_bound_enforced(self):
+        """post_padding_minutes above 120 must raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            self._make(post_padding_minutes=10000)
+
+    def test_reasonable_padding_accepted(self):
+        """Values within the 120-minute cap must be accepted."""
+        dl = self._make(pre_padding_minutes=30, post_padding_minutes=15)
+        self.assertEqual(dl.pre_padding_minutes, 30)
+        self.assertEqual(dl.post_padding_minutes, 15)
+
+    def test_zero_padding_accepted(self):
+        """Zero padding is the default and must remain valid."""
+        dl = self._make(pre_padding_minutes=0, post_padding_minutes=0)
+        self.assertEqual(dl.pre_padding_minutes, 0)
+        self.assertEqual(dl.post_padding_minutes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Before this fix, if something sent a download request with an extremely large padding value (say, 10000 minutes), Mustarrd would accept it and pass a multi-day duration to FFmpeg. This could lock a download slot for days or cause unexpected behavior.

After this fix, any request with padding above 120 minutes is rejected with a validation error, the same limit that scheduled recordings already enforced.

## What changed

`DownloadCreate` in `backend/api/downloads.py` had no upper bound on `pre_padding_minutes` and `post_padding_minutes`. `ScheduleCreate` already capped both at 120 minutes. This one-line change brings `DownloadCreate` in line.

## Before

```python
pre_padding_minutes: Optional[conint(ge=0)] = 0
post_padding_minutes: Optional[conint(ge=0)] = 0
```

## After

```python
pre_padding_minutes: Optional[conint(ge=0, le=120)] = 0
post_padding_minutes: Optional[conint(ge=0, le=120)] = 0
```

## How it was tested

Four regression tests added in `backend/tests/test_download_padding_bounds.py`:
- `test_pre_padding_upper_bound_enforced`: confirms a value of 10000 raises `ValidationError`
- `test_post_padding_upper_bound_enforced`: same for post padding
- `test_reasonable_padding_accepted`: confirms values within the cap work normally
- `test_zero_padding_accepted`: confirms default zero padding is still valid

All 4 new tests pass. Full suite: 300/300 pass.

Closes the gap identified in PR #103's review by Cleo.