### PR TITLE
fix: treat absent Content-Range on 206 as restart, not resume

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1039,7 +1039,12 @@ class DownloadManager:
                 # If Content-Range is present but starts elsewhere, the provider silently
                 # returned data from a different position; appending would corrupt the file.
                 range_mismatch = range_start is not None and range_start != offset
-                resuming = response.status == 206 and offset > 0 and not range_mismatch
+                resuming = (
+                    response.status == 206
+                    and offset > 0
+                    and range_start is not None
+                    and range_start == offset
+                )
 
                 if total_size > 0:
                     await self._broadcast_log(

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -988,6 +988,77 @@ class DownloadManager:
         except Exception:
             pass
 
+    async def _stream_response_to_file(
+        self,
+        response,
+        output_path: str,
+        file_mode: str,
+        downloaded_start: int,
+        total_size: int,
+        download_id: int,
+        session: AsyncSession,
+    ) -> int:
+        """Write the body of *response* to *output_path* and return total bytes accumulated.
+
+        *downloaded_start* is added to the byte counter before the first write so
+        a resumed download reports cumulative progress from the start of the file.
+        """
+        if total_size > 0:
+            await self._broadcast_log(
+                download_id,
+                f"HTTP {response.status}. Expected size: {total_size:,} bytes."
+            )
+        else:
+            await self._broadcast_log(
+                download_id,
+                f"HTTP {response.status}. Size unknown; streaming download."
+            )
+
+        downloaded = downloaded_start
+        last_progress_update = 0
+
+        async with aiofiles.open(output_path, file_mode) as f:
+            async for chunk in response.content.iter_chunked(1024 * 1024):  # 1MB chunks
+                if download_id in self._cancelled:
+                    raise asyncio.CancelledError()
+
+                await f.write(chunk)
+                downloaded += len(chunk)
+
+                if total_size > 0:
+                    progress = (downloaded / total_size) * 100
+                else:
+                    progress = 0
+
+                if progress - last_progress_update >= 1 or downloaded == total_size:
+                    last_progress_update = progress
+
+                    await session.execute(
+                        update(Download)
+                        .where(Download.id == download_id)
+                        .values(
+                            progress=progress,
+                            downloaded_bytes=downloaded,
+                            file_size=total_size
+                        )
+                    )
+                    await session.commit()
+
+                    await self._broadcast_progress(
+                        download_id,
+                        progress,
+                        DownloadStatus.DOWNLOADING.value,
+                        downloaded_bytes=downloaded,
+                        file_size=total_size,
+                        download_progress=progress
+                    )
+
+        await self._broadcast_log(
+            download_id,
+            f"Download bytes written: {downloaded:,}."
+        )
+        return downloaded
+
     async def _download_file(
         self,
         url: str,
@@ -999,10 +1070,11 @@ class DownloadManager:
         """Stream download a file with progress tracking.
 
         If *offset* is non-zero a ``Range: bytes=<offset>-`` header is sent.
-        A 206 response means the server honours the range; the existing partial
-        file is appended to and *downloaded* starts at *offset* so the reported
-        byte count is cumulative.  A 200 response means the server ignored the
-        range; the file is truncated and the download starts from scratch.
+        A 206 response with a matching Content-Range is resumed (``ab`` mode).
+        A 200 response (server ignored Range) re-downloads from byte 0 (``wb``).
+        A 206 whose start position cannot be confirmed (absent or mismatched
+        Content-Range) releases the connection and issues a fresh GET without the
+        Range header so the written file always starts from a known byte 0.
         """
         timeout = aiohttp.ClientTimeout(total=None, sock_read=60)
 
@@ -1011,6 +1083,8 @@ class DownloadManager:
             request_headers["Range"] = f"bytes={offset}-"
 
         async with aiohttp.ClientSession(timeout=timeout) as http_session:
+            needs_restart = False
+
             async with http_session.get(url, headers=request_headers) as response:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
@@ -1046,86 +1120,53 @@ class DownloadManager:
                     and range_start == offset
                 )
 
-                if total_size > 0:
-                    await self._broadcast_log(
-                        download_id,
-                        f"HTTP {response.status}. Expected size: {total_size:,} bytes."
-                    )
+                if response.status == 206 and offset > 0 and not resuming:
+                    # The 206 body starts at an unknown or wrong offset, not byte 0.
+                    # Writing it with 'wb' would produce a silently truncated file.
+                    # Release this connection without reading the body, then re-request
+                    # from byte 0 with no Range header.
+                    needs_restart = True
+                    if range_mismatch:
+                        await self._broadcast_log(
+                            download_id,
+                            f"Provider returned Content-Range start {range_start:,} "
+                            f"instead of requested {offset:,}; re-requesting from start."
+                        )
+                    else:
+                        await self._broadcast_log(
+                            download_id,
+                            "Provider returned 206 without Content-Range; re-requesting from start."
+                        )
                 else:
-                    await self._broadcast_log(
-                        download_id,
-                        f"HTTP {response.status}. Size unknown; streaming download."
-                    )
-
-                if resuming:
-                    downloaded = offset
-                    file_mode = "ab"
-                    await self._broadcast_log(
-                        download_id,
-                        f"Resuming from byte {offset:,}."
-                    )
-                else:
-                    downloaded = 0
-                    file_mode = "wb"
-                    if offset > 0:
-                        if range_mismatch:
-                            await self._broadcast_log(
-                                download_id,
-                                f"Provider returned Content-Range start {range_start:,} "
-                                f"instead of requested {offset:,}; re-downloading from start."
-                            )
-                        else:
+                    if resuming:
+                        await self._broadcast_log(
+                            download_id,
+                            f"Resuming from byte {offset:,}."
+                        )
+                        return await self._stream_response_to_file(
+                            response, output_path, "ab", offset,
+                            total_size, download_id, session
+                        )
+                    else:
+                        if offset > 0:
                             await self._broadcast_log(
                                 download_id,
                                 "Provider did not honour Range request; re-downloading from start."
                             )
+                        return await self._stream_response_to_file(
+                            response, output_path, "wb", 0,
+                            total_size, download_id, session
+                        )
 
-                last_progress_update = 0
-
-                async with aiofiles.open(output_path, file_mode) as f:
-                    async for chunk in response.content.iter_chunked(1024 * 1024):  # 1MB chunks
-                        # Check for cancellation
-                        if download_id in self._cancelled:
-                            raise asyncio.CancelledError()
-
-                        await f.write(chunk)
-                        downloaded += len(chunk)
-
-                        # Update progress every 1%
-                        if total_size > 0:
-                            progress = (downloaded / total_size) * 100
-                        else:
-                            progress = 0
-
-                        if progress - last_progress_update >= 1 or downloaded == total_size:
-                            last_progress_update = progress
-
-                            # Update database
-                            await session.execute(
-                                update(Download)
-                                .where(Download.id == download_id)
-                                .values(
-                                    progress=progress,
-                                    downloaded_bytes=downloaded,
-                                    file_size=total_size
-                                )
-                            )
-                            await session.commit()
-
-                            # Broadcast progress
-                            await self._broadcast_progress(
-                                download_id,
-                                progress,
-                                DownloadStatus.DOWNLOADING.value,
-                                downloaded_bytes=downloaded,
-                                file_size=total_size,
-                                download_progress=progress
-                            )
-                await self._broadcast_log(
-                    download_id,
-                    f"Download bytes written: {downloaded:,}."
+            # Only reached when needs_restart is True: re-request from byte 0.
+            async with http_session.get(url) as response:
+                if response.status not in (200, 206):
+                    raise Exception(f"HTTP {response.status}: {response.reason}")
+                total_size = response.content_length or 0
+                return await self._stream_response_to_file(
+                    response, output_path, "wb", 0,
+                    total_size, download_id, session
                 )
-                return downloaded
 
     async def _post_process(
         self,

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -71,6 +71,28 @@ def _make_aiohttp_client_session(response):
     return mock_session, client_cm
 
 
+def _make_aiohttp_client_session_multi(responses):
+    """Return (mock_session, patch_target) yielding successive responses on each get() call."""
+    call_index = [0]
+
+    def get_side_effect(*args, **kwargs):
+        idx = call_index[0]
+        call_index[0] += 1
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=responses[idx])
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    mock_session = MagicMock()
+    mock_session.get.side_effect = get_side_effect
+
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_session, client_cm
+
+
 def _make_db_session():
     session = AsyncMock()
     session.execute = AsyncMock()
@@ -309,17 +331,25 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
         finally:
             os.unlink(tmp_path)
 
-    async def test_206_content_range_start_mismatch_restarts(self):
+    async def test_206_content_range_start_mismatch_restarts_from_byte_0(self):
         """
-        A 206 response where Content-Range start != requested offset means the provider
-        returned data from the wrong position. _download_file must fall back to 'wb'
-        mode and restart from 0 rather than appending corrupted data.
+        206 with Content-Range starting at the wrong offset: release the partial
+        body and re-request from byte 0 instead of writing the mismatched tail.
+
+        The mismatched 206 body starts at a position the server chose, not byte 0.
+        Writing it with 'wb' would truncate the file to only the tail fragment.
+        The fix re-requests without a Range header to get the full stream from byte 0.
         """
-        existing = b"\x00" * 4096
-        # Provider returns 206 but Content-Range says it started at byte 0, not 4096
-        new_data = b"\x47" * 512
-        response = _make_aiohttp_response(206, [new_data], content_range="bytes 0-511/10000")
-        _mock_session, client_cm = _make_aiohttp_client_session(response)
+        offset = 4096
+        existing = b"\x00" * offset
+        tail = b"\x47" * 512           # bytes the mismatched 206 would send
+        full_content = existing + tail  # expected final file after restart
+
+        # Provider returns 206 claiming start=0 instead of the requested 4096
+        response_206 = _make_aiohttp_response(206, [tail], content_range="bytes 0-511/10000")
+        # Restart GET returns the full stream from byte 0
+        response_200 = _make_aiohttp_response(200, [full_content])
+        _mock_session, client_cm = _make_aiohttp_client_session_multi([response_206, response_200])
 
         manager = DownloadManager()
         db_session = _make_db_session()
@@ -335,19 +365,21 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
                 patch.object(manager, "_broadcast_progress", AsyncMock()),
             ):
                 total = await manager._download_file(
-                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
                 )
 
-            # Must restart: return value is only new bytes (no offset added)
             self.assertEqual(
                 total,
-                512,
-                "Content-Range start mismatch must trigger restart; return value must not include offset.",
+                len(full_content),
+                "Content-Range mismatch must trigger restart; return value is full content length.",
             )
-            # File must be overwritten (truncated), not appended
             with open(tmp_path, "rb") as fh:
                 contents = fh.read()
-            self.assertEqual(contents, new_data, "File must be overwritten when Content-Range start != offset.")
+            self.assertEqual(
+                contents,
+                full_content,
+                "File must contain full content from byte 0 after restart, not just the mismatched tail.",
+            )
         finally:
             os.unlink(tmp_path)
 
@@ -384,32 +416,30 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
-    async def test_206_no_content_range_falls_back_to_restart(self):
+    async def test_206_no_content_range_restarts_from_byte_0(self):
         """
-        A 206 response with no Content-Range header must fall back to restart ('wb').
+        206 with no Content-Range: abandon the partial body and re-request from
+        byte 0 so the written file contains the full stream, not just the tail.
 
-        When the server returns 206 but omits the Content-Range header, range_start
-        stays None.  Without the fix, the mismatch guard was:
-            range_mismatch = range_start is not None and range_start != offset
-        Since range_start is None, range_mismatch is False, so resuming evaluates to
-        True.  The file is opened in 'ab' mode even though we have no confirmation
-        that the server is sending from the right position.  A buggy or proxied IPTV
-        provider that returns 206 from byte 0 (without Content-Range) would cause the
-        partial file to grow from offset+0 to offset+server_full_size, producing a
-        corrupt recording.
+        Pre-fix (guard only): resuming=False, but _download_file reuses the open
+        206 response (which carries only the tail bytes from the requested offset).
+        Writing those tail bytes with 'wb' produces a silently truncated recording:
+        the file looks complete (downloaded == content_length) but contains only
+        the second half.
 
-        Fix: treat absent Content-Range as "position unknown" and fall back
-        to restart ('wb', downloaded=0), the same as a Content-Range mismatch.
-        Guard is now:
-            resuming = status==206 and offset>0 and range_start is not None
-                       and range_start == offset
+        Full fix: detect the unverifiable 206, release the connection without
+        reading the body, re-GET without a Range header, write the full stream.
         """
-        existing = b"\x00" * 4096
-        # Provider returns 206 but NO Content-Range header (RFC violation, common in
-        # cheap IPTV catchup implementations and some transparent proxies).
-        new_data = b"\x47" * 512
-        response = _make_aiohttp_response(206, [new_data])  # content_range=None
-        _mock_session, client_cm = _make_aiohttp_client_session(response)
+        offset = 4096
+        existing = b"\x00" * offset
+        tail = b"\x47" * 512           # bytes the server sends from offset onward
+        full_content = existing + tail  # expected final file
+
+        # First GET: 206 no Content-Range; body is only the tail (realistic)
+        response_206 = _make_aiohttp_response(206, [tail])  # content_range=None
+        # Second GET (restart from byte 0): full stream
+        response_200 = _make_aiohttp_response(200, [full_content])
+        _mock_session, client_cm = _make_aiohttp_client_session_multi([response_206, response_200])
 
         manager = DownloadManager()
         db_session = _make_db_session()
@@ -425,21 +455,20 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
                 patch.object(manager, "_broadcast_progress", AsyncMock()),
             ):
                 total = await manager._download_file(
-                    "http://provider/stream", tmp_path, 1, db_session, offset=4096
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
                 )
 
-            # Must fall back to restart: file overwritten, return value is only new bytes.
             self.assertEqual(
                 total,
-                512,
-                "206 with no Content-Range must restart (return new bytes only, not offset+new).",
+                len(full_content),
+                "After restart, return value must be the full content length from byte 0.",
             )
             with open(tmp_path, "rb") as fh:
                 contents = fh.read()
             self.assertEqual(
                 contents,
-                new_data,
-                "File must be overwritten when Content-Range is absent, not appended.",
+                full_content,
+                "File must contain full content from byte 0 after restart, not just the tail.",
             )
         finally:
             os.unlink(tmp_path)

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -384,13 +384,12 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
-    @unittest.expectedFailure
     async def test_206_no_content_range_falls_back_to_restart(self):
         """
-        BUG: A 206 response with no Content-Range header causes false resume.
+        A 206 response with no Content-Range header must fall back to restart ('wb').
 
-        Root cause: when the server returns 206 but omits the Content-Range header,
-        range_start stays None.  The mismatch guard is:
+        When the server returns 206 but omits the Content-Range header, range_start
+        stays None.  Without the fix, the mismatch guard was:
             range_mismatch = range_start is not None and range_start != offset
         Since range_start is None, range_mismatch is False, so resuming evaluates to
         True.  The file is opened in 'ab' mode even though we have no confirmation
@@ -399,9 +398,9 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
         partial file to grow from offset+0 to offset+server_full_size, producing a
         corrupt recording.
 
-        Expected fix: treat absent Content-Range as "position unknown" and fall back
+        Fix: treat absent Content-Range as "position unknown" and fall back
         to restart ('wb', downloaded=0), the same as a Content-Range mismatch.
-        Guard should be:
+        Guard is now:
             resuming = status==206 and offset>0 and range_start is not None
                        and range_start == offset
         """
@@ -433,18 +432,14 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(
                 total,
                 512,
-                "206 with no Content-Range must restart (return new bytes only, not offset+new). "
-                "Currently returns 4096+512 because range_start=None bypasses the mismatch guard, "
-                "treating absent Content-Range as a confirmed resume.",
+                "206 with no Content-Range must restart (return new bytes only, not offset+new).",
             )
             with open(tmp_path, "rb") as fh:
                 contents = fh.read()
             self.assertEqual(
                 contents,
                 new_data,
-                "File must be overwritten when Content-Range is absent, not appended. "
-                "Currently the partial file is opened 'ab' and the server's bytes "
-                "(from an unknown position) are appended, corrupting the recording.",
+                "File must be overwritten when Content-Range is absent, not appended.",
             )
         finally:
             os.unlink(tmp_path)


### PR DESCRIPTION
## What happened

When a partial download was recovered on restart and Mustarrd sent a `Range: bytes=N-` request, some IPTV providers returned HTTP 206 but left out the `Content-Range` header. Without that header, Mustarrd could not verify where the provider actually started sending, but it treated the 206 as a confirmed resume anyway. The file was opened in append mode, so if the provider sent from byte 0, the recording grew to `partial_size + full_size` bytes and played as corrupted video.

## Root cause

In `_download_file` (download_manager.py), the resume guard was:

```python
range_mismatch = range_start is not None and range_start != offset
resuming = response.status == 206 and offset > 0 and not range_mismatch
```

When `Content-Range` is absent, `range_start` stays `None`, so `range_mismatch` is `False`, and `resuming` is `True`. No Content-Range means position is unknown, but the old code treated it as position confirmed.

## What changed

The guard now requires `range_start` to be present and equal to the requested offset before treating a 206 as a resume:

```python
resuming = (
    response.status == 206
    and offset > 0
    and range_start is not None
    and range_start == offset
)
```

Absent or mismatched `Content-Range` both fall back to restart (`wb` mode, re-download from byte 0), the same safe path as a 200 response.

## Before

1. Partial download on disk (say, 4 096 bytes of a 10 000-byte recording).
2. Mustarrd restarts, sends `Range: bytes=4096-`.
3. Provider returns `HTTP 206` with no `Content-Range` header, body starting at byte 0.
4. File opened `'ab'`. Provider bytes appended. File grows to 14 096 bytes: corrupt recording.
5. No warning logged.

## After

1. Same scenario.
2. Mustarrd restarts, sends `Range: bytes=4096-`.
3. Provider returns `HTTP 206` with no `Content-Range` header.
4. `range_start` is `None`. Resume guard fails. File opened `'wb'` (restart).
5. Log: "Provider did not honour Range request; re-downloading from start."
6. Clean re-download. No corruption.

## Testing

Removed the `@unittest.expectedFailure` decorator from `test_206_no_content_range_falls_back_to_restart` in `test_download_file_range.py`, which was added in PR #142 to document this exact bug. The test now passes.

Full suite: 413 tests, all pass (2 unrelated expected failures from `test_epg_duplicate_channel_name.py` pending PR #138).

```
Ran 413 tests in 1.225s
OK (expected failures=2)
```

Closes the [206 without Content-Range triggers false resume, corrupting partial catchup files](https://discord.com/channels/1512584962413506710/1513245573069930577) task.