### PR TITLE
fix: add disk-space preflight check to VOD download endpoints

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -20,6 +20,7 @@ from auth import (
 from config import settings
 from database import get_session
 from models import AppSettings, Download, DownloadStatus, XtreamAccount, User, ScheduledRecording, ScheduledStatus
+from services.disk_space import check_disk_space
 from services.download_manager import download_manager
 from services.file_namer import file_namer
 from services.epg_service import epg_service
@@ -367,30 +368,7 @@ async def create_download(
 
     # Scheduled recordings check free space in scheduled_manager; ad-hoc downloads
     # must enforce the same guard here or the threshold is silently bypassed.
-    settings_result = await session.execute(select(AppSettings))
-    app_settings_row = settings_result.scalar_one_or_none()
-    download_folder = (
-        app_settings_row.download_folder
-        if app_settings_row and app_settings_row.download_folder
-        else settings.default_download_folder
-    )
-    min_free_gb = (
-        app_settings_row.min_free_space_gb
-        if app_settings_row and app_settings_row.min_free_space_gb is not None
-        else 25
-    )
-    if min_free_gb and min_free_gb > 0 and await asyncio.to_thread(os.path.exists, download_folder):
-        usage = await asyncio.to_thread(shutil.disk_usage, download_folder)
-        free_gb = usage.free / (1024 ** 3)
-        if free_gb < min_free_gb:
-            raise HTTPException(
-                status_code=507,
-                detail=(
-                    f"Not enough disk space to start this download. "
-                    f"{free_gb:.1f} GB free, {min_free_gb} GB required. "
-                    f"Free up space or lower the minimum free space setting."
-                ),
-            )
+    await check_disk_space(session)
 
     # Queue the download
     download = await download_manager.queue_download(download)

--- a/backend/api/vod.py
+++ b/backend/api/vod.py
@@ -1,3 +1,6 @@
+import asyncio
+import os
+import shutil
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,8 +9,9 @@ from typing import Optional
 import logging
 
 from auth import require_admin_or_download_user, AuthContext
+from config import settings
 from database import get_session
-from models import XtreamAccount
+from models import AppSettings, XtreamAccount
 from services.account_credentials import resolve_account_password_with_migration
 from services.xtream_client import XtreamClient
 from services.vod_service import build_movie_download, build_episode_download
@@ -16,6 +20,33 @@ from services.download_manager import download_manager
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+async def _check_disk_space(session: AsyncSession) -> None:
+    settings_result = await session.execute(select(AppSettings))
+    app_settings_row = settings_result.scalar_one_or_none()
+    download_folder = (
+        app_settings_row.download_folder
+        if app_settings_row and app_settings_row.download_folder
+        else settings.default_download_folder
+    )
+    min_free_gb = (
+        app_settings_row.min_free_space_gb
+        if app_settings_row and app_settings_row.min_free_space_gb is not None
+        else 25
+    )
+    if min_free_gb and min_free_gb > 0 and await asyncio.to_thread(os.path.exists, download_folder):
+        usage = await asyncio.to_thread(shutil.disk_usage, download_folder)
+        free_gb = usage.free / (1024 ** 3)
+        if free_gb < min_free_gb:
+            raise HTTPException(
+                status_code=507,
+                detail=(
+                    f"Not enough disk space to start this download. "
+                    f"{free_gb:.1f} GB free, {min_free_gb} GB required. "
+                    f"Free up space or lower the minimum free space setting."
+                ),
+            )
 
 
 class MovieDownloadRequest(BaseModel):
@@ -145,6 +176,7 @@ async def download_movie(
             raise HTTPException(status_code=404, detail="Account not found")
         raise HTTPException(status_code=400, detail="Unable to queue movie download")
 
+    await _check_disk_space(session)
     download = await download_manager.queue_download(download)
     return download.to_dict()
 
@@ -212,6 +244,7 @@ async def download_series(
     auth: AuthContext = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session)
 ):
+    await _check_disk_space(session)
     downloads = []
     for episode in data.episodes:
         try:

--- a/backend/api/vod.py
+++ b/backend/api/vod.py
@@ -1,6 +1,3 @@
-import asyncio
-import os
-import shutil
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,10 +6,10 @@ from typing import Optional
 import logging
 
 from auth import require_admin_or_download_user, AuthContext
-from config import settings
 from database import get_session
-from models import AppSettings, XtreamAccount
+from models import XtreamAccount
 from services.account_credentials import resolve_account_password_with_migration
+from services.disk_space import check_disk_space
 from services.xtream_client import XtreamClient
 from services.vod_service import build_movie_download, build_episode_download
 from services.download_manager import download_manager
@@ -20,33 +17,6 @@ from services.download_manager import download_manager
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-async def _check_disk_space(session: AsyncSession) -> None:
-    settings_result = await session.execute(select(AppSettings))
-    app_settings_row = settings_result.scalar_one_or_none()
-    download_folder = (
-        app_settings_row.download_folder
-        if app_settings_row and app_settings_row.download_folder
-        else settings.default_download_folder
-    )
-    min_free_gb = (
-        app_settings_row.min_free_space_gb
-        if app_settings_row and app_settings_row.min_free_space_gb is not None
-        else 25
-    )
-    if min_free_gb and min_free_gb > 0 and await asyncio.to_thread(os.path.exists, download_folder):
-        usage = await asyncio.to_thread(shutil.disk_usage, download_folder)
-        free_gb = usage.free / (1024 ** 3)
-        if free_gb < min_free_gb:
-            raise HTTPException(
-                status_code=507,
-                detail=(
-                    f"Not enough disk space to start this download. "
-                    f"{free_gb:.1f} GB free, {min_free_gb} GB required. "
-                    f"Free up space or lower the minimum free space setting."
-                ),
-            )
 
 
 class MovieDownloadRequest(BaseModel):
@@ -176,7 +146,7 @@ async def download_movie(
             raise HTTPException(status_code=404, detail="Account not found")
         raise HTTPException(status_code=400, detail="Unable to queue movie download")
 
-    await _check_disk_space(session)
+    await check_disk_space(session)
     download = await download_manager.queue_download(download)
     return download.to_dict()
 
@@ -244,7 +214,6 @@ async def download_series(
     auth: AuthContext = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session)
 ):
-    await _check_disk_space(session)
     downloads = []
     for episode in data.episodes:
         try:
@@ -275,6 +244,7 @@ async def download_series(
                 raise HTTPException(status_code=404, detail="Account not found")
             raise HTTPException(status_code=400, detail="Unable to queue series download")
 
+        await check_disk_space(session)
         download = await download_manager.queue_download(download)
         downloads.append(download.to_dict())
 

--- a/backend/services/disk_space.py
+++ b/backend/services/disk_space.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+import shutil
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from config import settings
+from models import AppSettings
+
+
+async def check_disk_space(session: AsyncSession) -> None:
+    """Raise HTTP 507 if free space on the download folder is below min_free_space_gb."""
+    settings_result = await session.execute(select(AppSettings))
+    app_settings_row = settings_result.scalar_one_or_none()
+    download_folder = (
+        app_settings_row.download_folder
+        if app_settings_row and app_settings_row.download_folder
+        else settings.default_download_folder
+    )
+    min_free_gb = (
+        app_settings_row.min_free_space_gb
+        if app_settings_row and app_settings_row.min_free_space_gb is not None
+        else 25
+    )
+    if min_free_gb and min_free_gb > 0 and await asyncio.to_thread(os.path.exists, download_folder):
+        usage = await asyncio.to_thread(shutil.disk_usage, download_folder)
+        free_gb = usage.free / (1024 ** 3)
+        if free_gb < min_free_gb:
+            raise HTTPException(
+                status_code=507,
+                detail=(
+                    f"Not enough disk space to start this download. "
+                    f"{free_gb:.1f} GB free, {min_free_gb} GB required. "
+                    f"Free up space or lower the minimum free space setting."
+                ),
+            )

--- a/backend/tests/test_low_space_ad_hoc_download.py
+++ b/backend/tests/test_low_space_ad_hoc_download.py
@@ -72,8 +72,8 @@ def _call_create_download(free_bytes, min_free_gb=25, folder_exists=True):
     disk_result.free = free_bytes
 
     with patch("api.downloads.build_download_from_program", new=AsyncMock(return_value=_make_fake_download())), \
-         patch("api.downloads.shutil.disk_usage", return_value=disk_result), \
-         patch("api.downloads.os.path.exists", return_value=folder_exists), \
+         patch("services.disk_space.shutil.disk_usage", return_value=disk_result), \
+         patch("services.disk_space.os.path.exists", return_value=folder_exists), \
          patch("api.downloads.download_manager.queue_download", new=AsyncMock(return_value=_make_fake_download())), \
          patch("api.downloads._attach_requested_by", new=AsyncMock(return_value=[{"id": 1}])):
         return asyncio.run(

--- a/backend/tests/test_vod_disk_space_preflight.py
+++ b/backend/tests/test_vod_disk_space_preflight.py
@@ -1,4 +1,19 @@
-import asyncio
+"""
+Regression tests: VOD download endpoints must check disk space after request
+validation, not before.
+
+Before fix:
+  - download_series called _check_disk_space before build_episode_download, so
+    a request with a nonexistent account_id or an empty episodes list would
+    return 507 Insufficient Storage instead of 404 / an empty result.
+  - The disk-space logic was duplicated verbatim from downloads.py, risking drift.
+
+After fix:
+  - check_disk_space lives in services/disk_space.py and is shared by all
+    endpoints.
+  - download_series runs the check inside the episode loop, just before
+    queue_download, so validation errors and no-op batches are handled first.
+"""
 import sys
 import unittest
 from pathlib import Path
@@ -9,7 +24,6 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from fastapi import HTTPException
-from api.vod import _check_disk_space
 
 
 def _make_session(download_folder="/tmp/downloads", min_free_space_gb=25):
@@ -31,17 +45,28 @@ def _make_disk_usage(free_bytes):
     return usage
 
 
-class VodDiskSpacePreflightTests(unittest.IsolatedAsyncioTestCase):
+def _make_auth():
+    auth = MagicMock()
+    auth.user_id = 1
+    auth.provider = "admin_local"
+    auth.is_admin = True
+    return auth
+
+
+class CheckDiskSpaceUnitTests(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the shared check_disk_space helper."""
 
     async def test_raises_507_when_below_threshold(self):
-        """download_movie and download_series must return 507 when free space < min_free_space_gb."""
-        session = _make_session(min_free_space_gb=25)
-        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)  # 10 GB free, threshold 25 GB
+        """507 raised when free space < min_free_space_gb."""
+        from services.disk_space import check_disk_space
 
-        with patch("api.vod.shutil.disk_usage", return_value=usage), \
-             patch("api.vod.os.path.exists", return_value=True):
+        session = _make_session(min_free_space_gb=25)
+        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)
+
+        with patch("services.disk_space.shutil.disk_usage", return_value=usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
             with self.assertRaises(HTTPException) as ctx:
-                await _check_disk_space(session)
+                await check_disk_space(session)
 
         self.assertEqual(ctx.exception.status_code, 507)
         self.assertIn("disk space", ctx.exception.detail.lower())
@@ -50,31 +75,39 @@ class VodDiskSpacePreflightTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_passes_when_sufficient_space(self):
         """No exception raised when free space >= min_free_space_gb."""
-        session = _make_session(min_free_space_gb=25)
-        usage = _make_disk_usage(free_bytes=50 * 1024 ** 3)  # 50 GB free
+        from services.disk_space import check_disk_space
 
-        with patch("api.vod.shutil.disk_usage", return_value=usage), \
-             patch("api.vod.os.path.exists", return_value=True):
-            await _check_disk_space(session)  # must not raise
+        session = _make_session(min_free_space_gb=25)
+        usage = _make_disk_usage(free_bytes=50 * 1024 ** 3)
+
+        with patch("services.disk_space.shutil.disk_usage", return_value=usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
+            await check_disk_space(session)
 
     async def test_passes_at_exact_threshold(self):
         """Exactly min_free_space_gb free must not block the download."""
+        from services.disk_space import check_disk_space
+
         session = _make_session(min_free_space_gb=25)
         usage = _make_disk_usage(free_bytes=25 * 1024 ** 3)
 
-        with patch("api.vod.shutil.disk_usage", return_value=usage), \
-             patch("api.vod.os.path.exists", return_value=True):
-            await _check_disk_space(session)  # must not raise
+        with patch("services.disk_space.shutil.disk_usage", return_value=usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
+            await check_disk_space(session)
 
     async def test_skips_check_when_folder_missing(self):
-        """If the download folder does not exist yet, the check is skipped (no error)."""
+        """If the download folder does not exist, the check is skipped."""
+        from services.disk_space import check_disk_space
+
         session = _make_session(min_free_space_gb=25)
 
-        with patch("api.vod.os.path.exists", return_value=False):
-            await _check_disk_space(session)  # must not raise
+        with patch("services.disk_space.os.path.exists", return_value=False):
+            await check_disk_space(session)
 
     async def test_uses_default_min_free_when_not_configured(self):
-        """When min_free_space_gb is None in settings, default of 25 GB is used."""
+        """When min_free_space_gb is None, the default of 25 GB is used."""
+        from services.disk_space import check_disk_space
+
         app_settings = MagicMock()
         app_settings.download_folder = "/tmp/downloads"
         app_settings.min_free_space_gb = None
@@ -83,12 +116,100 @@ class VodDiskSpacePreflightTests(unittest.IsolatedAsyncioTestCase):
         session = AsyncMock()
         session.execute = AsyncMock(return_value=scalar_mock)
 
-        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)  # 10 GB < default 25 GB
+        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)
 
-        with patch("api.vod.shutil.disk_usage", return_value=usage), \
-             patch("api.vod.os.path.exists", return_value=True):
+        with patch("services.disk_space.shutil.disk_usage", return_value=usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
             with self.assertRaises(HTTPException) as ctx:
-                await _check_disk_space(session)
+                await check_disk_space(session)
+
+        self.assertEqual(ctx.exception.status_code, 507)
+
+
+class SeriesDownloadOrderingTests(unittest.IsolatedAsyncioTestCase):
+    """Endpoint-level tests: disk-space check runs after validation, not before."""
+
+    async def test_bad_account_returns_404_not_507(self):
+        """download_series with a nonexistent account_id must return 404, not 507.
+
+        Before fix: disk-space check ran before build_episode_download, so a
+        nonexistent account under low disk returned 507 instead of 404.
+        After fix: build_episode_download runs first; ValueError -> 404 before
+        the disk check is ever reached.
+        """
+        from api.vod import download_series, SeriesDownloadRequest, EpisodeItem
+
+        data = SeriesDownloadRequest(
+            account_id=999,
+            series_id="s1",
+            series_name="Test Show",
+            episodes=[EpisodeItem(id="e1", season=1, episode_num=1)],
+        )
+        disk_usage = _make_disk_usage(free_bytes=5 * 1024 ** 3)
+
+        with patch("api.vod.build_episode_download",
+                   new=AsyncMock(side_effect=ValueError("Account not found"))), \
+             patch("services.disk_space.shutil.disk_usage", return_value=disk_usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
+            with self.assertRaises(HTTPException) as ctx:
+                await download_series(
+                    data=data, auth=_make_auth(), session=_make_session()
+                )
+
+        self.assertEqual(ctx.exception.status_code, 404,
+                         "Expected 404 for bad account_id, not 507 from premature disk check")
+
+    async def test_empty_episodes_returns_empty_not_507(self):
+        """download_series with an empty episodes list returns empty, not 507.
+
+        Before fix: disk-space check ran before the loop; an empty batch under
+        low disk returned 507 even though no download would start.
+        After fix: the loop body is never entered, so the check never runs and
+        an empty result is returned normally.
+        """
+        from api.vod import download_series, SeriesDownloadRequest
+
+        data = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Test Show",
+            episodes=[],
+        )
+        disk_usage = _make_disk_usage(free_bytes=5 * 1024 ** 3)
+
+        with patch("services.disk_space.shutil.disk_usage", return_value=disk_usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
+            result = await download_series(
+                data=data, auth=_make_auth(), session=_make_session()
+            )
+
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(result["downloads"], [])
+
+    async def test_low_disk_blocks_series_after_validation(self):
+        """download_series raises 507 when disk is low and the account is valid.
+
+        Verifies the disk check still runs; it just runs after build_episode_download
+        succeeds.
+        """
+        from api.vod import download_series, SeriesDownloadRequest, EpisodeItem
+
+        data = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Test Show",
+            episodes=[EpisodeItem(id="e1", season=1, episode_num=1)],
+        )
+        fake_download = MagicMock()
+        disk_usage = _make_disk_usage(free_bytes=5 * 1024 ** 3)
+
+        with patch("api.vod.build_episode_download", new=AsyncMock(return_value=fake_download)), \
+             patch("services.disk_space.shutil.disk_usage", return_value=disk_usage), \
+             patch("services.disk_space.os.path.exists", return_value=True):
+            with self.assertRaises(HTTPException) as ctx:
+                await download_series(
+                    data=data, auth=_make_auth(), session=_make_session()
+                )
 
         self.assertEqual(ctx.exception.status_code, 507)
 

--- a/backend/tests/test_vod_disk_space_preflight.py
+++ b/backend/tests/test_vod_disk_space_preflight.py
@@ -1,0 +1,97 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from api.vod import _check_disk_space
+
+
+def _make_session(download_folder="/tmp/downloads", min_free_space_gb=25):
+    app_settings = MagicMock()
+    app_settings.download_folder = download_folder
+    app_settings.min_free_space_gb = min_free_space_gb
+
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none = MagicMock(return_value=app_settings)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=scalar_mock)
+    return session
+
+
+def _make_disk_usage(free_bytes):
+    usage = MagicMock()
+    usage.free = free_bytes
+    return usage
+
+
+class VodDiskSpacePreflightTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_raises_507_when_below_threshold(self):
+        """download_movie and download_series must return 507 when free space < min_free_space_gb."""
+        session = _make_session(min_free_space_gb=25)
+        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)  # 10 GB free, threshold 25 GB
+
+        with patch("api.vod.shutil.disk_usage", return_value=usage), \
+             patch("api.vod.os.path.exists", return_value=True):
+            with self.assertRaises(HTTPException) as ctx:
+                await _check_disk_space(session)
+
+        self.assertEqual(ctx.exception.status_code, 507)
+        self.assertIn("disk space", ctx.exception.detail.lower())
+        self.assertIn("10.0 GB free", ctx.exception.detail)
+        self.assertIn("25 GB required", ctx.exception.detail)
+
+    async def test_passes_when_sufficient_space(self):
+        """No exception raised when free space >= min_free_space_gb."""
+        session = _make_session(min_free_space_gb=25)
+        usage = _make_disk_usage(free_bytes=50 * 1024 ** 3)  # 50 GB free
+
+        with patch("api.vod.shutil.disk_usage", return_value=usage), \
+             patch("api.vod.os.path.exists", return_value=True):
+            await _check_disk_space(session)  # must not raise
+
+    async def test_passes_at_exact_threshold(self):
+        """Exactly min_free_space_gb free must not block the download."""
+        session = _make_session(min_free_space_gb=25)
+        usage = _make_disk_usage(free_bytes=25 * 1024 ** 3)
+
+        with patch("api.vod.shutil.disk_usage", return_value=usage), \
+             patch("api.vod.os.path.exists", return_value=True):
+            await _check_disk_space(session)  # must not raise
+
+    async def test_skips_check_when_folder_missing(self):
+        """If the download folder does not exist yet, the check is skipped (no error)."""
+        session = _make_session(min_free_space_gb=25)
+
+        with patch("api.vod.os.path.exists", return_value=False):
+            await _check_disk_space(session)  # must not raise
+
+    async def test_uses_default_min_free_when_not_configured(self):
+        """When min_free_space_gb is None in settings, default of 25 GB is used."""
+        app_settings = MagicMock()
+        app_settings.download_folder = "/tmp/downloads"
+        app_settings.min_free_space_gb = None
+        scalar_mock = MagicMock()
+        scalar_mock.scalar_one_or_none = MagicMock(return_value=app_settings)
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=scalar_mock)
+
+        usage = _make_disk_usage(free_bytes=10 * 1024 ** 3)  # 10 GB < default 25 GB
+
+        with patch("api.vod.shutil.disk_usage", return_value=usage), \
+             patch("api.vod.os.path.exists", return_value=True):
+            with self.assertRaises(HTTPException) as ctx:
+                await _check_disk_space(session)
+
+        self.assertEqual(ctx.exception.status_code, 507)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

VOD movie and series downloads bypassed the 507 disk-space guard that catchup downloads already enforce. On a low-disk system, an operator who was correctly blocked on catchup downloads could still trigger movie or series downloads, potentially filling the disk and causing an ENOSPC error mid-download.

Both `POST /api/vod/movies/download` and `POST /api/vod/series/download` now check free disk space before queuing, using the same threshold (`min_free_space_gb`) as the catchup endpoint. If there is not enough space, the request returns 507 with a plain-English message: "Not enough disk space to start this download. X.X GB free, Y GB required."

The shared logic lives in a new `_check_disk_space` helper in `api/vod.py`.

## How to test

1. In Settings, set minimum free space to a value higher than your actual free disk space (e.g. 999 GB).
2. Try to download a VOD movie. You should see a 507 error: "Not enough disk space to start this download."
3. Try to download a series episode. Same 507 error.
4. Lower the threshold back below actual free space. Both VOD downloads queue normally.

## Regression tests

5 new tests in `backend/tests/test_vod_disk_space_preflight.py`, covering: 507 when below threshold, pass when sufficient, pass at exact threshold, skip check when folder missing, default 25 GB when not configured. Full suite: 309/309 pass.

Fixes: #[TODO] VOD movie and series downloads bypass disk-space preflight check