### PR TITLE
[Design] Hide inactive stage bars during download

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -209,29 +209,37 @@ function DownloadCard({
               </Text>
             )}
 
-            <Group justify="space-between">
-              <Text size="xs" c="dimmed">Commercial Detect</Text>
-              <Text size="xs" c="dimmed">
-                {formatStagePercent(comskipProgress, comskipIndeterminate)}
-              </Text>
-            </Group>
-            <ProgressBar
-              progress={comskipProgress ?? 0}
-              color="orange"
-              indeterminate={comskipIndeterminate}
-            />
+            {(comskipProgress !== null || comskipIndeterminate) && (
+              <>
+                <Group justify="space-between">
+                  <Text size="xs" c="dimmed">Commercial Detect</Text>
+                  <Text size="xs" c="dimmed">
+                    {formatStagePercent(comskipProgress, comskipIndeterminate)}
+                  </Text>
+                </Group>
+                <ProgressBar
+                  progress={comskipProgress ?? 0}
+                  color="orange"
+                  indeterminate={comskipIndeterminate}
+                />
+              </>
+            )}
 
-            <Group justify="space-between">
-              <Text size="xs" c="dimmed">Re-encode</Text>
-              <Text size="xs" c="dimmed">
-                {formatStagePercent(transcodeProgress, transcodeIndeterminate)}
-              </Text>
-            </Group>
-            <ProgressBar
-              progress={transcodeProgress ?? 0}
-              color="teal"
-              indeterminate={transcodeIndeterminate}
-            />
+            {(transcodeProgress !== null || transcodeIndeterminate) && (
+              <>
+                <Group justify="space-between">
+                  <Text size="xs" c="dimmed">Re-encode</Text>
+                  <Text size="xs" c="dimmed">
+                    {formatStagePercent(transcodeProgress, transcodeIndeterminate)}
+                  </Text>
+                </Group>
+                <ProgressBar
+                  progress={transcodeProgress ?? 0}
+                  color="teal"
+                  indeterminate={transcodeIndeterminate}
+                />
+              </>
+            )}
 
             {download.status === 'processing' && (
               <Text size="xs" c="dimmed">


### PR DESCRIPTION
## What changed

When a download is active, the Downloads page shows progress bars for each post-processing stage: Download, Commercial Detect, and Re-encode.

Previously all three bars always rendered as soon as a download started. For users who have ComSkip or transcoding disabled (the default for many operators), the Commercial Detect and Re-encode bars appeared immediately with blank labels and zero progress, and stayed that way for the entire download. A non-technical operator had no way to tell whether those stages were disabled or just broken.

Now each stage bar only appears when that stage is actually running (has reported progress or is in an indeterminate state). Operators see only what is relevant to their current recording.

## Before

Download in progress with ComSkip and transcoding disabled: three bars, two permanently blank. Commercial Detect and Re-encode stuck at dashes the entire time.

## After

Same download: only the Download bar is shown. Clean, no confusing placeholders.

Screenshots posted in #design.

## How it was tested

Playwright script mocked a downloading record with null comskip_progress and transcode_progress (representing a user with ComSkip and transcoding disabled). Confirmed before: three bars rendered. After: one bar rendered. The Commercial Detect and Re-encode bars appear correctly as soon as those stages report any progress.

## Files changed

- frontend/src/pages/Downloads.jsx: wrap Commercial Detect and Re-encode sections in conditional render guards