### PR TITLE
[Design] Show specific failure reason under Unreachable badge on Accounts page

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -96,6 +96,9 @@ async def _apply_lightweight_migrations(conn) -> None:
     if not await _column_exists(conn, "xtream_accounts", "last_connection_checked_at"):
         await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN last_connection_checked_at DATETIME"))
 
+    if not await _column_exists(conn, "xtream_accounts", "last_connection_error"):
+        await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN last_connection_error TEXT"))
+
 
 async def _migrate_legacy_account_passwords() -> None:
     from models import XtreamAccount

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -27,6 +27,7 @@ class XtreamAccount(Base):
     catchup_fallback_offset_minutes: Mapped[int] = mapped_column(Integer, default=0)
     last_connection_ok: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     last_connection_checked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_connection_error: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     def to_dict(self):
         return {
@@ -44,4 +45,5 @@ class XtreamAccount(Base):
             "guide_offset_hours": int(self.guide_offset_hours or 0),
             "last_connection_ok": self.last_connection_ok,
             "last_connection_checked_at": self.last_connection_checked_at.isoformat() + "Z" if self.last_connection_checked_at else None,
+            "last_connection_error": self.last_connection_error,
         }

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -22,6 +22,25 @@ from services.log_stream import backend_log_stream
 logger = logging.getLogger(__name__)
 
 
+def _friendly_connection_error(e: Exception) -> str:
+    """Translate a connection exception into a short, user-readable string."""
+    import aiohttp
+    msg = str(e)
+    if isinstance(e, asyncio.TimeoutError):
+        return "Connection timed out."
+    if isinstance(e, aiohttp.ClientConnectorError):
+        return "Cannot reach provider. Check the server URL."
+    if isinstance(e, aiohttp.ClientError):
+        return "Network error. Try again later."
+    if "Invalid credentials" in msg:
+        return "Invalid credentials. Check your username and password."
+    if "Authentication failed" in msg or "HTTP 401" in msg or "HTTP 403" in msg:
+        return "Provider rejected login. Check your username and password."
+    if "HTTP 5" in msg:
+        return "Provider server error. Try again later."
+    return msg or "Connection failed."
+
+
 class EPGIngestManager:
     def __init__(self):
         self._running = False
@@ -91,7 +110,7 @@ class EPGIngestManager:
             except Exception as exc:
                 self._status["last_error"] = str(exc)
                 await self._log(f"Account EPG refresh failed: {exc}", level="error", account=account)
-                await self._update_connection_status(account.id, ok=False)
+                await self._update_connection_status(account.id, ok=False, error=_friendly_connection_error(exc))
                 raise
             finally:
                 self._status.update({
@@ -143,7 +162,7 @@ class EPGIngestManager:
                 })
                 logger.exception("Error refreshing XMLTV for account %s", account.id)
                 await self._log(f"EPG refresh failed: {exc}", level="error", account=account)
-                await self._update_connection_status(account.id, ok=False)
+                await self._update_connection_status(account.id, ok=False, error=_friendly_connection_error(exc))
 
         self._status.update({
             "running": False,
@@ -345,7 +364,7 @@ class EPGIngestManager:
             account=account
         )
 
-    async def _update_connection_status(self, account_id: int, ok: bool) -> None:
+    async def _update_connection_status(self, account_id: int, ok: bool, error: str | None = None) -> None:
         try:
             async with async_session_maker() as session:
                 result = await session.execute(
@@ -355,6 +374,7 @@ class EPGIngestManager:
                 if account:
                     account.last_connection_ok = ok
                     account.last_connection_checked_at = datetime.now(timezone.utc)
+                    account.last_connection_error = error if not ok else None
                     await session.commit()
         except Exception:
             logger.exception("Failed to update connection status for account %s", account_id)

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -38,7 +38,9 @@ def _friendly_connection_error(e: Exception) -> str:
         return "Provider rejected login. Check your username and password."
     if "HTTP 5" in msg:
         return "Provider server error. Try again later."
-    return msg or "Connection failed."
+    # Truncate raw fallthrough so a stray library exception cannot store a wall of
+    # text or a URL-carrying error string in the card.
+    return (msg[:200] + "...") if len(msg) > 200 else (msg or "Connection failed.")
 
 
 class EPGIngestManager:

--- a/backend/tests/test_account_connection_status.py
+++ b/backend/tests/test_account_connection_status.py
@@ -40,6 +40,39 @@ class ConnectionStatusUpdateTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(db_account.last_connection_ok)
         self.assertIsNotNone(db_account.last_connection_checked_at)
 
+    async def test_failure_stores_error_message(self):
+        """_update_connection_status stores the error string when ok=False."""
+        manager = EPGIngestManager()
+        db_account = MagicMock()
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=db_account)))
+        session.commit = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.epg_ingest_manager.async_session_maker", return_value=session):
+            await manager._update_connection_status(account_id=1, ok=False, error="Invalid credentials. Check your username and password.")
+
+        self.assertEqual(db_account.last_connection_error, "Invalid credentials. Check your username and password.")
+
+    async def test_success_clears_error_message(self):
+        """_update_connection_status clears last_connection_error when ok=True."""
+        manager = EPGIngestManager()
+        db_account = MagicMock()
+        db_account.last_connection_error = "Previous error"
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=db_account)))
+        session.commit = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("services.epg_ingest_manager.async_session_maker", return_value=session):
+            await manager._update_connection_status(account_id=1, ok=True)
+
+        self.assertIsNone(db_account.last_connection_error)
+
     async def test_success_sets_last_connection_ok_true(self):
         """EPG refresh success writes last_connection_ok=True to the account."""
         manager = EPGIngestManager()
@@ -91,7 +124,11 @@ class ConnectionStatusUpdateTests(unittest.IsolatedAsyncioTestCase):
 
             await manager._refresh_all_accounts()
 
-        mock_status.assert_called_once_with(account.id, ok=False)
+        mock_status.assert_called_once()
+        call = mock_status.call_args
+        self.assertEqual(call.args[0], account.id)
+        self.assertFalse(call.kwargs["ok"])
+        self.assertIsNotNone(call.kwargs.get("error"))
 
 
 class AccountToDictTimestampTests(unittest.TestCase):

--- a/backend/tests/test_friendly_connection_error.py
+++ b/backend/tests/test_friendly_connection_error.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for _friendly_connection_error in epg_ingest_manager.
+
+Covers all 7 branches:
+  1. asyncio.TimeoutError
+  2. aiohttp.ClientConnectorError
+  3. aiohttp.ClientError (generic)
+  4. "Invalid credentials" in str(e)
+  5. "Authentication failed" / "HTTP 401" / "HTTP 403"
+  6. "HTTP 5..." in str(e)
+  7. Fallthrough (unrecognised message, including length cap)
+
+Ordering matters: isinstance checks run before substring checks, so
+ClientConnectorError (a subclass of ClientError) must be tested before
+the generic ClientError branch.
+"""
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+import aiohttp
+from services.epg_ingest_manager import _friendly_connection_error
+
+
+class FriendlyConnectionErrorTests(unittest.TestCase):
+
+    def test_timeout_error(self):
+        result = _friendly_connection_error(asyncio.TimeoutError())
+        self.assertIn("timed out", result.lower())
+
+    def test_client_connector_error(self):
+        # ClientConnectorError requires an os.strerror-compatible mock
+        exc = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=OSError("refused")
+        )
+        result = _friendly_connection_error(exc)
+        self.assertIn("reach", result.lower())
+
+    def test_generic_client_error(self):
+        exc = aiohttp.ClientError("something went wrong")
+        result = _friendly_connection_error(exc)
+        self.assertIn("network", result.lower())
+
+    def test_invalid_credentials_substring(self):
+        exc = Exception("Invalid credentials for account")
+        result = _friendly_connection_error(exc)
+        self.assertIn("credentials", result.lower())
+
+    def test_http_401(self):
+        exc = Exception("HTTP 401: Unauthorized")
+        result = _friendly_connection_error(exc)
+        self.assertIn("login", result.lower())
+
+    def test_http_403(self):
+        exc = Exception("HTTP 403: Forbidden")
+        result = _friendly_connection_error(exc)
+        self.assertIn("login", result.lower())
+
+    def test_http_500(self):
+        exc = Exception("HTTP 500: Internal Server Error")
+        result = _friendly_connection_error(exc)
+        self.assertIn("server error", result.lower())
+
+    def test_http_503(self):
+        exc = Exception("HTTP 503: Service Unavailable")
+        result = _friendly_connection_error(exc)
+        self.assertIn("server error", result.lower())
+
+    def test_fallthrough_short_message(self):
+        exc = Exception("some unrecognised error")
+        result = _friendly_connection_error(exc)
+        self.assertEqual(result, "some unrecognised error")
+
+    def test_fallthrough_empty_message(self):
+        exc = Exception("")
+        result = _friendly_connection_error(exc)
+        self.assertEqual(result, "Connection failed.")
+
+    def test_fallthrough_truncates_long_message(self):
+        long_msg = "x" * 300
+        exc = Exception(long_msg)
+        result = _friendly_connection_error(exc)
+        self.assertLessEqual(len(result), 210, "Long messages must be truncated")
+        self.assertTrue(result.endswith("..."))
+
+    def test_connector_error_before_generic_client_error(self):
+        """ClientConnectorError is a ClientError subclass: must hit the connector branch."""
+        exc = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=OSError("connection refused")
+        )
+        result = _friendly_connection_error(exc)
+        self.assertIn("reach", result.lower(),
+                      "ClientConnectorError must match the connector branch, not the generic one")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -210,41 +210,48 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
         )}
       </Group>
 
-      <Group mt="xs" gap={6} align="center">
-        <Box
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: '50%',
-            flexShrink: 0,
-            backgroundColor:
+      <Stack mt="xs" gap={2}>
+        <Group gap={6} align="center">
+          <Box
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              flexShrink: 0,
+              backgroundColor:
+                account.last_connection_ok === true
+                  ? 'var(--mantine-color-green-6)'
+                  : account.last_connection_ok === false
+                  ? 'var(--mantine-color-red-6)'
+                  : 'var(--mantine-color-gray-5)',
+            }}
+          />
+          <Text
+            size="xs"
+            c={
               account.last_connection_ok === true
-                ? 'var(--mantine-color-green-6)'
+                ? 'green'
                 : account.last_connection_ok === false
-                ? 'var(--mantine-color-red-6)'
-                : 'var(--mantine-color-gray-5)',
-          }}
-        />
-        <Text
-          size="xs"
-          c={
-            account.last_connection_ok === true
-              ? 'green'
+                ? 'red'
+                : 'dimmed'
+            }
+          >
+            {account.last_connection_ok === true
+              ? 'Connected'
               : account.last_connection_ok === false
-              ? 'red'
-              : 'dimmed'
-          }
-        >
-          {account.last_connection_ok === true
-            ? 'Connected'
-            : account.last_connection_ok === false
-            ? 'Unreachable'
-            : 'Not checked yet'}
-          {account.last_connection_checked_at
-            ? ` · ${timeAgo(account.last_connection_checked_at)}`
-            : ''}
-        </Text>
-      </Group>
+              ? 'Unreachable'
+              : 'Not checked yet'}
+            {account.last_connection_checked_at
+              ? ` · ${timeAgo(account.last_connection_checked_at)}`
+              : ''}
+          </Text>
+        </Group>
+        {account.last_connection_ok === false && account.last_connection_error && (
+          <Text size="xs" c="dimmed" ml={14}>
+            {account.last_connection_error}
+          </Text>
+        )}
+      </Stack>
     </Card>
   )
 }


### PR DESCRIPTION
## What a user would notice

When an account fails to connect, the Accounts page now shows a short plain-English reason under the red dot. Before this change, the badge just said "Unreachable" with no hint of what to do. Now the operator sees something like "Invalid credentials. Check your username and password." or "Cannot reach provider. Check the server URL." and knows exactly what to fix without reading logs.

## What changed

- New `last_connection_error` text column on `XtreamAccount` (added via the existing ALTER TABLE migration pattern, no migration framework needed).
- `EPGIngestManager._update_connection_status` now accepts an optional error string. When `ok=False`, it stores a translated message; when `ok=True`, it clears it.
- New `_friendly_connection_error()` function maps common exception types (timeout, DNS failure, bad credentials, HTTP 4xx/5xx) to short actionable strings.
- `AccountsSection.jsx`: error text appears as a small dimmed line under the "Unreachable" status, only when the account is unreachable and an error reason is stored.

## How it was tested

8 regression tests in `test_account_connection_status.py` (3 new: `test_failure_stores_error_message`, `test_success_clears_error_message`, updated `test_refresh_all_accounts_marks_failure_on_exception`). 330/330 pass. Before/after screenshots confirmed in the running app.

## Before

**Desktop:** "Unreachable" badge, no explanation.
![Before desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513146620441657354/before_desktop.png?ex=6a26ab1b&is=6a25599b&hm=219d3486659b8a1fe6e091ed4e3c3313f05a20923b5f4b7fe3ea910578cea75d&)

**Mobile:**
![Before mobile](https://cdn.discordapp.com/attachments/1512586038969765908/1513146649864699954/before_mobile.png?ex=6a26ab22&is=6a2559a2&hm=e9999bbe187145913e9de265f493c9e17bf19c56eef8c781d7e85667c8f06740&)

## After

**Desktop:** "Unreachable" + "Invalid credentials. Check your username and password."
![After desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513146635147018291/after_desktop.png?ex=6a26ab1e&is=6a25599e&hm=fdcf73a91b9d2757a96cc638380a802182f5dc71b5639e5be5ccf0f6cd9ad4ef&)

**Mobile:**
![After mobile](https://cdn.discordapp.com/attachments/1512586038969765908/1513146653593436320/after_mobile.png?ex=6a26ab23&is=6a2559a3&hm=22cd93b706c3946e61819152139fb67118f1aaa998058a8060e68aa559f77bdd&)