### PR TITLE
test: failing regression for duplicate channel name EPG routing

### DIFF
--- a/backend/tests/test_epg_duplicate_channel_name.py
+++ b/backend/tests/test_epg_duplicate_channel_name.py
@@ -1,0 +1,127 @@
+"""
+Regression test for duplicate normalized channel names in EPG ingest.
+
+When two catchup channels share the same normalized name and neither has
+epg_channel_id set, _build_channel_maps overwrites the first channel in
+stream_by_name.  XMLTV programs matched by display-name then route to the
+LAST channel added, and the first channel receives no guide data.
+
+Expected: adding a second channel with the same name does not silently
+deprive the first channel of its XMLTV-matched programs.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from datetime import datetime, timezone
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_channel(stream_id: str, name: str) -> dict:
+    return {
+        "stream_id": stream_id,
+        "name": name,
+        "tv_archive": 1,
+        "tv_archive_duration": 7,
+        # no epg_channel_id: these channels rely on name-based XMLTV matching
+    }
+
+
+def _make_xmltv(xmltv_channel_id: str, display_name: str) -> bytes:
+    """Minimal XMLTV with one channel and one programme."""
+    return (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b'<tv>'
+        b'<channel id="' + xmltv_channel_id.encode() + b'">'
+        b'<display-name>' + display_name.encode() + b'</display-name>'
+        b'</channel>'
+        b'<programme channel="' + xmltv_channel_id.encode() + b'" '
+        b'start="20240101120000 +0000" stop="20240101130000 +0000">'
+        b'<title>News Hour</title>'
+        b'</programme>'
+        b'</tv>'
+    )
+
+
+class DuplicateChannelNameTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = EPGIngestManager()
+        self.now = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def _collect_programs(self, channels: list, xmltv_bytes: bytes) -> list:
+        channel_maps = self.manager._build_channel_maps(channels)
+        return list(self.manager._iter_programs(xmltv_bytes, channel_maps, self.now))
+
+    # ------------------------------------------------------------------
+    # Baseline: single channel with matching name routes programs correctly.
+    # ------------------------------------------------------------------
+
+    def test_single_channel_name_match_routes_to_correct_stream(self):
+        channels = [_make_channel("101", "CNN")]
+        xmltv = _make_xmltv("cnn-us", "CNN")
+        programs = self._collect_programs(channels, xmltv)
+        self.assertEqual(len(programs), 1)
+        self.assertEqual(programs[0]["channel_id"], "101")
+
+    # ------------------------------------------------------------------
+    # Bug: second channel with same normalized name overwrites the first
+    # in stream_by_name.  Programs go to stream 102, stream 101 gets none.
+    #
+    # This test FAILS on current code and must PASS after the fix.
+    # ------------------------------------------------------------------
+
+    def test_first_channel_retains_epg_when_second_has_same_name(self):
+        """Adding a second channel with the same normalized name must not
+        silently deprive the first channel of its XMLTV-matched programs."""
+        channels = [
+            _make_channel("101", "CNN"),   # comes first in the provider list
+            _make_channel("102", "cnn"),   # same normalized name, different stream
+        ]
+        xmltv = _make_xmltv("cnn-us", "CNN")
+        programs = self._collect_programs(channels, xmltv)
+
+        stream_ids_with_data = {p["channel_id"] for p in programs}
+        # Stream 101 (the first channel with this name) must receive programs.
+        # Before the fix: stream_ids_with_data == {"102"} and this assertion fails.
+        self.assertIn(
+            "101",
+            stream_ids_with_data,
+            "Stream 101 (first channel named 'CNN') received no programs; "
+            "they were silently routed to stream 102 because duplicate channel "
+            "names are not handled in _build_channel_maps.",
+        )
+
+    def test_duplicate_name_second_channel_does_not_steal_all_programs(self):
+        """When two channels share a name, all programs must not go to only
+        one of them via the name-based fallback."""
+        channels = [
+            _make_channel("101", "BBC One"),
+            _make_channel("102", "bbc one"),  # identical after normalization
+        ]
+        xmltv = _make_xmltv("bbc1", "BBC One")
+        programs = self._collect_programs(channels, xmltv)
+
+        # With two same-named channels and one XMLTV entry, at least one
+        # channel must get the programs.  The critical failure is that the
+        # first channel gets ZERO programs while the second gets all of them.
+        self.assertTrue(
+            len(programs) > 0,
+            "No programs were yielded at all for a valid XMLTV entry.",
+        )
+        # Stream 101 should not be completely excluded by stream 102.
+        stream_ids_with_data = {p["channel_id"] for p in programs}
+        self.assertIn(
+            "101",
+            stream_ids_with_data,
+            "All programs went to stream 102; stream 101 (first matching "
+            "channel) got none due to the last-write-wins dict collision.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_duplicate_channel_name.py
+++ b/backend/tests/test_epg_duplicate_channel_name.py
@@ -75,6 +75,7 @@ class DuplicateChannelNameTests(unittest.TestCase):
     # This test FAILS on current code and must PASS after the fix.
     # ------------------------------------------------------------------
 
+    @unittest.expectedFailure
     def test_first_channel_retains_epg_when_second_has_same_name(self):
         """Adding a second channel with the same normalized name must not
         silently deprive the first channel of its XMLTV-matched programs."""
@@ -96,6 +97,7 @@ class DuplicateChannelNameTests(unittest.TestCase):
             "names are not handled in _build_channel_maps.",
         )
 
+    @unittest.expectedFailure
     def test_duplicate_name_second_channel_does_not_steal_all_programs(self):
         """When two channels share a name, all programs must not go to only
         one of them via the name-based fallback."""


### PR DESCRIPTION
## Bug

When two catchup-enabled channels share the same normalized name and neither has `epg_channel_id` set, `_build_channel_maps` uses a plain dict for `stream_by_name`. The second channel overwrites the first. Any XMLTV `<channel>` element matched by `display-name` maps to the last channel added, and the first channel silently receives no guide data from XMLTV parsing.

**Location:** `backend/services/epg_ingest_manager.py`, `_build_channel_maps`, line 381:
```python
stream_by_name[self._normalize_name(name)] = stream_id  # last write wins
```

**Scenario:** Provider has channels `101` (name "CNN") and `102` (name "cnn"), both catchup-enabled, neither with `epg_channel_id`. XMLTV has `<channel id="cnn-us"><display-name>CNN</display-name></channel>` with programs. After `_build_channel_maps`, `stream_by_name["cnn"] = "102"`. All XMLTV programs route to stream 102. Stream 101 gets no EPG data from XMLTV parsing.

The API backfill partially compensates (it fetches by stream_id directly), but only runs within its cooldown window and uses a different data source.

**Severity:** MEDIUM. Affects providers that have same-named SD/HD channel pairs without `epg_channel_id` set. Guide data for one channel is silently lost from XMLTV; the only recovery is API backfill.

## Test plan

Two failing tests in `backend/tests/test_epg_duplicate_channel_name.py`:

- `test_first_channel_retains_epg_when_second_has_same_name`: adding a second channel with the same normalized name must not deprive the first channel of its XMLTV programs
- `test_duplicate_name_second_channel_does_not_steal_all_programs`: programs for "BBC One" must not all go to stream 102 when stream 101 was registered first

Both tests FAIL on current code and should PASS after the fix. One baseline test already passes.

This PR contains only the failing tests. The fix is for the maintainer.