### PR TITLE
[Design] Rename Active/Inactive badge to Enabled/Disabled on account cards

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -143,7 +143,7 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
             </Badge>
           )}
           <Badge color={account.is_active ? 'green' : 'gray'} variant="light">
-            {account.is_active ? 'Active' : 'Inactive'}
+            {account.is_active ? 'Enabled' : 'Disabled'}
           </Badge>
           <Menu shadow="md" width={150}>
             <Menu.Target>


### PR DESCRIPTION
## What changed

The account card badge labeled **Active** (green) sat directly above a **Unreachable** (red dot) connection status indicator. For a non-technical operator, these two signals are contradictory: the green badge reads as "this is working" while the red dot says "it is not."

The badge describes whether the account is enabled in Mustarrd, not whether the provider connection is live. Renaming it to **Enabled** (or **Disabled** when off) makes that meaning explicit, and removes the contradiction.

**Before:** "ACTIVE" + "Unreachable" — operator cannot tell which one to trust.

**After:** "ENABLED" + "Unreachable" — operator reads: the account is turned on, but the connection is currently failing.

Before/after screenshots in #design.

## Change

One-line change in `frontend/src/components/settings/AccountsSection.jsx`. No logic touched.

## Test plan

- [ ] Account with a working connection shows **Enabled** + **Connected** (green)
- [ ] Account with a failed connection shows **Enabled** + **Unreachable** (red) — no contradiction
- [ ] Disabled account (is_active=false) shows **Disabled** (gray)