### PR TITLE
Add Upcoming tab to Downloads page

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -19,7 +19,7 @@ from auth import (
 )
 from config import settings
 from database import get_session
-from models import AppSettings, Download, DownloadStatus, XtreamAccount, User
+from models import AppSettings, Download, DownloadStatus, XtreamAccount, User, ScheduledRecording, ScheduledStatus
 from services.download_manager import download_manager
 from services.file_namer import file_namer
 from services.epg_service import epg_service
@@ -204,6 +204,28 @@ async def get_failed_download_count(
         query = query.where(Download.completed_at >= cutoff)
     result = await session.execute(query)
     return {"count": result.scalar() or 0}
+
+
+@router.get("/upcoming")
+async def get_upcoming_recordings(
+    auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """List scheduled and paused-low-space recordings sorted by air date."""
+    query = (
+        select(ScheduledRecording)
+        .where(
+            ScheduledRecording.status.in_([
+                ScheduledStatus.SCHEDULED.value,
+                ScheduledStatus.PAUSED_LOW_SPACE.value,
+            ])
+        )
+        .order_by(ScheduledRecording.program_start.asc())
+    )
+    if not auth.is_admin:
+        query = query.where(ScheduledRecording.requested_by_user_id == auth.user_id)
+    result = await session.execute(query)
+    return [r.to_dict() for r in result.scalars().all()]
 
 
 @router.get("")

--- a/backend/tests/test_upcoming_recordings_endpoint.py
+++ b/backend/tests/test_upcoming_recordings_endpoint.py
@@ -1,0 +1,151 @@
+"""
+Tests for GET /api/downloads/upcoming.
+
+Returns a list of ScheduledRecording rows with status SCHEDULED or
+PAUSED_LOW_SPACE, ordered by program_start ascending.
+
+A non-admin user sees only their own scheduled recordings.
+"""
+import asyncio
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import ScheduledStatus
+
+
+def _make_recording(rec_id, title, channel, program_start, status="scheduled", user_id=1):
+    rec = MagicMock()
+    rec.id = rec_id
+    rec.program_title = title
+    rec.channel_name = channel
+    rec.program_start = program_start
+    rec.program_end = program_start
+    rec.stop_timestamp = None
+    rec.post_padding_minutes = 0
+    rec.status = status
+    rec.to_dict.return_value = {
+        "id": rec_id,
+        "program_title": title,
+        "channel_name": channel,
+        "program_start": program_start.isoformat(),
+        "status": status,
+        "requested_by_user_id": user_id,
+    }
+    return rec
+
+
+class UpcomingRecordingsTests(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_admin_auth(self):
+        auth = MagicMock()
+        auth.is_admin = True
+        auth.user_id = 1
+        return auth
+
+    def _make_user_auth(self, user_id=2):
+        auth = MagicMock()
+        auth.is_admin = False
+        auth.user_id = user_id
+        return auth
+
+    def _make_session(self, recordings):
+        scalars_result = MagicMock()
+        scalars_result.all = MagicMock(return_value=recordings)
+        execute_result = MagicMock()
+        execute_result.scalars = MagicMock(return_value=scalars_result)
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=execute_result)
+        return session
+
+    def _capture_session(self, recordings=None):
+        captured = {}
+        recordings = recordings or []
+        scalars_result = MagicMock()
+        scalars_result.all = MagicMock(return_value=recordings)
+        execute_result = MagicMock()
+        execute_result.scalars = MagicMock(return_value=scalars_result)
+
+        async def capture_execute(query, *args, **kwargs):
+            captured["stmt"] = query
+            return execute_result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        return session, captured
+
+    def test_returns_list_for_admin(self):
+        from api.downloads import get_upcoming_recordings
+        t1 = datetime(2026, 6, 10, 20, 0)
+        t2 = datetime(2026, 6, 11, 21, 0)
+        recs = [
+            _make_recording(1, "Show A", "Channel 1", t1),
+            _make_recording(2, "Show B", "Channel 2", t2),
+        ]
+        session = self._make_session(recs)
+        auth = self._make_admin_auth()
+        result = self._run(get_upcoming_recordings(auth=auth, session=session))
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["program_title"], "Show A")
+        self.assertEqual(result[1]["program_title"], "Show B")
+
+    def test_returns_empty_list_when_none_scheduled(self):
+        from api.downloads import get_upcoming_recordings
+        session = self._make_session([])
+        auth = self._make_admin_auth()
+        result = self._run(get_upcoming_recordings(auth=auth, session=session))
+        self.assertEqual(result, [])
+
+    def test_query_filters_scheduled_and_paused_low_space(self):
+        from api.downloads import get_upcoming_recordings
+        session, captured = self._capture_session()
+        auth = self._make_admin_auth()
+        self._run(get_upcoming_recordings(auth=auth, session=session))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn(f"'{ScheduledStatus.SCHEDULED.value}'", compiled)
+        self.assertIn(f"'{ScheduledStatus.PAUSED_LOW_SPACE.value}'", compiled)
+
+    def test_query_orders_by_program_start_ascending(self):
+        from api.downloads import get_upcoming_recordings
+        session, captured = self._capture_session()
+        auth = self._make_admin_auth()
+        self._run(get_upcoming_recordings(auth=auth, session=session))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn("program_start", compiled.lower())
+        self.assertIn("ASC", compiled)
+
+    def test_non_admin_scoped_to_user(self):
+        from api.downloads import get_upcoming_recordings
+        session, captured = self._capture_session()
+        auth = self._make_user_auth(user_id=42)
+        self._run(get_upcoming_recordings(auth=auth, session=session))
+        stmt = captured.get("stmt")
+        self.assertIsNotNone(stmt)
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        self.assertIn("42", compiled, "user_id filter must appear for non-admin")
+
+    def test_paused_low_space_recording_included(self):
+        from api.downloads import get_upcoming_recordings
+        t = datetime(2026, 6, 12, 9, 0)
+        recs = [_make_recording(3, "Paused Show", "Channel 3", t, status="paused_low_space")]
+        session = self._make_session(recs)
+        auth = self._make_admin_auth()
+        result = self._run(get_upcoming_recordings(auth=auth, session=session))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["status"], "paused_low_space")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -128,6 +128,7 @@ export const downloadsApi = {
   previewFilename: (data) => request('/downloads/preview-filename', { method: 'POST', body: data }),
   diskSpace: () => request('/downloads/disk-space'),
   clearFinished: () => request('/downloads/finished', { method: 'DELETE' }),
+  upcoming: () => request('/downloads/upcoming'),
   failedCount: (since) => {
     const params = since != null ? `?since=${since}` : ''
     return request(`/downloads/failed-count${params}`)

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -35,6 +35,7 @@ import {
   IconChevronDown,
   IconChevronUp,
   IconDatabase,
+  IconCalendar,
 } from '@tabler/icons-react'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
@@ -363,6 +364,12 @@ export default function Downloads() {
     refetchInterval: 30000,
   })
 
+  const { data: upcomingRecordings } = useQuery({
+    queryKey: ['downloads', 'upcoming'],
+    queryFn: downloadsApi.upcoming,
+    refetchInterval: 30000,
+  })
+
   useEffect(() => {
     localStorage.setItem('mustarrd_downloads_visited', String(Date.now()))
     queryClient.invalidateQueries({ queryKey: ['downloads', 'failed-count'] })
@@ -566,6 +573,9 @@ export default function Downloads() {
           <Tabs.Tab value="active" leftSection={<IconDownload size={16} />}>
             Active {activeDownloads.length > 0 && `(${activeDownloads.length})`}
           </Tabs.Tab>
+          <Tabs.Tab value="upcoming" leftSection={<IconCalendar size={16} />}>
+            Upcoming {upcomingRecordings?.length > 0 && `(${upcomingRecordings.length})`}
+          </Tabs.Tab>
           <Tabs.Tab value="history" leftSection={<IconClock size={16} />}>
             History {historyDownloads.length > 0 && `(${historyDownloads.length})`}
           </Tabs.Tab>
@@ -602,6 +612,48 @@ export default function Downloads() {
                   onPlayFile={handlePlayFile}
                   guideOffsetHours={accountGuideOffsets[Number(download.account_id)] || 0}
                 />
+              ))}
+            </Stack>
+          )}
+        </Tabs.Panel>
+
+        <Tabs.Panel value="upcoming" pt="md">
+          {!upcomingRecordings || upcomingRecordings.length === 0 ? (
+            <Card shadow="sm" padding="xl" radius="md" withBorder>
+              <Stack align="center" gap="md">
+                <IconCalendar size={48} opacity={0.3} />
+                <Text c="dimmed" ta="center">
+                  No upcoming recordings.
+                </Text>
+                <Text c="dimmed" ta="center" size="sm">
+                  Schedule a show from the Browse page and it will appear here.
+                </Text>
+              </Stack>
+            </Card>
+          ) : (
+            <Stack gap="sm">
+              {upcomingRecordings.map((rec) => (
+                <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
+                  <Group justify="space-between" wrap="nowrap">
+                    <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
+                      <Text fw={500} truncate>{rec.program_title}</Text>
+                      <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
+                      <Group gap="xs">
+                        <Text size="xs" c="dimmed">
+                          {rec.program_start
+                            ? dayjs(rec.program_start).format('ddd MMM D, YYYY h:mm A')
+                            : 'Unknown time'}
+                        </Text>
+                        <Text size="xs" c="dimmed">({formatDuration(rec.duration_minutes)})</Text>
+                      </Group>
+                    </Stack>
+                    {rec.status === 'paused_low_space' && (
+                      <Badge color="orange" variant="light" size="sm">
+                        Low disk space
+                      </Badge>
+                    )}
+                  </Group>
+                </Card>
               ))}
             </Stack>
           )}

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -640,9 +640,7 @@ export default function Downloads() {
                       <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
                       <Group gap="xs">
                         <Text size="xs" c="dimmed">
-                          {rec.program_start
-                            ? dayjs(rec.program_start).format('ddd MMM D, YYYY h:mm A')
-                            : 'Unknown time'}
+                          {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}
                         </Text>
                         <Text size="xs" c="dimmed">({formatDuration(rec.duration_minutes)})</Text>
                       </Group>


### PR DESCRIPTION
## What changed

The Downloads page now has an **Upcoming** tab showing scheduled recordings sorted by air date. Before this, an operator who set up a schedule had no way to confirm it would fire without going to a separate Schedules page. Silence looked the same as broken.

## What a user sees

A new **Upcoming** tab appears between Active and History. It lists each scheduled recording with show name, channel, air date/time, and duration. Recordings paused because of low disk space show an orange **Low Disk Space** badge so the operator knows why they are not queued yet.

The tab count badge (e.g. **Upcoming (3)**) gives instant visual confirmation that schedules are set without clicking into the tab.

## How it works

- New `GET /api/downloads/upcoming` endpoint: queries `ScheduledRecording` rows with status `scheduled` or `paused_low_space`, ordered by `program_start` ascending. Non-admin users see only their own schedules.
- `downloadsApi.upcoming()` added to `api.js`.
- New `Upcoming` tab panel in `Downloads.jsx`; polls every 30 seconds alongside disk space.
- 6 regression tests added. 302/302 tests pass.

## Before

Downloads page: Active and History tabs only. No signal that schedules exist.

## After

Downloads page: Active, Upcoming (3), History tabs. Each row shows show name, channel, scheduled time, and duration. Low disk space recordings are badged.

## Testing

302 backend tests pass. Screenshots captured at desktop (1280x800) and mobile (390x844) with real seeded scheduled_recording rows including one paused_low_space entry.