### PR TITLE
docs: add changelog entries for PRs #102 and #105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Fixed: Downloads no longer fail when a stream or video ID contains special characters
+
+**What you would notice:** Some IPTV providers assign stream IDs, on-demand video IDs, or series episode IDs that include characters like `/`, `#`, or `?`. Before this fix, those characters would corrupt the download URL, and every attempt to record from those channels would fail immediately with no clear reason. The content appeared available in your guide, but the download never started or returned a confusing error. This is now fixed for all four Xtream download URL types (live streams, timeshift, on-demand video, and series episodes).
+
+**What changed:** Stream IDs, video IDs, and episode IDs are now encoded before being placed in the download URL, the same way your username and password were already encoded by an earlier fix.
+
+---
+
+### Fixed: Recording padding is now capped at 120 minutes for manual downloads
+
+**What you would notice:** When starting a manual download with a very large pre-padding or post-padding value, Mustarrd would build a download window spanning days or longer and send it to your provider. The provider would usually return a confusing error or deliver garbage content with no clear explanation. Manual downloads now enforce the same 120-minute maximum padding that scheduled recordings already had.
+
+**What changed:** The manual download request handler now rejects padding values above 120 minutes, matching the limit already in place for scheduled recordings.
+
+---
+
 ### Improved: Red badge on the Downloads menu item shows how many recordings have failed
 
 **What you would notice:** Before this change, there was no way to know a recording had failed without manually opening the Downloads page. You might not notice a failed recording for days. A small red badge now appears on the Downloads item in the sidebar as soon as a recording permanently fails. The badge shows the number of failures since you last visited Downloads. Opening the Downloads page clears the badge. The existing yellow badge that shows how many downloads are currently in progress continues to work alongside it.


### PR DESCRIPTION
## Summary

- PR #102: Downloads that failed when a stream, VOD, or episode ID contained `/`, `#`, or `?` are now fixed. All four Xtream path builders now encode the ID segment before building the URL.
- PR #105: Manual download requests with very large padding values (e.g. 99999 minutes) would build multi-day download windows and cause confusing provider errors. Manual downloads now cap padding at 120 minutes, matching scheduled recordings.

## What a user would notice

Before: Downloads would silently fail for channels whose provider-assigned IDs contained special characters, with no useful error message. Also, entering an unreasonably large padding value for a manual download would produce a cryptic failure.

After: Both issues are resolved. The CHANGELOG now explains each fix in plain language.

## What changed

`CHANGELOG.md` only. Two new entries added under 2026-06-07, above the existing entries for that date. No code changed.

## Test plan

- [x] Read both changelog entries aloud to verify they are clear to a non-technical user
- [x] Confirmed no em dashes in the new text
- [x] Diff is CHANGELOG.md only