### PR TITLE
[Design] Keep time and duration together in Downloads > Upcoming cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -646,12 +646,9 @@ export default function Downloads() {
                     <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
                       <Text fw={500}>{rec.program_title}</Text>
                       <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
-                      <Group gap="xs">
-                        <Text size="xs" c="dimmed">
-                          Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}
-                        </Text>
-                        <Text size="xs" c="dimmed">({formatDuration(rec.duration_minutes)})</Text>
-                      </Group>
+                      <Text size="xs" c="dimmed">
+                        Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
+                      </Text>
                     </Stack>
                     {rec.status === 'paused_low_space' && (
                       <Badge color="yellow" variant="light" size="sm" leftSection={<IconAlertCircle size={12} />}>


### PR DESCRIPTION
## What a user would notice

On the Downloads > Upcoming tab, cards with a status badge (like **Paused (Low Space)**) showed the air time and duration on separate lines. The duration "(1h 30m)" looked like a disconnected, unlabelled field rather than part of the time information above it.

## What changed

The date and duration were two separate Text elements inside a Mantine Group. On narrow screens the Group wraps each element independently, so the duration ends up alone on the next line.

Merged into a single Text element so they wrap as one unit. On desktop they stay on the same line even when a badge is present. On mobile they still wrap when the line is long, but as natural text flow, not as two disconnected pieces.

One-line change in frontend/src/pages/Downloads.jsx. No logic touched.

Note: PR #147 adds an "Airs: " prefix to the date on this same line. This PR is compatible. After #147 merges, Herald can rebase this branch with a trivial one-line conflict resolution.

## Before and after

Before (mobile): duration "(1h 30m)" orphaned on its own line below the date.
After (mobile): date and duration are one text unit.
Before (desktop): date on one line, duration pushed to next line by the badge.
After (desktop): "Wed Jun 10, 2026 8:00 PM (1h 30m)" stays on one line alongside the badge.

Screenshots posted in #design.

## How it was tested

App started locally. Playwright screenshots taken at 1280px (desktop) and 390px (mobile) before and after the change. The PAUSED (LOW SPACE) card on the Upcoming tab shows the fix clearly.