### PR TITLE
[Design] Fix Post-Processing section labels: split Concurrency from Recording Format

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -793,7 +793,7 @@ export default function Settings() {
         <Divider variant="dashed" />
 
         <Stack gap="md">
-          <Text size="xs" fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: '0.06em' }}>Recording Format</Text>
+          <Text size="xs" fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: '0.06em' }}>Concurrency</Text>
 
           <NumberInput
             label="Max Concurrent Post-Processing"
@@ -812,6 +812,12 @@ export default function Settings() {
               </Text>
             </Alert>
           )}
+        </Stack>
+
+        <Divider variant="dashed" />
+
+        <Stack gap="md">
+          <Text size="xs" fw={600} c="dimmed" tt="uppercase" style={{ letterSpacing: '0.06em' }}>Recording Format</Text>
 
           <Select
             label="Recording Format"


### PR DESCRIPTION
## What changed

Settings > Post-Processing had a "RECORDING FORMAT" section label that incorrectly grouped "Max Concurrent Post-Processing" with the format controls. A non-technical operator looking for how to change their output format would find a parallelism setting sitting inside that section with no obvious relationship to format.

The fix splits the section into two, matching the pattern already used in Settings > Recording:

- **CONCURRENCY**: Max Concurrent Post-Processing (how many files are processed at once)
- **RECORDING FORMAT**: Recording Format dropdown, Hardware Acceleration, Delete original, ComSkip settings

One file changed: `frontend/src/pages/Settings.jsx`. No logic touched.

## Before

"Max Concurrent Post-Processing" sat under the "RECORDING FORMAT" label, appearing to be a format setting.

## After

"Max Concurrent Post-Processing" is under its own "CONCURRENCY" label. "RECORDING FORMAT" covers only the format-related controls. A divider separates the two sections.

See before/after screenshots in #design.

## How it was tested

Ran the app locally, navigated to Settings > Post-Processing at 1280px and 390px. Before/after screenshots in #design. No backend tests needed (frontend-only layout change, no logic touched).