### PR TITLE
fix: add dict-to-list coercion to VOD and series XtreamClient methods

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -103,7 +103,8 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get VOD categories: HTTP {response.status}")
-            return await response.json(content_type=None)
+            data = await response.json(content_type=None)
+            return list(data.values()) if isinstance(data, dict) else data
 
     async def get_vod_streams(self, category_id: Optional[str] = None) -> list:
         """Get VOD (movies) streams."""
@@ -112,7 +113,8 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get VOD streams: HTTP {response.status}")
-            return await response.json(content_type=None)
+            data = await response.json(content_type=None)
+            return list(data.values()) if isinstance(data, dict) else data
 
     async def get_vod_info(self, vod_id: str) -> dict:
         """Get VOD (movie) details."""
@@ -130,7 +132,8 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get series categories: HTTP {response.status}")
-            return await response.json(content_type=None)
+            data = await response.json(content_type=None)
+            return list(data.values()) if isinstance(data, dict) else data
 
     async def get_series(self, category_id: Optional[str] = None) -> list:
         """Get series list."""
@@ -139,7 +142,8 @@ class XtreamClient:
         async with session.get(url, timeout=VOD_TIMEOUT) as response:
             if response.status != 200:
                 raise Exception(f"Failed to get series: HTTP {response.status}")
-            return await response.json(content_type=None)
+            data = await response.json(content_type=None)
+            return list(data.values()) if isinstance(data, dict) else data
 
     async def get_series_info(self, series_id: str) -> dict:
         """Get series details (seasons + episodes)."""

--- a/backend/tests/test_xtream_client_vod_dict_response.py
+++ b/backend/tests/test_xtream_client_vod_dict_response.py
@@ -1,0 +1,110 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.xtream_client import XtreamClient
+
+
+def _mock_session(json_data, status=200):
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=cm)
+    return AsyncMock(return_value=session)
+
+
+def _client():
+    return XtreamClient("http://provider.test:8080", "user", "pass")
+
+
+class GetVodCategoriesDictResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dict_response_returns_list(self):
+        cat1 = {"category_id": "1", "category_name": "Action"}
+        cat2 = {"category_id": "2", "category_name": "Comedy"}
+        client = _client()
+        client._get_session = _mock_session({"0": cat1, "1": cat2})
+        result = await client.get_vod_categories()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn(cat1, result)
+        self.assertIn(cat2, result)
+
+    async def test_list_response_passed_through(self):
+        cats = [{"category_id": "1", "category_name": "Action"}]
+        client = _client()
+        client._get_session = _mock_session(cats)
+        result = await client.get_vod_categories()
+        self.assertEqual(result, cats)
+
+
+class GetVodStreamsDictResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dict_response_returns_list(self):
+        m1 = {"stream_id": 10, "name": "The Matrix"}
+        m2 = {"stream_id": 11, "name": "Inception"}
+        client = _client()
+        client._get_session = _mock_session({"0": m1, "1": m2})
+        result = await client.get_vod_streams()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn(m1, result)
+        self.assertIn(m2, result)
+
+    async def test_list_response_passed_through(self):
+        movies = [{"stream_id": 10, "name": "The Matrix"}]
+        client = _client()
+        client._get_session = _mock_session(movies)
+        result = await client.get_vod_streams()
+        self.assertEqual(result, movies)
+
+
+class GetSeriesCategoriesDictResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dict_response_returns_list(self):
+        cat1 = {"category_id": "5", "category_name": "Drama"}
+        cat2 = {"category_id": "6", "category_name": "Sci-Fi"}
+        client = _client()
+        client._get_session = _mock_session({"0": cat1, "1": cat2})
+        result = await client.get_series_categories()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn(cat1, result)
+        self.assertIn(cat2, result)
+
+    async def test_list_response_passed_through(self):
+        cats = [{"category_id": "5", "category_name": "Drama"}]
+        client = _client()
+        client._get_session = _mock_session(cats)
+        result = await client.get_series_categories()
+        self.assertEqual(result, cats)
+
+
+class GetSeriesDictResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dict_response_returns_list(self):
+        s1 = {"series_id": 20, "name": "Breaking Bad"}
+        s2 = {"series_id": 21, "name": "The Wire"}
+        client = _client()
+        client._get_session = _mock_session({"0": s1, "1": s2})
+        result = await client.get_series()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn(s1, result)
+        self.assertIn(s2, result)
+
+    async def test_list_response_passed_through(self):
+        series = [{"series_id": 20, "name": "Breaking Bad"}]
+        client = _client()
+        client._get_session = _mock_session(series)
+        result = await client.get_series()
+        self.assertEqual(result, series)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

On some IPTV providers (certain Xtream Codes forks), opening the Movies or Series page showed nothing at all. No error was displayed. The page was simply blank.

## What changed

Some providers return a JSON object (`{}`) instead of a JSON array (`[]`) for their VOD and series listings. The same bug was already fixed for the Live TV page, but the fix was not carried over to Movies and Series.

This PR applies the same one-line normalization to four methods:
- `get_vod_categories` (Movies: category list)
- `get_vod_streams` (Movies: film list)
- `get_series_categories` (Series: category list)
- `get_series` (Series: show list)

When the provider returns an object, the values are extracted as a list. When it returns an array, nothing changes.

## How it was tested

8 new regression tests in `backend/tests/test_xtream_client_vod_dict_response.py` cover dict and list responses for all four methods. Full suite: 344/344 pass.

**Before:** Movies/Series page blank when provider returns `{}`. Frontend logged `data.map is not a function`.

**After:** Provider dict response normalized to a list; Movies and Series pages load normally.