### PR TITLE
test: failing regression for 206 without Content-Range false resume

### DIFF
--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -384,5 +384,71 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
+    @unittest.expectedFailure
+    async def test_206_no_content_range_falls_back_to_restart(self):
+        """
+        BUG: A 206 response with no Content-Range header causes false resume.
+
+        Root cause: when the server returns 206 but omits the Content-Range header,
+        range_start stays None.  The mismatch guard is:
+            range_mismatch = range_start is not None and range_start != offset
+        Since range_start is None, range_mismatch is False, so resuming evaluates to
+        True.  The file is opened in 'ab' mode even though we have no confirmation
+        that the server is sending from the right position.  A buggy or proxied IPTV
+        provider that returns 206 from byte 0 (without Content-Range) would cause the
+        partial file to grow from offset+0 to offset+server_full_size, producing a
+        corrupt recording.
+
+        Expected fix: treat absent Content-Range as "position unknown" and fall back
+        to restart ('wb', downloaded=0), the same as a Content-Range mismatch.
+        Guard should be:
+            resuming = status==206 and offset>0 and range_start is not None
+                       and range_start == offset
+        """
+        existing = b"\x00" * 4096
+        # Provider returns 206 but NO Content-Range header (RFC violation, common in
+        # cheap IPTV catchup implementations and some transparent proxies).
+        new_data = b"\x47" * 512
+        response = _make_aiohttp_response(206, [new_data])  # content_range=None
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(existing)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                )
+
+            # Must fall back to restart: file overwritten, return value is only new bytes.
+            self.assertEqual(
+                total,
+                512,
+                "206 with no Content-Range must restart (return new bytes only, not offset+new). "
+                "Currently returns 4096+512 because range_start=None bypasses the mismatch guard, "
+                "treating absent Content-Range as a confirmed resume.",
+            )
+            with open(tmp_path, "rb") as fh:
+                contents = fh.read()
+            self.assertEqual(
+                contents,
+                new_data,
+                "File must be overwritten when Content-Range is absent, not appended. "
+                "Currently the partial file is opened 'ab' and the server's bytes "
+                "(from an unknown position) are appended, corrupting the recording.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What the operator notices

After a power cut or restart mid-download, a partially-downloaded catchup recording resumes instead of being corrupted. PR #130 shipped that fix. But a specific class of flaky IPTV provider can still corrupt the file on resume.

## Bug

When an IPTV catchup server responds to a Range request with HTTP 206 but **omits the Content-Range header** (an RFC 7233 violation that some cheap catchup implementations and transparent proxies do produce), the PR #130 resume guard silently passes:

```python
range_mismatch = range_start is not None and range_start != offset
# range_start is None (no header) => range_mismatch = False
resuming = response.status == 206 and offset > 0 and not range_mismatch
# => resuming = True, even though we have no position confirmation
```

The file is opened in `'ab'` mode. If the provider is actually sending from byte 0, the partial file grows from `offset` to `offset + full_size`, producing a corrupt `.ts` file that Plex and Jellyfin will reject.

## Reproduction steps

1. Start a large catchup download (unknown-length stream, no Content-Length).
2. Kill Mustarrd mid-download. A partial `.ts` file exists on disk.
3. Configure a mock provider that responds to Range requests with `HTTP 206` and no `Content-Range` header (sends the full stream from byte 0).
4. Restart Mustarrd.
5. The partial file is opened `'ab'` and the full stream is appended. Resulting file is `partial_size + full_size` bytes and plays as garbage.

**Expected:** treat absent Content-Range as "position unknown" and fall back to restart (`'wb'`, `downloaded=0`), same as a Content-Range start mismatch.

**Actual:** file is appended and returned as completed. Corrupt recording stored.

## Fix (not in this PR)

Change the resume guard in `_download_file`:

```python
# before
resuming = response.status == 206 and offset > 0 and not range_mismatch
# after
resuming = response.status == 206 and offset > 0 and range_start is not None and range_start == offset
```

## This PR

Adds one `@unittest.expectedFailure` test (`test_206_no_content_range_falls_back_to_restart`) to `test_download_file_range.py`. The test proves the bug is present (the code appends instead of restarting). Marked expected failure so CI stays green on main until the fix lands.

413 tests pass, 3 expected failures.