### PR TITLE
[Design] Wrap recording title instead of truncating on narrow screens

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -126,7 +126,7 @@ function DownloadCard({
       <Stack gap="xs">
         <Group justify="space-between" wrap="nowrap">
           <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
-            <Text fw={500} truncate>
+            <Text fw={500}>
               {download.program_title}
             </Text>
             <Text size="sm" c="dimmed" truncate>

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -101,7 +101,7 @@ function ScheduleCard({
       <Stack gap="xs">
         <Group justify="space-between" wrap="nowrap">
           <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
-            <Text fw={500} truncate>
+            <Text fw={500}>
               {schedule.program_title}
             </Text>
             <Text size="sm" c="dimmed" truncate>


### PR DESCRIPTION
## What operators will notice

On phone screens, recording titles that share a row with a wide badge were cut off with "..." making it impossible to tell which show was affected. After this fix, the title wraps to a second line so the full show name is always readable.

## What changed

Removed `truncate` from the program title `Text` in `ScheduleCard` (Scheduled page) and `DownloadCard` (Downloads page). One-line change in each file. No logic touched.

## Before (mobile)

The Scheduled page showed "Great British ..." when the "Paused (Low Space)" badge took up horizontal space. A non-technical operator cannot identify which show is paused.

## After (mobile)

The title wraps: "Great British / Bake Off" on two lines. Full show name is visible. Badge and menu remain aligned to the right.

## Desktop

No visible change on desktop. Show titles fit on one line at 1280px width, so wrapping never triggers.

## How it was tested

- Started app locally, captured before and after screenshots at 390x844 (mobile) and 1280x800 (desktop).
- Before: "Great British ..." on Scheduled mobile.
- After: "Great British Bake Off" wraps cleanly, badge stays right-aligned.