### PR TITLE
docs: add changelog entries for PRs #106 and #107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Settings now rejects invalid values and explains what is accepted
+
+**What you would notice:** Before this change, if you typed an unsupported format like "avi" into the Transcode Format field or left Minimum Free Space set to 0, Mustarrd would save the value silently and every transcoded download would fail with a confusing FFmpeg error, or the disk-space guard would be disabled entirely with no warning. Settings now shows a clear error immediately when a value is not accepted. If your saved configuration already has 0 in the Minimum Free Space field (possible on older installs), Mustarrd now silently corrects it to 25 GB so you can open and save Settings without hitting an error.
+
+**What changed:** The Transcode Format and Hardware Acceleration fields now only accept values Mustarrd supports. The Minimum Free Space field requires at least 1 GB. A legacy stored value of 0 is corrected to 25 GB automatically when you open Settings.
+
+---
+
+### Improved: Downloads page now has an Upcoming tab showing your scheduled recordings
+
+**What you would notice:** The Downloads page now has three tabs: Active, Upcoming, and History. The new Upcoming tab lists every recording that is scheduled to download automatically, sorted by when the program airs. Each row shows the show name, channel, air time, and duration. If a recording is paused because your drive is running low on space, it shows an orange badge explaining why. A count badge on the tab heading (for example "Upcoming (3)") shows how many recordings are queued without requiring you to click in.
+
+**What changed:** A new Upcoming tab was added to the Downloads page between the Active and History tabs. A new backend endpoint returns the list of upcoming scheduled recordings.
+
+---
+
 ### Fixed: Downloads no longer fail when a stream or video ID contains special characters
 
 **What you would notice:** Some IPTV providers assign stream IDs, on-demand video IDs, or series episode IDs that include characters like `/`, `#`, or `?`. Before this fix, those characters would corrupt the download URL, and every attempt to record from those channels would fail immediately with no clear reason. The content appeared available in your guide, but the download never started or returned a confusing error. This is now fixed for all four Xtream download URL types (live streams, timeshift, on-demand video, and series episodes).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Then open **http://localhost:4177** in your browser.
 ### Monitor Downloads
 
 - Go to the **Downloads** page to see active downloads with progress bars
+- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show an orange badge explaining why
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - Failed downloads can be retried from the same page


### PR DESCRIPTION
## What this does

Adds changelog entries for two recently merged PRs that had no documentation yet, and updates the README Monitor Downloads section.

**PR #106 (settings validation):** Settings now rejects invalid `transcode_format`, `hw_accel`, and `min_free_space_gb` values with a clear error instead of silently accepting them and breaking downloads. Legacy stored `min_free_space_gb=0` is coerced to 25 on read.

**PR #107 (Upcoming tab):** The Downloads page now has an Upcoming tab between Active and History, listing scheduled recordings by air date with a count badge and low-disk-space indicators.

**README:** Added a bullet under Monitor Downloads explaining the new Upcoming tab.

## How it was tested

Entries verified against the merged commits (2779b01 for #106, ff14560 for #107). No code changed.