### PR TITLE
fix: delete EPGProgram rows when account is deleted

### DIFF
--- a/backend/api/accounts.py
+++ b/backend/api/accounts.py
@@ -4,13 +4,14 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, delete
 
 from auth import require_admin, require_admin_or_download_user, AuthContext
 from database import get_session
-from models import AppSettings, XtreamAccount, ScheduledRecording, ScheduledStatus, Download, DownloadStatus
+from models import AppSettings, EPGProgram, XtreamAccount, ScheduledRecording, ScheduledStatus, Download, DownloadStatus
 from services.download_manager import download_manager
 from services.epg_ingest_manager import epg_ingest_manager
+from services.epg_service import epg_service
 from services.account_credentials import (
     encrypt_account_password,
     resolve_account_password_with_migration,
@@ -236,8 +237,13 @@ async def delete_account(
     )
     active_dl_ids = [d.id for d in dl_result.scalars().all()]
 
+    await session.execute(
+        delete(EPGProgram).where(EPGProgram.account_id == account.id)
+    )
+
     await session.delete(account)
     await session.commit()
+    epg_service.clear_cache()
 
     for dl_id in active_dl_ids:
         await download_manager.cancel_download(dl_id)

--- a/backend/tests/test_default_account_settings.py
+++ b/backend/tests/test_default_account_settings.py
@@ -124,11 +124,13 @@ class DefaultAccountSettingsTests(unittest.IsolatedAsyncioTestCase):
                 _ScalarResult(app_settings),
                 _empty_list,
                 _empty_list,
+                AsyncMock(),  # delete(EPGProgram)
             ]
         )
 
         with patch("api.accounts.download_manager"):
-            result = await delete_account(5, None, session)
+            with patch("api.accounts.epg_service"):
+                result = await delete_account(5, None, session)
 
         self.assertIsNone(app_settings.default_account_id)
         self.assertEqual(result, {"status": "deleted"})

--- a/backend/tests/test_delete_account_cleanup.py
+++ b/backend/tests/test_delete_account_cleanup.py
@@ -80,11 +80,13 @@ class DeleteAccountScheduleCleanupTests(unittest.IsolatedAsyncioTestCase):
             _scalar_one(app_settings),
             _scalar_list(schedules),
             _scalar_list(active_downloads),
+            AsyncMock(),  # delete(EPGProgram)
         ])
 
         with patch("api.accounts.download_manager") as mock_dm:
-            mock_dm.cancel_download = AsyncMock()
-            result = await delete_account(account.id, None, session)
+            with patch("api.accounts.epg_service"):
+                mock_dm.cancel_download = AsyncMock()
+                result = await delete_account(account.id, None, session)
 
         return session, mock_dm, result
 

--- a/backend/tests/test_delete_account_epg_cleanup.py
+++ b/backend/tests/test_delete_account_epg_cleanup.py
@@ -1,19 +1,22 @@
 """
 Regression test: delete_account must bulk-delete all EPGProgram rows for the
-account before removing the account row.
+account before removing the account row, and clear the in-process EPG cache so
+a reused account id cannot serve stale EPG data.
 
 Before fix: session.delete(account) left epg_programs rows with the deleted
 account_id.  Rows accumulated indefinitely, and SQLite integer PK reuse meant
 a new account with the same id immediately inherited the old account's EPG data.
+The in-memory EPGService cache also kept serving the old data until TTL expired.
 
 After fix: a DELETE FROM epg_programs WHERE account_id = ? statement runs inside
 the same transaction before session.delete(account), so no orphaned rows remain.
+epg_service.clear_cache() is called after the commit so no stale cache entries
+survive account deletion.
 """
 import sys
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
@@ -28,6 +31,13 @@ def _scalar_one(value):
         def scalar_one_or_none(self):
             return value
     return R()
+
+
+def _scalars_empty():
+    """Return a mock execute result whose .scalars().all() yields []."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    return result
 
 
 def _make_account(account_id=1):
@@ -47,25 +57,31 @@ class DeleteAccountEPGCleanupTests(unittest.IsolatedAsyncioTestCase):
             app_settings = AppSettings()
         session = AsyncMock()
         # Execute call order:
-        #   1. select(XtreamAccount)  -> account lookup
-        #   2. select(AppSettings)    -> settings lookup
-        #   3. delete(EPGProgram)     -> bulk EPG cleanup (return value unused)
+        #   1. select(XtreamAccount)    -> account lookup
+        #   2. select(AppSettings)      -> settings lookup
+        #   3. select(ScheduledRecording) -> schedule cancel (PR #121)
+        #   4. select(Download)         -> active download ids (PR #121)
+        #   5. delete(EPGProgram)       -> bulk EPG cleanup
         session.execute = AsyncMock(side_effect=[
             _scalar_one(account),
             _scalar_one(app_settings),
+            _scalars_empty(),
+            _scalars_empty(),
             AsyncMock(),
         ])
-        result = await delete_account(account.id, None, session)
+        with patch("api.accounts.download_manager"):
+            with patch("api.accounts.epg_service"):
+                result = await delete_account(account.id, None, session)
         return session, result
 
     async def test_epg_programs_delete_executed(self):
         account = _make_account()
         session, result = await self._run_delete(account)
         self.assertEqual(result, {"status": "deleted"})
-        # Third execute call must target epg_programs table.
+        # Fifth execute call must target epg_programs table.
         calls = session.execute.await_args_list
-        self.assertEqual(len(calls), 3)
-        epg_stmt = calls[2].args[0]
+        self.assertEqual(len(calls), 5)
+        epg_stmt = calls[4].args[0]
         self.assertEqual(str(epg_stmt.table), str(EPGProgram.__table__))
 
     async def test_epg_delete_runs_before_account_row_delete(self):
@@ -76,6 +92,8 @@ class DeleteAccountEPGCleanupTests(unittest.IsolatedAsyncioTestCase):
         orig_execute = AsyncMock(side_effect=[
             _scalar_one(account),
             _scalar_one(AppSettings()),
+            _scalars_empty(),
+            _scalars_empty(),
             AsyncMock(),
         ])
 
@@ -90,9 +108,12 @@ class DeleteAccountEPGCleanupTests(unittest.IsolatedAsyncioTestCase):
         session.execute = AsyncMock(side_effect=tracking_execute)
         session.delete = AsyncMock(side_effect=tracking_delete)
 
-        await delete_account(account.id, None, session)
+        with patch("api.accounts.download_manager"):
+            with patch("api.accounts.epg_service"):
+                await delete_account(account.id, None, session)
 
-        epg_execute_pos = [i for i, v in enumerate(call_order) if v == "execute"][2]
+        # The 5th execute (index 4) is the EPG delete; it must precede session.delete
+        epg_execute_pos = [i for i, v in enumerate(call_order) if v == "execute"][4]
         delete_pos = next(i for i, v in enumerate(call_order) if v == "delete")
         self.assertLess(epg_execute_pos, delete_pos)
 
@@ -101,6 +122,22 @@ class DeleteAccountEPGCleanupTests(unittest.IsolatedAsyncioTestCase):
         session, _ = await self._run_delete(account)
         session.delete.assert_awaited_with(account)
         session.commit.assert_awaited()
+
+    async def test_epg_cache_cleared_on_delete(self):
+        """epg_service.clear_cache() must be called after account deletion."""
+        account = _make_account()
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=[
+            _scalar_one(account),
+            _scalar_one(AppSettings()),
+            _scalars_empty(),
+            _scalars_empty(),
+            AsyncMock(),
+        ])
+        with patch("api.accounts.download_manager"):
+            with patch("api.accounts.epg_service") as mock_epg_service:
+                await delete_account(account.id, None, session)
+                mock_epg_service.clear_cache.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_delete_account_epg_cleanup.py
+++ b/backend/tests/test_delete_account_epg_cleanup.py
@@ -1,0 +1,107 @@
+"""
+Regression test: delete_account must bulk-delete all EPGProgram rows for the
+account before removing the account row.
+
+Before fix: session.delete(account) left epg_programs rows with the deleted
+account_id.  Rows accumulated indefinitely, and SQLite integer PK reuse meant
+a new account with the same id immediately inherited the old account's EPG data.
+
+After fix: a DELETE FROM epg_programs WHERE account_id = ? statement runs inside
+the same transaction before session.delete(account), so no orphaned rows remain.
+"""
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from api.accounts import delete_account
+from models import AppSettings, EPGProgram, XtreamAccount
+
+
+def _scalar_one(value):
+    class R:
+        def scalar_one_or_none(self):
+            return value
+    return R()
+
+
+def _make_account(account_id=1):
+    return XtreamAccount(
+        id=account_id,
+        name="Provider",
+        server_url="http://example",
+        username="user",
+        password="",
+    )
+
+
+class DeleteAccountEPGCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    async def _run_delete(self, account, app_settings=None):
+        if app_settings is None:
+            app_settings = AppSettings()
+        session = AsyncMock()
+        # Execute call order:
+        #   1. select(XtreamAccount)  -> account lookup
+        #   2. select(AppSettings)    -> settings lookup
+        #   3. delete(EPGProgram)     -> bulk EPG cleanup (return value unused)
+        session.execute = AsyncMock(side_effect=[
+            _scalar_one(account),
+            _scalar_one(app_settings),
+            AsyncMock(),
+        ])
+        result = await delete_account(account.id, None, session)
+        return session, result
+
+    async def test_epg_programs_delete_executed(self):
+        account = _make_account()
+        session, result = await self._run_delete(account)
+        self.assertEqual(result, {"status": "deleted"})
+        # Third execute call must target epg_programs table.
+        calls = session.execute.await_args_list
+        self.assertEqual(len(calls), 3)
+        epg_stmt = calls[2].args[0]
+        self.assertEqual(str(epg_stmt.table), str(EPGProgram.__table__))
+
+    async def test_epg_delete_runs_before_account_row_delete(self):
+        """EPGProgram cleanup must precede session.delete(account)."""
+        account = _make_account()
+        call_order = []
+
+        orig_execute = AsyncMock(side_effect=[
+            _scalar_one(account),
+            _scalar_one(AppSettings()),
+            AsyncMock(),
+        ])
+
+        async def tracking_execute(stmt, *args, **kwargs):
+            call_order.append("execute")
+            return await orig_execute(stmt, *args, **kwargs)
+
+        async def tracking_delete(obj):
+            call_order.append("delete")
+
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=tracking_execute)
+        session.delete = AsyncMock(side_effect=tracking_delete)
+
+        await delete_account(account.id, None, session)
+
+        epg_execute_pos = [i for i, v in enumerate(call_order) if v == "execute"][2]
+        delete_pos = next(i for i, v in enumerate(call_order) if v == "delete")
+        self.assertLess(epg_execute_pos, delete_pos)
+
+    async def test_session_delete_and_commit_called(self):
+        account = _make_account()
+        session, _ = await self._run_delete(account)
+        session.delete.assert_awaited_with(account)
+        session.commit.assert_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Deleting an account via Settings > Accounts > Delete left all of that account's program guide entries (\`epg_programs\` rows) in the database and kept them in the in-process EPG cache. Both problems are fixed.

**Why it matters for operators:**

- Storage: A provider with 30 days of EPG across 1,000 channels can store 200,000+ rows. Deleting and re-adding an account (e.g. after changing credentials) multiplies this each cycle.
- Data mixing: SQLite reuses integer primary keys. If a new account is created and gets the same \`id\` as a deleted one, it immediately inherits the old account's EPG data without any refresh running. Before this fix, stale cache entries could serve the old guide data until the TTL expired: a cross-account data leak.

## What changed

\`backend/api/accounts.py\`: before removing the account row, the delete handler now issues a \`DELETE FROM epg_programs WHERE account_id = ?\` in the same transaction, then calls \`epg_service.clear_cache()\` after committing. No schema changes.

## Before

```sql
-- After deleting account id=1:
SELECT COUNT(*) FROM epg_programs WHERE account_id = 1;
-- Returns the same count as before deletion (rows were never cleaned up)
-- EPG cache also still serving deleted account's guide until TTL expires
```

## After

```sql
-- After deleting account id=1:
SELECT COUNT(*) FROM epg_programs WHERE account_id = 1;
-- Returns 0
-- EPG cache cleared immediately, no stale data for any reused account id
```

## How to test

1. Add an account. Let EPG refresh run (or trigger it manually in Settings > EPG Refresh).
2. Confirm rows exist: \`SELECT COUNT(*) FROM epg_programs WHERE account_id = <id>\`.
3. Delete the account via Settings > Accounts > Delete.
4. Re-query: \`SELECT COUNT(*) FROM epg_programs WHERE account_id = <id>\` returns 0.

## Tests

4 regression tests in \`backend/tests/test_delete_account_epg_cleanup.py\`:

- \`test_epg_programs_delete_executed\`: the DELETE statement targets the \`epg_programs\` table
- \`test_epg_delete_runs_before_account_row_delete\`: bulk delete runs before \`session.delete(account)\`
- \`test_session_delete_and_commit_called\`: transaction commits correctly
- \`test_epg_cache_cleared_on_delete\`: \`epg_service.clear_cache()\` is called after deletion

382 tests pass.

Closes the [#tasks thread](https://discord.com/channels/1512584984451440751/1512877465192628326).