### PR TITLE
[Design] Add Airs: label to Downloads > Upcoming time display

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -648,7 +648,7 @@ export default function Downloads() {
                       <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
                       <Group gap="xs">
                         <Text size="xs" c="dimmed">
-                          {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}
+                          Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}
                         </Text>
                         <Text size="xs" c="dimmed">({formatDuration(rec.duration_minutes)})</Text>
                       </Group>


### PR DESCRIPTION
## What changed

On the Downloads > Upcoming tab, each recording card shows a date and time below the channel name. Before this change, the time appeared with no label:

```
Coronation Street
ITV
Tue Jun 9, 2026 8:00 PM  (1h 0m)
```

A non-technical operator cannot tell if that time is when the show airs, when the download will start, or something else. The Scheduled Recordings page labels the same information as "Airs: ..." which makes it immediately clear.

After this change:

```
Coronation Street
ITV
Airs: Tue Jun 9, 2026 8:00 PM  (1h 0m)
```

One-word change in Downloads.jsx. No logic touched.

## Before / After

Screenshots posted in #design. Before and after shown at desktop (1280px) and mobile (390px).

The "Great British Bake Off" card already wrapped on mobile before this change because the badge and date compete for space on narrow screens. That wrapping behavior is unchanged.

## How tested

- Started app locally (backend + frontend dev server).
- Playwright screenshots captured before and after at desktop and mobile widths.
- Confirmed all three Upcoming cards show "Airs:" prefix.
- Confirmed no change to Active tab, History tab, or Scheduled page.