### PR TITLE
docs: add changelog entries for PRs #130, #136, and #137; fix stale README badge color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Show titles no longer get cut off on phones
+
+**What you would notice:** On phone screens, if a show title was long and shared a row with a wide badge (like "PAUSED (LOW SPACE)"), the title was cut off with "..." making it impossible to read the full name. The title now wraps to a second line so the full show name is always visible.
+
+**What changed:** The program title on the Scheduled and Downloads pages now wraps instead of truncating when there is not enough horizontal space. No visual change on desktop screens.
+
+---
+
+### Fixed: Hardware-accelerated transcoding no longer overwrites recordings with empty files
+
+**What you would notice:** If you had Transcoding turned on with the output format set to TS and hardware acceleration turned on (VAAPI, NVIDIA, AMD, or Apple Silicon), every completed recording was silently overwritten with a 0-byte empty file. The download looked done in the UI but the file on disk was empty. This did not affect users with hardware acceleration set to CPU, or users saving to MKV or MP4.
+
+**What changed:** When the output format is already TS (the same format as the source file), Mustarrd no longer runs FFmpeg at all. The file is left as-is. This was always the correct behavior: copying a TS file to itself with stream copy produces an empty file. The CPU code path happened to avoid this bug, but any hardware-accelerated path triggered it.
+
+---
+
+### Fixed: Resuming an interrupted download no longer starts over from the beginning
+
+**What you would notice:** If the backend restarted while a recording was in progress and your provider did not report how long the download would be, the download would always restart from byte zero. For a recording close to the end of your provider's catchup window, re-downloading from scratch could cause the window to close before the file was complete. Mustarrd now sends a Range request to your provider when resuming. If the provider supports it (most do), the download picks up from where it left off. If the provider does not support resuming, Mustarrd falls back to starting over and logs a message explaining why.
+
+**What changed:** When recovering an in-progress download, Mustarrd now sends a `Range: bytes=<offset>-` header to request only the remaining portion. If the provider responds with HTTP 206, the existing partial file is kept and bytes are appended from the saved position. If the provider responds with HTTP 200 (ignoring the Range header), Mustarrd falls back to a full re-download, same as before.
+
+---
+
 ### Improved: Low disk space badge on Downloads now matches the Scheduled page
 
 **What you would notice:** When a recording is paused because your drive is running low on space, the Downloads page showed an orange badge reading "LOW DISK SPACE" with no icon. The Scheduled page showed the same paused recording as a yellow "PAUSED (LOW SPACE)" badge with an alert icon. The two pages were describing the same condition in two different ways. Both pages now show "PAUSED (LOW SPACE)" in yellow with an alert icon, so you always see the same label no matter which page you check.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then open **http://localhost:4177** in your browser.
 ### Monitor Downloads
 
 - Go to the **Downloads** page to see active downloads with progress bars
-- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show an orange badge explaining why
+- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - Failed downloads can be retried from the same page


### PR DESCRIPTION
## What a user would notice

The changelog now covers three fixes and improvements that merged since the last docs update. One stale description in the README was also corrected.

## Changes

**CHANGELOG.md** - Three new entries added under 2026-06-07:

- **PR #130 (fix):** Resuming an interrupted download no longer starts over from the beginning. Mustarrd now sends a Range request when recovering a partial download. If the provider supports it, the file continues from where it left off. If not, it falls back to a full re-download as before.
- **PR #136 (fix):** Hardware-accelerated transcoding (VAAPI, NVIDIA, AMD, Apple Silicon) with output format TS no longer silently overwrites recordings with empty files. Mustarrd now skips FFmpeg entirely for TS-to-TS output, which is always a no-op.
- **PR #137 (design):** Show titles on the Scheduled and Downloads pages now wrap to a second line on narrow screens instead of being cut off with "...".

**README.md** - Fixed one stale line in the "Monitor Downloads" section. The Upcoming tab low-space badge was described as "an orange badge" but PR #134 changed it to a yellow "PAUSED (LOW SPACE)" badge with an alert icon. Updated to match.

## How it was tested

Verified changelog entries against each PR description. Confirmed no em dashes in any changed text. README diff visually reviewed against the current UI badge appearance from PR #134.