### PR TITLE
fix: preserve partial bytes on recovery for unknown-length streams

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -579,6 +579,9 @@ class DownloadManager:
                 output_dir = os.path.dirname(download.output_path)
                 os.makedirs(output_dir, exist_ok=True)
 
+                # Preserve any recovered partial-file offset for Range resume attempt.
+                recovery_offset = download.downloaded_bytes or 0
+
                 # Update status to downloading
                 download.status = DownloadStatus.DOWNLOADING.value
                 download.progress = 0.0
@@ -598,7 +601,8 @@ class DownloadManager:
                     download.source_url,
                     download.output_path,
                     download_id,
-                    session
+                    session,
+                    offset=recovery_offset,
                 )
                 if downloaded_bytes == 0:
                     raise Exception(
@@ -989,15 +993,29 @@ class DownloadManager:
         url: str,
         output_path: str,
         download_id: int,
-        session: AsyncSession
+        session: AsyncSession,
+        offset: int = 0,
     ):
-        """Stream download a file with progress tracking."""
+        """Stream download a file with progress tracking.
+
+        If *offset* is non-zero a ``Range: bytes=<offset>-`` header is sent.
+        A 206 response means the server honours the range; the existing partial
+        file is appended to and *downloaded* starts at *offset* so the reported
+        byte count is cumulative.  A 200 response means the server ignored the
+        range; the file is truncated and the download starts from scratch.
+        """
         timeout = aiohttp.ClientTimeout(total=None, sock_read=60)
 
+        request_headers: dict = {}
+        if offset > 0:
+            request_headers["Range"] = f"bytes={offset}-"
+
         async with aiohttp.ClientSession(timeout=timeout) as http_session:
-            async with http_session.get(url) as response:
+            async with http_session.get(url, headers=request_headers) as response:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
+
+                resuming = response.status == 206 and offset > 0
 
                 total_size = response.content_length or 0
                 if response.status == 206:
@@ -1016,10 +1034,26 @@ class DownloadManager:
                         download_id,
                         f"HTTP {response.status}. Size unknown; streaming download."
                     )
-                downloaded = 0
+
+                if resuming:
+                    downloaded = offset
+                    file_mode = "ab"
+                    await self._broadcast_log(
+                        download_id,
+                        f"Resuming from byte {offset:,}."
+                    )
+                else:
+                    downloaded = 0
+                    file_mode = "wb"
+                    if offset > 0:
+                        await self._broadcast_log(
+                            download_id,
+                            "Provider did not honour Range request; re-downloading from start."
+                        )
+
                 last_progress_update = 0
 
-                async with aiofiles.open(output_path, 'wb') as f:
+                async with aiofiles.open(output_path, file_mode) as f:
                     async for chunk in response.content.iter_chunked(1024 * 1024):  # 1MB chunks
                         # Check for cancellation
                         if download_id in self._cancelled:

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1015,15 +1015,32 @@ class DownloadManager:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
-                resuming = response.status == 206 and offset > 0
-
                 total_size = response.content_length or 0
+                range_start = None
                 if response.status == 206:
                     content_range = response.headers.get("Content-Range")
-                    if content_range and "/" in content_range:
-                        total_part = content_range.split("/")[-1].strip()
-                        if total_part.isdigit():
-                            total_size = int(total_part)
+                    if content_range:
+                        # Parse start byte from "bytes <start>-<end>/<total>"
+                        try:
+                            byte_range = content_range.split("/")[0].strip()
+                            if byte_range.lower().startswith("bytes "):
+                                byte_range = byte_range[6:]
+                            start_str = byte_range.split("-")[0].strip()
+                            if start_str.isdigit():
+                                range_start = int(start_str)
+                        except Exception:
+                            pass
+                        if "/" in content_range:
+                            total_part = content_range.split("/")[-1].strip()
+                            if total_part.isdigit():
+                                total_size = int(total_part)
+
+                # Only resume if server confirmed it started at the requested offset.
+                # If Content-Range is present but starts elsewhere, the provider silently
+                # returned data from a different position; appending would corrupt the file.
+                range_mismatch = range_start is not None and range_start != offset
+                resuming = response.status == 206 and offset > 0 and not range_mismatch
+
                 if total_size > 0:
                     await self._broadcast_log(
                         download_id,
@@ -1046,10 +1063,17 @@ class DownloadManager:
                     downloaded = 0
                     file_mode = "wb"
                     if offset > 0:
-                        await self._broadcast_log(
-                            download_id,
-                            "Provider did not honour Range request; re-downloading from start."
-                        )
+                        if range_mismatch:
+                            await self._broadcast_log(
+                                download_id,
+                                f"Provider returned Content-Range start {range_start:,} "
+                                f"instead of requested {offset:,}; re-downloading from start."
+                            )
+                        else:
+                            await self._broadcast_log(
+                                download_id,
+                                "Provider did not honour Range request; re-downloading from start."
+                            )
 
                 last_progress_update = 0
 

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -465,7 +465,13 @@ class DownloadManager:
 
                     download.status = DownloadStatus.PENDING.value
                     download.progress = 0.0
-                    download.downloaded_bytes = 0
+                    if download.file_size == 0 and input_file.is_file():
+                        try:
+                            download.downloaded_bytes = input_file.stat().st_size
+                        except Exception:
+                            download.downloaded_bytes = 0
+                    else:
+                        download.downloaded_bytes = 0
                     download.file_size = 0
                     download.error_message = None
                     recovered_download_ids.append(download.id)

--- a/backend/tests/test_disk_full.py
+++ b/backend/tests/test_disk_full.py
@@ -87,7 +87,7 @@ class DiskFullTests(unittest.IsolatedAsyncioTestCase):
             download = _FakeDownload(dl_id=42, output_path=output_path)
             session = _FakeSession(download)
 
-            async def fake_download_file(url, path, dl_id, ses):
+            async def fake_download_file(url, path, dl_id, ses, offset=0):
                 # Simulate provider sends some bytes, then disk fills.
                 with open(path, "wb") as fh:
                     fh.write(b"\x47" * 512 * 1024)  # 512 KB partial TS data

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -309,6 +309,48 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
         finally:
             os.unlink(tmp_path)
 
+    async def test_206_content_range_start_mismatch_restarts(self):
+        """
+        A 206 response where Content-Range start != requested offset means the provider
+        returned data from the wrong position. _download_file must fall back to 'wb'
+        mode and restart from 0 rather than appending corrupted data.
+        """
+        existing = b"\x00" * 4096
+        # Provider returns 206 but Content-Range says it started at byte 0, not 4096
+        new_data = b"\x47" * 512
+        response = _make_aiohttp_response(206, [new_data], content_range="bytes 0-511/10000")
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(existing)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                )
+
+            # Must restart: return value is only new bytes (no offset added)
+            self.assertEqual(
+                total,
+                512,
+                "Content-Range start mismatch must trigger restart; return value must not include offset.",
+            )
+            # File must be overwritten (truncated), not appended
+            with open(tmp_path, "rb") as fh:
+                contents = fh.read()
+            self.assertEqual(contents, new_data, "File must be overwritten when Content-Range start != offset.")
+        finally:
+            os.unlink(tmp_path)
+
     async def test_no_range_header_when_offset_zero(self):
         """offset=0 (normal download) must not send a Range header."""
         new_data = b"\x47" * 256

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -1,0 +1,346 @@
+"""
+Tests for HTTP Range resume support in _download_file and the offset propagation
+from _execute_download.
+
+Root cause addressed: when an unknown-length stream was recovered after a restart,
+recover_incomplete_downloads correctly set downloaded_bytes to the on-disk size,
+but _execute_download immediately reset it to 0 and _download_file opened the file
+with 'wb' (truncating the partial data).  The fix:
+  - _execute_download saves downloaded_bytes as recovery_offset before resetting.
+  - _download_file accepts an offset parameter; if offset > 0 it sends a
+    Range: bytes=<offset>- header.
+  - 206 response: file opened 'ab', downloaded counter starts at offset (resume).
+  - 200 response: file opened 'wb', downloaded counter starts at 0 (restart).
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_aiohttp_response(status, chunks, content_range=None):
+    """Return a mock aiohttp response that yields *chunks* from iter_chunked."""
+    response = MagicMock()
+    response.status = status
+    response.content_length = None
+    response.reason = "OK"
+
+    # Support both dict-style and .get() header access used in _download_file
+    headers = {}
+    if content_range:
+        headers["Content-Range"] = content_range
+    response.headers = headers
+
+    async def iter_chunked(_size):
+        for chunk in chunks:
+            yield chunk
+
+    response.content.iter_chunked = iter_chunked
+    return response
+
+
+def _make_aiohttp_client_session(response):
+    """Return (mock_session, patch_target) that yields *response* from .get()."""
+    get_cm = MagicMock()
+    get_cm.__aenter__ = AsyncMock(return_value=response)
+    get_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = get_cm
+
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_session, client_cm
+
+
+def _make_db_session():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _execute_download offset propagation
+# ---------------------------------------------------------------------------
+
+class ExecuteDownloadOffsetTests(unittest.TestCase):
+    """_execute_download must forward downloaded_bytes as offset to _download_file."""
+
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_execute_download_passes_recovered_bytes_as_offset(self):
+        """
+        When a recovered unknown-length download has downloaded_bytes=4096 in the DB,
+        _execute_download must call _download_file with offset=4096 so the provider
+        can resume the transfer instead of re-downloading from scratch.
+        """
+        captured_offset = []
+
+        async def capture_offset(url, path, dl_id, ses, offset=0):
+            captured_offset.append(offset)
+            return 1024
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = output_file
+            mock_download.source_url = "http://provider/stream"
+            mock_download.progress = 0.0
+            mock_download.downloaded_bytes = 4096  # set by recover_incomplete_downloads
+            mock_download.file_size = 0
+            mock_download.error_message = None
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_download
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield mock_session
+
+            with (
+                patch("services.download_manager.async_session_maker", mock_session_maker),
+                patch.object(self.manager, "_download_file", capture_offset),
+                patch.object(self.manager, "_broadcast_progress", AsyncMock()),
+                patch.object(self.manager, "_broadcast_log", AsyncMock()),
+                patch.object(self.manager, "_needs_post_processing", return_value=False),
+                patch.object(self.manager, "_move_to_completed", return_value=output_file),
+            ):
+                asyncio.run(self.manager._execute_download(1))
+
+        self.assertEqual(
+            captured_offset,
+            [4096],
+            "_execute_download must pass downloaded_bytes as offset to _download_file. "
+            "Without this, _download_file cannot send a Range header and the provider "
+            "re-streams from the beginning, risking catchup-window expiry.",
+        )
+
+    def test_execute_download_passes_zero_offset_for_normal_download(self):
+        """A normal (non-recovered) download has downloaded_bytes=0 and must pass offset=0."""
+        captured_offset = []
+
+        async def capture_offset(url, path, dl_id, ses, offset=0):
+            captured_offset.append(offset)
+            return 512
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 2
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = output_file
+            mock_download.source_url = "http://provider/stream"
+            mock_download.progress = 0.0
+            mock_download.downloaded_bytes = 0
+            mock_download.file_size = 0
+            mock_download.error_message = None
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_download
+            mock_session = AsyncMock()
+            mock_session.execute = AsyncMock(return_value=mock_result)
+            mock_session.commit = AsyncMock()
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield mock_session
+
+            with (
+                patch("services.download_manager.async_session_maker", mock_session_maker),
+                patch.object(self.manager, "_download_file", capture_offset),
+                patch.object(self.manager, "_broadcast_progress", AsyncMock()),
+                patch.object(self.manager, "_broadcast_log", AsyncMock()),
+                patch.object(self.manager, "_needs_post_processing", return_value=False),
+                patch.object(self.manager, "_move_to_completed", return_value=output_file),
+            ):
+                asyncio.run(self.manager._execute_download(2))
+
+        self.assertEqual(captured_offset, [0])
+
+
+# ---------------------------------------------------------------------------
+# _download_file Range behaviour
+# ---------------------------------------------------------------------------
+
+class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
+    """_download_file Range header and file-mode selection."""
+
+    async def test_range_header_sent_when_offset_nonzero(self):
+        """offset>0 must produce a Range: bytes=<offset>- request header."""
+        new_data = b"\x47" * 512
+        response = _make_aiohttp_response(206, [new_data], content_range="bytes 4096-4607/4608")
+        mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        tmp_f = tempfile.NamedTemporaryFile(suffix=".ts", delete=False)
+        tmp_f.write(b"\x00" * 4096)
+        tmp_f.close()
+        tmp_path = tmp_f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                )
+
+            mock_session.get.assert_called_once()
+            _url, _kwargs = mock_session.get.call_args[0], mock_session.get.call_args[1]
+            sent_headers = _kwargs.get("headers", {})
+            self.assertEqual(
+                sent_headers.get("Range"),
+                "bytes=4096-",
+                "Range header must be sent when offset>0.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_206_response_appends_and_counts_from_offset(self):
+        """
+        A 206 response means the server honours the Range request.
+        _download_file must open the file in 'ab' mode and return offset + new bytes.
+        """
+        existing = b"\x00" * 4096
+        new_data = b"\x47" * 512
+        response = _make_aiohttp_response(206, [new_data], content_range="bytes 4096-4607/4608")
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(existing)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                )
+
+            # Return value must be offset + newly received bytes (cumulative)
+            self.assertEqual(
+                total,
+                4096 + 512,
+                "_download_file must return offset+new_bytes on 206 (cumulative count).",
+            )
+            # File must contain old bytes plus new bytes (append, not overwrite)
+            with open(tmp_path, "rb") as fh:
+                contents = fh.read()
+            self.assertEqual(len(contents), 4096 + 512, "File must be appended, not truncated.")
+            self.assertEqual(contents[:4096], existing)
+            self.assertEqual(contents[4096:], new_data)
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_200_response_restarts_when_range_not_honoured(self):
+        """
+        A 200 response when offset>0 means the server ignored the Range header.
+        _download_file must fall back to 'wb' mode and return only new bytes (no offset).
+        """
+        existing = b"\x00" * 4096
+        new_data = b"\x47" * 512
+        response = _make_aiohttp_response(200, [new_data])
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(existing)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                )
+
+            # Return value must be only the newly received bytes (restart from 0)
+            self.assertEqual(
+                total,
+                512,
+                "_download_file must return only new bytes on 200 (no offset added).",
+            )
+            # File must be overwritten (truncated), not appended
+            with open(tmp_path, "rb") as fh:
+                contents = fh.read()
+            self.assertEqual(contents, new_data, "File must be overwritten on 200 fallback.")
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_no_range_header_when_offset_zero(self):
+        """offset=0 (normal download) must not send a Range header."""
+        new_data = b"\x47" * 256
+        response = _make_aiohttp_response(200, [new_data])
+        mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=0
+                )
+
+            _url, _kwargs = mock_session.get.call_args[0], mock_session.get.call_args[1]
+            sent_headers = _kwargs.get("headers", {})
+            self.assertNotIn(
+                "Range",
+                sent_headers,
+                "No Range header must be sent when offset is 0.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_download_manager_cancel_cleanup.py
+++ b/backend/tests/test_download_manager_cancel_cleanup.py
@@ -41,7 +41,7 @@ class CancelCleanupTests(unittest.TestCase):
             async def mock_session_maker():
                 yield mock_session
 
-            async def fake_download_file(url, path, download_id, session):
+            async def fake_download_file(url, path, download_id, session, offset=0):
                 with open(path, "wb") as f:
                     f.write(b"\x00" * 1024)
                 raise asyncio.CancelledError()

--- a/backend/tests/test_download_manager_completed_at.py
+++ b/backend/tests/test_download_manager_completed_at.py
@@ -56,7 +56,7 @@ class DownloadManagerCompletedAtTests(unittest.TestCase):
             mock_download.downloaded_bytes = 0
             mock_download.completed_at = None
 
-            async def fail_download(url, path, download_id, session):
+            async def fail_download(url, path, download_id, session, offset=0):
                 raise Exception("Connection reset by peer")
 
             with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):

--- a/backend/tests/test_download_manager_zero_bytes.py
+++ b/backend/tests/test_download_manager_zero_bytes.py
@@ -42,7 +42,7 @@ class ZeroBytesDownloadTests(unittest.TestCase):
             async def mock_session_maker():
                 yield mock_session
 
-            async def fake_download_file_zero_bytes(url, path, download_id, session):
+            async def fake_download_file_zero_bytes(url, path, download_id, session, offset=0):
                 # Provider returns HTTP 200 with empty body: file created but no bytes written.
                 open(path, "wb").close()
                 return 0
@@ -104,7 +104,7 @@ class ZeroBytesDownloadTests(unittest.TestCase):
             async def mock_session_maker():
                 yield mock_session
 
-            async def fake_download_file_with_bytes(url, path, download_id, session):
+            async def fake_download_file_with_bytes(url, path, download_id, session, offset=0):
                 with open(path, "wb") as f:
                     f.write(b"\x00" * 1024)
                 return 1024

--- a/backend/tests/test_recover_unknown_length.py
+++ b/backend/tests/test_recover_unknown_length.py
@@ -1,0 +1,169 @@
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+def _make_recovery_session(downloads, settings=None):
+    settings_result = MagicMock()
+    settings_result.scalar_one_or_none.return_value = settings
+
+    downloads_result = MagicMock()
+    downloads_result.scalars.return_value.all.return_value = downloads
+
+    call_count = [0]
+
+    async def execute(stmt):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return settings_result
+        return downloads_result
+
+    session = AsyncMock()
+    session.execute = execute
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def ctx():
+        yield session
+
+    return ctx
+
+
+class RecoverUnknownLengthTests(unittest.IsolatedAsyncioTestCase):
+    async def test_unknown_length_partial_file_preserves_bytes_on_recovery(self):
+        """
+        BUG: recover_incomplete_downloads resets downloaded_bytes=0 for every
+        incomplete DOWNLOADING record, including streams where the provider sent no
+        Content-Length (file_size=0).
+
+        Root cause: `and download.file_size` is falsy when file_size=0, so
+        is_complete is always False for unknown-length downloads. The code then
+        unconditionally resets downloaded_bytes=0, discarding partial progress.
+
+        For a near-the-window-edge recording this means: restart -> full re-download
+        required -> catchup window closes before re-download finishes -> recording lost.
+
+        Fix: when file_size==0 and a non-empty partial file exists on disk, set
+        downloaded_bytes to the actual on-disk size instead of resetting to 0.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x00" * 4096)
+            tmp_path = f.name
+        try:
+            download = MagicMock()
+            download.id = 42
+            download.status = DownloadStatus.DOWNLOADING.value
+            download.output_path = tmp_path
+            download.file_size = 0
+            download.downloaded_bytes = 4096
+            download.error_message = None
+
+            manager = DownloadManager()
+
+            with (
+                patch("services.download_manager.async_session_maker", _make_recovery_session([download])),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+                patch.object(manager, "_resolve_completed_folder", return_value="/tmp/completed_test"),
+                patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+            ):
+                await manager.recover_incomplete_downloads()
+
+            # The partial file has 4096 bytes on disk.
+            # After recovery the DB must reflect that, not 0.
+            self.assertEqual(
+                download.downloaded_bytes,
+                4096,
+                "downloaded_bytes must reflect the on-disk partial file size when "
+                "file_size=0 (unknown-length stream). Resetting to 0 loses progress "
+                "and forces a full re-download that may exceed the catchup window.",
+            )
+            self.assertEqual(
+                download.status,
+                DownloadStatus.PENDING.value,
+                "Unknown-length partial download must be requeued as PENDING.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_known_length_incomplete_still_resets_bytes(self):
+        """
+        When file_size is known (>0) but the download is incomplete, downloaded_bytes
+        should still be reset to 0. No regression from the fix.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x00" * 512)
+            tmp_path = f.name
+        try:
+            download = MagicMock()
+            download.id = 43
+            download.status = DownloadStatus.DOWNLOADING.value
+            download.output_path = tmp_path
+            download.file_size = 10000
+            download.downloaded_bytes = 512
+            download.error_message = None
+
+            manager = DownloadManager()
+
+            with (
+                patch("services.download_manager.async_session_maker", _make_recovery_session([download])),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+                patch.object(manager, "_resolve_completed_folder", return_value="/tmp/completed_test"),
+                patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+            ):
+                await manager.recover_incomplete_downloads()
+
+            self.assertEqual(
+                download.downloaded_bytes,
+                0,
+                "Known-length incomplete download must reset downloaded_bytes to 0.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_unknown_length_missing_file_resets_bytes(self):
+        """
+        When file_size=0 but no partial file exists on disk, downloaded_bytes resets
+        to 0 (nothing to preserve).
+        """
+        download = MagicMock()
+        download.id = 44
+        download.status = DownloadStatus.DOWNLOADING.value
+        download.output_path = "/tmp/nonexistent_recovery_stream_test.ts"
+        download.file_size = 0
+        download.downloaded_bytes = 1024
+        download.error_message = None
+
+        manager = DownloadManager()
+
+        with (
+            patch("services.download_manager.async_session_maker", _make_recovery_session([download])),
+            patch.object(manager, "_broadcast_log", AsyncMock()),
+            patch.object(manager, "_broadcast_progress", AsyncMock()),
+            patch.object(manager, "_resolve_completed_folder", return_value="/tmp/completed_test"),
+            patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+        ):
+            await manager.recover_incomplete_downloads()
+
+        self.assertEqual(
+            download.downloaded_bytes,
+            0,
+            "No partial file on disk: downloaded_bytes must reset to 0.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If your provider does not report how long a program's download will be (no Content-Length header), and you restarted the backend while a recording was in progress, the download would restart from the beginning. For a recording near the end of the provider's catchup window (say, 23 hours into a 24-hour archive), the re-download would not finish before the window closed, and the recording would fail.

After this fix, Mustarrd sends a Range request to the provider when resuming. If the provider supports it (HTTP 206), the download continues from where it left off: the partial file is kept, the byte counter shows cumulative progress, and the catchup window is no longer a problem. If the provider does not support Range (HTTP 200), Mustarrd falls back to downloading from the start, exactly as before, and logs a message explaining why.

## What changed

**Previously (the problem Cleo and Codex identified):** `recover_incomplete_downloads` set `downloaded_bytes` to the on-disk file size, but `_execute_download` immediately reset it to 0 and `_download_file` opened the output file with `'wb'` (truncating it), so the partial data was discarded and a full re-download was forced.

**Now:**
- `_execute_download` reads `downloaded_bytes` into `recovery_offset` before resetting it, then passes `offset=recovery_offset` to `_download_file`.
- `_download_file` accepts an `offset` parameter. When `offset > 0`, it sends `Range: bytes=<offset>-` in the request.
- **206 response:** provider supports resume. File opened in `'ab'` mode (append), `downloaded` counter starts at `offset`. The reported byte count is cumulative across the restart.
- **200 response:** provider ignores the Range header. File opened in `'wb'` mode (overwrite), `downloaded` starts at 0. Same behavior as before, plus a log message so operators know a resume was attempted.

## How it was tested

**Before:** `test_execute_download_passes_recovered_bytes_as_offset` would fail because `_download_file` was called with `offset=0`, discarding the recovery value.

**After:** 403 tests pass, including 6 new regression tests:

- `ExecuteDownloadOffsetTests.test_execute_download_passes_recovered_bytes_as_offset`: verifies `_execute_download` forwards `downloaded_bytes` as offset.
- `ExecuteDownloadOffsetTests.test_execute_download_passes_zero_offset_for_normal_download`: verifies no regression for normal (non-recovered) downloads.
- `DownloadFileRangeTests.test_range_header_sent_when_offset_nonzero`: verifies `Range: bytes=4096-` is sent.
- `DownloadFileRangeTests.test_206_response_appends_and_counts_from_offset`: verifies file is appended, return value is offset+new bytes.
- `DownloadFileRangeTests.test_200_response_restarts_when_range_not_honoured`: verifies fallback to `'wb'`, return value is new bytes only.
- `DownloadFileRangeTests.test_no_range_header_when_offset_zero`: verifies no Range header on normal downloads.

```
Ran 403 tests in 1.263s
OK
```