### PR TITLE
docs: add changelog entries for PRs #140 and #143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-07
 
+### Improved: Settings now groups post-processing options under clearer headings
+
+**What you would notice:** In Settings, the Post-Processing section previously showed "Max Concurrent Post-Processing" under a heading labelled "RECORDING FORMAT," which made it look like a format setting when it is not. The concurrent jobs control now lives under its own "CONCURRENCY" heading, and "RECORDING FORMAT" covers only the format-related options (output format, hardware acceleration, delete original, and ComSkip settings). The options themselves are unchanged; only the grouping is clearer.
+
+**What changed:** The Settings > Post-Processing page now has two distinct section headings: "CONCURRENCY" above the concurrent jobs control, and "RECORDING FORMAT" above the format controls. No behavior was changed.
+
+---
+
 ### Improved: Show titles no longer get cut off on phones
 
 **What you would notice:** On phone screens, if a show title was long and shared a row with a wide badge (like "PAUSED (LOW SPACE)"), the title was cut off with "..." making it impossible to read the full name. The title now wraps to a second line so the full show name is always visible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Improved: Long show titles in Downloads > Upcoming no longer get cut off on phones
+
+**What you would notice:** On phone screens, long show titles on the Downloads > Upcoming tab were still being cut off with "..." after an earlier fix covered the Scheduled page and the Downloads list view. The Upcoming tab now wraps titles to a second line so the full show name is always readable.
+
+**What changed:** Program titles on the Downloads > Upcoming tab now wrap instead of truncating on narrow screens. No visual change on desktop screens.
+
+---
+
 ### Improved: Show titles no longer get cut off on phones
 
 **What you would notice:** On phone screens, if a show title was long and shared a row with a wide badge (like "PAUSED (LOW SPACE)"), the title was cut off with "..." making it impossible to read the full name. The title now wraps to a second line so the full show name is always visible.


### PR DESCRIPTION
## What changed

Adds changelog entries for two merged PRs:

- **PR #140:** Settings > Post-Processing now groups options under clearer headings (CONCURRENCY and RECORDING FORMAT split apart).
- **PR #143:** Long show titles in Downloads > Upcoming tab now wrap on narrow screens instead of getting cut off. This tab was missed when the Scheduled page and Downloads list view received the same fix in PR #137.

## What a user would notice

The changelog explains both changes in plain English for operators who are not programmers.

## How it was tested

Diff confirmed both entries match what the PRs actually shipped. No em dashes used.