### PR TITLE
[Design] Wrap upcoming recording title instead of truncating

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -644,7 +644,7 @@ export default function Downloads() {
                 <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
                   <Group justify="space-between" wrap="nowrap">
                     <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
-                      <Text fw={500} truncate>{rec.program_title}</Text>
+                      <Text fw={500}>{rec.program_title}</Text>
                       <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
                       <Group gap="xs">
                         <Text size="xs" c="dimmed">


### PR DESCRIPTION
## What changed

Downloads > Upcoming tab program titles now wrap to a second line instead of being cut off.

## Why

PR #137 removed `truncate` from program titles on the Scheduled Recordings page so long show names are always readable. The same fix was not applied to the Upcoming tab in Downloads.jsx. A long title like "EastEnders: The Final Farewell to Albert Square - Special Christmas Episode" appeared as "EastEnders: The Final Farewell to Albert S..." on mobile.

## What an operator will notice

On the Downloads > Upcoming tab, long show titles now wrap to a second line instead of being cut off. Short titles are unchanged.

## Change

One word removed from Downloads.jsx line 647: `truncate` removed from the program title Text component. Channel name keeps `truncate` since it is secondary info. No logic touched.

## How it was tested

Playwright screenshots at 390px mobile width with a long title. Before: title truncated. After: title wraps. Before/after screenshots in #design.