### PR TITLE
[Design] Hide noisy default badges on account cards

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -190,14 +190,12 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
           <Badge variant="outline" size="sm" color="blue">
             Catchup: up to {catchupSummary.maxDays} days
           </Badge>
-        ) : (
-          <Badge variant="outline" size="sm" color="gray">
-            Catchup: none reported
+        ) : null}
+        {Number(account?.guide_offset_hours || 0) !== 0 && (
+          <Badge variant="light" size="sm" color="grape">
+            {getGuideOffsetLabel(account)}
           </Badge>
         )}
-        <Badge variant="light" size="sm" color="grape">
-          {getGuideOffsetLabel(account)}
-        </Badge>
         {account.max_connections && (
           <Badge variant="outline" size="sm">
             {account.active_connections || 0}/{account.max_connections} connections


### PR DESCRIPTION
## What changed

Two badges appeared on every IPTV account card even when they carried no useful information:

- **Catchup: none reported** — shown when the provider did not report catchup availability. A non-technical user has no way to know what this means or what to do about it.
- **Guide offset: 0h** — shown even when the offset is the default (zero). The 0h value is not actionable.

Both badges are now hidden when they represent the default/empty state. Catchup availability is shown only when the provider actually reports days of archive. Guide offset is shown only when it is non-zero.

## Before

Both cards display "CATCHUP: NONE REPORTED" and "GUIDE OFFSET: 0H" regardless of whether that information is meaningful.

Desktop before: every account card has two grey/purple jargon badges below the URL and username.
Mobile before: same two badges crowd the card on a small screen.

## After

Cards show only what matters: connection status (Unreachable/Connected), and catchup or offset info only when it is non-default.

Desktop after: cards are clean. Connection status is the focus.
Mobile after: less crowding, status is readable at a glance.

## Test plan

- [ ] Add an account. Confirm no catchup or offset badge appears with default settings.
- [ ] Set guide offset to a non-zero value on one account. Confirm offset badge appears.
- [ ] Confirm that an account with catchup data (maxDays > 0) still shows the catchup badge.