### PR TITLE
[Design] Show actionable error when Browse channels fail to load

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -43,7 +43,7 @@ import {
   getNowUtc,
 } from '../utils/channelTime'
 
-function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading }) {
+function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, isError }) {
   const [search, setSearch] = useState('')
 
   const filteredChannels = useMemo(() => {
@@ -57,6 +57,24 @@ function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading }) 
     return (
       <Stack align="center" justify="center" h={200}>
         <Loader />
+      </Stack>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Stack align="center" justify="center" h={200} gap="xs" px="sm">
+        <IconAlertCircle size={28} color="var(--mantine-color-red-5)" />
+        <Text size="sm" c="dimmed" ta="center">
+          Could not reach your provider.
+        </Text>
+        <Text size="xs" c="dimmed" ta="center">
+          Check your account status in{' '}
+          <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+            Settings → Accounts
+          </Link>
+          .
+        </Text>
       </Stack>
     )
   }
@@ -369,7 +387,11 @@ export default function Browse() {
   })
 
   // Fetch channels
-  const { data: channels, isLoading: channelsLoading } = useQuery({
+  const {
+    data: channels,
+    isLoading: channelsLoading,
+    isError: channelsIsError,
+  } = useQuery({
     queryKey: ['channels', selectedAccountId],
     queryFn: () => channelsApi.getChannels(selectedAccountId, null, true),
     enabled: !!selectedAccountId,
@@ -913,6 +935,7 @@ export default function Browse() {
                     selectedChannel={selectedChannel}
                     onSelectChannel={handleSelectChannel}
                     isLoading={channelsLoading}
+                    isError={channelsIsError}
                   />
                 </Stack>
               </Card>
@@ -944,6 +967,7 @@ export default function Browse() {
                     selectedChannel={selectedChannel}
                     onSelectChannel={handleSelectChannel}
                     isLoading={channelsLoading}
+                    isError={channelsIsError}
                   />
                 </Stack>
               </Card>

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -43,7 +43,7 @@ import {
   getNowUtc,
 } from '../utils/channelTime'
 
-function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, isError }) {
+function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, isError, isAdmin }) {
   const [search, setSearch] = useState('')
 
   const filteredChannels = useMemo(() => {
@@ -69,11 +69,17 @@ function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, is
           Could not reach your provider.
         </Text>
         <Text size="xs" c="dimmed" ta="center">
-          Check your account status in{' '}
-          <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
-            Settings → Accounts
-          </Link>
-          .
+          {isAdmin ? (
+            <>
+              Check your account status in{' '}
+              <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+                Settings → Accounts
+              </Link>
+              .
+            </>
+          ) : (
+            'Contact your administrator to check the account connection.'
+          )}
         </Text>
       </Stack>
     )
@@ -379,6 +385,11 @@ export default function Browse() {
   const [desktopSeriesHeight, setDesktopSeriesHeight] = useState(getInitialDesktopPanelHeight)
   const [mobileMoviesView, setMobileMoviesView] = useState('categories')
   const [mobileSeriesView, setMobileSeriesView] = useState('categories')
+
+  const { data: authStatus } = useQuery({
+    queryKey: ['auth', 'status'],
+    queryFn: authApi.status,
+  })
 
   // Fetch accounts
   const { data: accounts, isLoading: accountsLoading } = useQuery({
@@ -936,6 +947,7 @@ export default function Browse() {
                     onSelectChannel={handleSelectChannel}
                     isLoading={channelsLoading}
                     isError={channelsIsError}
+                    isAdmin={authStatus?.is_admin}
                   />
                 </Stack>
               </Card>
@@ -968,6 +980,7 @@ export default function Browse() {
                     onSelectChannel={handleSelectChannel}
                     isLoading={channelsLoading}
                     isError={channelsIsError}
+                    isAdmin={authStatus?.is_admin}
                   />
                 </Stack>
               </Card>


### PR DESCRIPTION
## What a user would notice

Before: when an account's provider is unreachable, the Channels panel on the Browse page loads briefly then shows "No channels available yet." — identical to what you would see on a freshly connected account with no channels. There is no way to tell whether your provider is down or whether channels simply have not arrived yet.

After: the Channels panel shows a red alert icon and "Could not reach your provider." Admin users also see a direct link to Settings → Accounts where they can check the account's connection status badge and error reason. Non-admin users see "Contact your administrator to check the account connection." with no link (since non-admins cannot reach the Accounts section).

## What changed

- `ChannelList` accepts new `isAdmin` and `isError` props.
- The Browse component reads `authStatus` from TanStack Query's existing `['auth', 'status']` cache (no extra network call) and passes `is_admin` down to both `ChannelList` usages.
- When `isError` is true, admins see the Settings → Accounts link; non-admins see plain text.
- Only `Browse.jsx` changed. No backend changes.

## How it was tested

Started the app locally against accounts pointing at unreachable providers. Waited for TanStack Query to exhaust retries. Verified:
- Admin session: red alert, "Could not reach your provider.", clickable "Settings → Accounts" link navigates correctly.
- Non-admin session (local user and Plex user): red alert, "Could not reach your provider.", plain "Contact your administrator to check the account connection." text, no link.
- Desktop and mobile layouts both show the correct state.

## Before and after

**Before** (any user, provider unreachable): Channels panel spins then shows "No channels available yet." — same as an account with no channels.

**After (admin)**: red alert icon, "Could not reach your provider. Check your account status in Settings → Accounts." with a clickable link.

**After (non-admin)**: red alert icon, "Could not reach your provider. Contact your administrator to check the account connection." — no link.