### PR TITLE
docs: add changelog entries for PR #132 and PR #134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Account cards now say "Enabled" and "Disabled" instead of "Active" and "Inactive"
+
+**What you would notice:** The status badge on each account card used to read "ACTIVE" in green when an account was turned on. This sat next to the red "Unreachable" dot that appears when Mustarrd cannot reach your provider. Seeing a green "ACTIVE" badge next to a red failure dot was confusing: the green badge looked like everything was working, but the red dot said it was not. The badge now reads "ENABLED" when the account is turned on, and "DISABLED" when it is turned off. "Enabled" describes whether the account is switched on in Mustarrd, not whether the connection to your provider is currently working. The red "Unreachable" dot separately tells you about the connection.
+
+**What changed:** The label on the account status badge was updated to use "Enabled" and "Disabled" instead of "Active" and "Inactive." Colors and behavior are unchanged.
+
+---
+
 ### Fixed: Settings no longer accepts negative recording padding values
 
 **What you would notice:** Before this fix, you could save a negative number for "Default pre-padding" or "Default post-padding" in Settings and Mustarrd would silently accept it. A negative padding value shifted the recording start time in the wrong direction and shortened the captured duration, causing recordings to miss content or fail without any clear explanation. Mustarrd now rejects negative values immediately and returns an error, so your padding settings always behave as expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Low disk space badge on Downloads now matches the Scheduled page
+
+**What you would notice:** When a recording is paused because your drive is running low on space, the Downloads page showed an orange badge reading "LOW DISK SPACE" with no icon. The Scheduled page showed the same paused recording as a yellow "PAUSED (LOW SPACE)" badge with an alert icon. The two pages were describing the same condition in two different ways. Both pages now show "PAUSED (LOW SPACE)" in yellow with an alert icon, so you always see the same label no matter which page you check.
+
+**What changed:** The badge label and color on the Downloads page Upcoming tab now match the Scheduled page for recordings paused due to low disk space. No recording behavior was changed.
+
+---
+
 ### Improved: Account cards now say "Enabled" and "Disabled" instead of "Active" and "Inactive"
 
 **What you would notice:** The status badge on each account card used to read "ACTIVE" in green when an account was turned on. This sat next to the red "Unreachable" dot that appears when Mustarrd cannot reach your provider. Seeing a green "ACTIVE" badge next to a red failure dot was confusing: the green badge looked like everything was working, but the red dot said it was not. The badge now reads "ENABLED" when the account is turned on, and "DISABLED" when it is turned off. "Enabled" describes whether the account is switched on in Mustarrd, not whether the connection to your provider is currently working. The red "Unreachable" dot separately tells you about the connection.


### PR DESCRIPTION
## What changed

Two design PRs merged since the last CHANGELOG update. This PR adds their entries.

**PR #132** (Rename Active/Inactive badge to Enabled/Disabled on account cards): Account status badge label updated.

**PR #134** (Align low-space badge on Downloads with Scheduled page): Downloads > Upcoming tab low disk space badge now matches the Scheduled page in label, color, and icon.

Entries added at the top of the 2026-06-07 section, most-recent-first.

## How it was tested

Checked both entries for: no em dashes, plain-English wording, correct date, most-recent-first ordering, and `---` separators per convention.