### PR TITLE
[Design] Drop redundant 0m from whole-hour durations

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -59,7 +59,7 @@ function formatDuration(minutes) {
   const hours = d.hours()
   const mins = d.minutes()
   if (hours > 0) {
-    return `${hours}h ${mins}m`
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
   }
   return `${mins}m`
 }

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -43,7 +43,7 @@ function formatDuration(minutes) {
   const hours = d.hours()
   const mins = d.minutes()
   if (hours > 0) {
-    return `${hours}h ${mins}m`
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
   }
   return `${mins}m`
 }


### PR DESCRIPTION
## What changed

Recording durations that are exactly N hours used to display as "1h 0m". The trailing "0m" adds no information. This PR removes it so those durations now show as "1h". Mixed-minute durations ("1h 30m", "30m") are unchanged.

## Why

A non-technical user sees "Coronation Street (1h 0m)" and might wonder if the "0m" means something. "1h" says the same thing with less noise.

## What a user would notice

**Before:** Scheduled Recordings shows "Airs: Jun 9, 2026 8:00 PM - 9:00 PM (1h 0m)" and "Download starts: ... (1h 0m recording)". Downloads > Upcoming shows "(1h 0m)".

**After:** Same rows show "(1h)" and "(1h recording)". Recordings with partial hours like "1h 30m" are not affected.

## Files changed

- `frontend/src/pages/Downloads.jsx` - one-line change in formatDuration
- `frontend/src/pages/Scheduled.jsx` - identical one-line change in formatDuration

No logic touched. No backend changes.

## How it was tested

Started the full stack locally (backend on 4177, frontend on 4178) and used Playwright to capture before and after screenshots at 1280x800 desktop and 390x844 mobile. Before/after screenshots posted in #design.