### PR TITLE
docs: update feature list to reflect Recording Format dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mustarrd connects to your IPTV provider and lets you download past programs. Thi
 
 - **Browse past programs:** scroll back through your provider's program guide (EPG) and see what's available to download
 - **Commercial skip:** ComSkip integration removes commercials before saving
-- **Remux to MKV:** TS playback sucks. MKV is a much easier container to skip through
+- **Flexible output formats:** save recordings as-is (.ts), remux to MKV or MP4, or re-encode with FFmpeg for smaller files
 - **Download from On Demand:** If your provider provides on demand listings, you can grab those too!
 - **Scheduled recordings:** set programs to download automatically when they air
 - **Smart file naming:** TV shows, movies, and sports get automatically named in the right format (`Breaking Bad - S01E01 - Pilot.ts`, `The Matrix (1999).ts`, etc.)


### PR DESCRIPTION
## What an operator would notice

The README Features list said "Remux to MKV" which no longer describes what is available. PR #112 replaced four separate Settings toggles (Enable Transcoding, Remux Only, Enable ComSkip, Transcode Format) with a single "Recording Format" dropdown. The dropdown offers MKV container, MP4 container, MKV re-encode, MP4 re-encode, and ComSkip variants. A user reading "Remux to MKV" would not know MP4 is also an option.

## What changed

One line in the README Features list. "Remux to MKV" is now "Flexible output formats: save recordings as-is (.ts), remux to MKV or MP4, or re-encode with FFmpeg for smaller files."

## How it was tested

Verified against PR #112 merged behavior and the current Settings.jsx Recording Format dropdown options. Docs-only change, no code touched.