### PR TITLE
fix: reject text/* responses from provider as error pages

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1015,6 +1015,13 @@ class DownloadManager:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
+                content_type = response.headers.get("Content-Type", "")
+                if content_type.lower().startswith("text/"):
+                    raise Exception(
+                        f"Provider returned an error page (Content-Type: {content_type}). "
+                        "The catchup window may have expired or be unavailable."
+                    )
+
                 total_size = response.content_length or 0
                 range_start = None
                 if response.status == 206:

--- a/backend/tests/test_download_html_body.py
+++ b/backend/tests/test_download_html_body.py
@@ -1,0 +1,216 @@
+"""
+Regression test: provider returns HTTP 200 with a text/html body (error page).
+
+Before the fix, _download_file would write the HTML to the output file and mark
+the download COMPLETED. With post-processing off the user ended up with an HTML
+file that looked like a completed recording. With post-processing on, FFmpeg
+failed on the HTML input and the download ended as COMPLETED with a warning.
+
+After the fix, _download_file raises an exception as soon as it sees a text/*
+Content-Type so the download is marked FAILED with a clear message.
+"""
+
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+def _make_response(status, content_type, chunks):
+    response = MagicMock()
+    response.status = status
+    response.reason = "OK"
+    response.content_length = None
+    response.headers = {"Content-Type": content_type}
+
+    async def iter_chunked(_size):
+        for chunk in chunks:
+            yield chunk
+
+    response.content.iter_chunked = iter_chunked
+    return response
+
+
+def _make_client_session(response):
+    get_cm = MagicMock()
+    get_cm.__aenter__ = AsyncMock(return_value=response)
+    get_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = get_cm
+
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    return client_cm
+
+
+class HtmlBodyRejectionTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_html_200_raises_exception(self):
+        """HTTP 200 with text/html body must raise, not write HTML to disk."""
+        html = b"<html><body>Catchup not available</body></html>"
+        response = _make_response(200, "text/html; charset=utf-8", [html])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    with self.assertRaises(Exception) as ctx:
+                        await manager._download_file(
+                            "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts",
+                            tmp_path,
+                            1,
+                            db_session,
+                            offset=0,
+                        )
+
+        self.assertIn(
+            "error page",
+            str(ctx.exception).lower(),
+            "Exception message must mention 'error page' so the failure reason "
+            "is understandable in the download log.",
+        )
+
+    async def test_html_206_raises_exception(self):
+        """HTTP 206 with text/html body must also raise."""
+        html = b"<html>Session limit reached</html>"
+        response = _make_response(206, "text/html", [html])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    with self.assertRaises(Exception) as ctx:
+                        await manager._download_file(
+                            "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts",
+                            tmp_path,
+                            1,
+                            db_session,
+                            offset=0,
+                        )
+
+        self.assertIn("error page", str(ctx.exception).lower())
+
+    async def test_text_plain_raises_exception(self):
+        """text/plain is also a non-video response and must be rejected."""
+        response = _make_response(200, "text/plain", [b"Catchup unavailable"])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    with self.assertRaises(Exception):
+                        await manager._download_file(
+                            "http://provider/stream",
+                            tmp_path,
+                            1,
+                            db_session,
+                            offset=0,
+                        )
+
+    async def test_video_mpeg_not_rejected(self):
+        """video/mpeg must not be rejected. Normal IPTV streams must still work."""
+        data = b"\x47" * 1024
+        response = _make_response(200, "video/mpeg", [data])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    total = await manager._download_file(
+                        "http://provider/stream",
+                        tmp_path,
+                        1,
+                        db_session,
+                        offset=0,
+                    )
+
+        self.assertEqual(total, 1024, "video/mpeg response must complete normally.")
+
+    async def test_octet_stream_not_rejected(self):
+        """application/octet-stream must not be rejected."""
+        data = b"\x47" * 512
+        response = _make_response(200, "application/octet-stream", [data])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    total = await manager._download_file(
+                        "http://provider/stream",
+                        tmp_path,
+                        1,
+                        db_session,
+                        offset=0,
+                    )
+
+        self.assertEqual(total, 512, "application/octet-stream must complete normally.")
+
+    async def test_no_content_type_not_rejected(self):
+        """Absent Content-Type header must not be rejected (many providers omit it)."""
+        data = b"\x47" * 256
+        response = _make_response(200, "", [data])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    total = await manager._download_file(
+                        "http://provider/stream",
+                        tmp_path,
+                        1,
+                        db_session,
+                        offset=0,
+                    )
+
+        self.assertEqual(total, 256, "Missing Content-Type must not block the download.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What happened

When an IPTV provider returns HTTP 200 with a `text/html` body (for example, "Catchup not available" or "Session limit reached"), the downloader was treating it as a valid stream. The HTML was written byte-for-byte into the `.ts` output file, and the recording was marked **COMPLETED**.

A non-technical user would see a completed recording that plays as garbage, with no indication anything went wrong.

## What changed

`_download_file` now checks `Content-Type` immediately after the status check. If the type starts with `text/` (covers `text/html`, `text/plain`, and similar), the download is aborted with a clear error:

> "Provider returned an error page (Content-Type: text/html). The catchup window may have expired or be unavailable."

`video/*`, `application/octet-stream`, and missing `Content-Type` are all unchanged. Many IPTV providers omit `Content-Type` entirely and that still works.

## Before

1. Queue a catchup download for a channel whose provider returns `HTTP 200 Content-Type: text/html` with body `<html>Catchup not available</html>`.
2. Download reaches COMPLETED. Output file contains the HTML page.
3. No error shown to the user.

## After

1. Same request.
2. Download is marked FAILED with message: "Provider returned an error page (Content-Type: text/html). The catchup window may have expired or be unavailable."
3. User sees a clear failure reason.

## Testing

New test file `backend/tests/test_download_html_body.py` with 6 cases:

- `test_html_200_raises_exception`: HTTP 200 + `text/html` raises with "error page" in the message.
- `test_html_206_raises_exception`: HTTP 206 + `text/html` also raises.
- `test_text_plain_raises_exception`: `text/plain` is also rejected.
- `test_video_mpeg_not_rejected`: `video/mpeg` completes normally.
- `test_octet_stream_not_rejected`: `application/octet-stream` completes normally.
- `test_no_content_type_not_rejected`: Absent `Content-Type` does not block the download.

Full suite: 419 tests pass (3 expected failures for unrelated open bugs in PRs #138 and #146).

```
Ran 419 tests in 1.256s
OK (expected failures=3)
```

Closes: https://discord.com/channels/1512584979490906232/1512684030368415916