### PR TITLE
fix: block setup link from reactivating disabled users

### DIFF
--- a/backend/api/admin_users.py
+++ b/backend/api/admin_users.py
@@ -148,6 +148,8 @@ async def generate_setup_link(
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if user.status == "disabled":
+        raise HTTPException(status_code=400, detail="Cannot generate a setup link for a disabled user")
     token = await _create_setup_token(session, user_id)
     return {
         "token": token,

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -600,10 +600,13 @@ async def complete_user_setup(
     user = user_result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if user.status == "disabled":
+        raise HTTPException(status_code=403, detail="Account is disabled")
 
     user.password_hash = hash_password(payload.password)
     user.password_reset_required = False
-    user.status = "active"
+    if user.status != "active":
+        user.status = "active"
     user.updated_at = datetime.utcnow()
     row.used_at = datetime.utcnow()
     await session.commit()

--- a/backend/tests/test_setup_link_disabled_user.py
+++ b/backend/tests/test_setup_link_disabled_user.py
@@ -1,0 +1,185 @@
+"""
+Regression test: complete_user_setup must not reactivate disabled users.
+
+Before fix: POST /api/auth/user/setup/{token} set user.status = "active"
+unconditionally. An admin who disabled a user could have their decision bypassed
+if an unexpired setup link existed: the user could POST the token and reactivate
+themselves within the 24-hour TTL.
+
+generate_setup_link also had no status check, so an admin could accidentally
+issue a link for an already-disabled user, granting them a reactivation window.
+
+After fix:
+- complete_user_setup returns HTTP 403 if the user is disabled.
+- generate_setup_link returns HTTP 400 if the user is disabled.
+- Active and pending users are unaffected.
+"""
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import select
+
+from api.auth import complete_user_setup, UserSetupPayload, _hash_setup_token
+from api.admin_users import generate_setup_link
+from database import Base
+from models import User, UserSetupToken
+
+
+def _make_user(status="pending"):
+    return User(
+        role="download_only",
+        status=status,
+        display_name="Test User",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _make_token(user_id, raw_token="test-token-abc", hours_ahead=24):
+    return UserSetupToken(
+        user_id=user_id,
+        token_hash=_hash_setup_token(raw_token),
+        expires_at=datetime.utcnow() + timedelta(hours=hours_ahead),
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class CompleteSetupDisabledUserTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _seed(self, status="pending", raw_token="test-token-abc"):
+        async with self.session_factory() as session:
+            user = _make_user(status=status)
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            uid = user.id
+
+        async with self.session_factory() as session:
+            token = _make_token(uid, raw_token=raw_token)
+            session.add(token)
+            await session.commit()
+
+        return uid
+
+    async def test_disabled_user_gets_403(self):
+        """complete_user_setup must return 403 when user is disabled."""
+        raw = "test-token-disabled"
+        await self._seed(status="disabled", raw_token=raw)
+
+        async with self.session_factory() as session:
+            with self.assertRaises(HTTPException) as ctx:
+                await complete_user_setup(
+                    raw, UserSetupPayload(password="Password1!"), session
+                )
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    async def test_disabled_user_status_unchanged(self):
+        """complete_user_setup must not change a disabled user's status to active."""
+        raw = "test-token-disabled2"
+        uid = await self._seed(status="disabled", raw_token=raw)
+
+        async with self.session_factory() as session:
+            try:
+                await complete_user_setup(
+                    raw, UserSetupPayload(password="Password1!"), session
+                )
+            except HTTPException:
+                pass
+
+        async with self.session_factory() as session:
+            result = await session.execute(select(User).where(User.id == uid))
+            user = result.scalar_one_or_none()
+        self.assertEqual(user.status, "disabled", "Disabled user was reactivated via setup link.")
+
+    async def test_pending_user_is_activated(self):
+        """complete_user_setup must still activate a pending user (regression guard)."""
+        raw = "test-token-pending"
+        uid = await self._seed(status="pending", raw_token=raw)
+
+        async with self.session_factory() as session:
+            result = await complete_user_setup(
+                raw, UserSetupPayload(password="Password1!"), session
+            )
+        self.assertEqual(result, {"status": "configured"})
+
+        async with self.session_factory() as session:
+            row = await session.execute(select(User).where(User.id == uid))
+            user = row.scalar_one_or_none()
+        self.assertEqual(user.status, "active")
+
+    async def test_active_user_remains_active(self):
+        """complete_user_setup (e.g. for password reset) does not break active users."""
+        raw = "test-token-active"
+        uid = await self._seed(status="active", raw_token=raw)
+
+        async with self.session_factory() as session:
+            result = await complete_user_setup(
+                raw, UserSetupPayload(password="Password1!"), session
+            )
+        self.assertEqual(result, {"status": "configured"})
+
+        async with self.session_factory() as session:
+            row = await session.execute(select(User).where(User.id == uid))
+            user = row.scalar_one_or_none()
+        self.assertEqual(user.status, "active")
+
+
+class GenerateSetupLinkDisabledUserTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _create_user(self, status="active"):
+        async with self.session_factory() as session:
+            user = _make_user(status=status)
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            return user.id
+
+    async def test_disabled_user_returns_400(self):
+        """generate_setup_link must return 400 for a disabled user."""
+        uid = await self._create_user(status="disabled")
+        async with self.session_factory() as session:
+            with self.assertRaises(HTTPException) as ctx:
+                await generate_setup_link(uid, _admin=None, session=session)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    async def test_active_user_gets_link(self):
+        """generate_setup_link must still work for an active user (regression guard)."""
+        uid = await self._create_user(status="active")
+        async with self.session_factory() as session:
+            result = await generate_setup_link(uid, _admin=None, session=session)
+        self.assertIn("token", result)
+        self.assertIn("setup_path", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If an admin disabled a user account, that user could still log back in within 24 hours by using their existing setup link. The disable had no effect until the link expired on its own.

## What changed

Two small guards were added:

1. **`POST /api/auth/user/setup/{token}`** now returns HTTP 403 if the user is disabled. The setup link is not consumed and the user's status stays disabled.
2. **`POST /api/admin/users/{id}/setup-link`** now returns HTTP 400 if the admin tries to generate a new link for an already-disabled user.

Active and pending users are unaffected.

## Root cause

`complete_user_setup` (auth.py) set `user.status = \"active\"` unconditionally, overwriting a deliberate \"disabled\" status. `generate_setup_link` (admin_users.py) had no status check, so admins could unknowingly issue a 24-hour reactivation window for a disabled account.

## How it was tested

6 new real-DB regression tests in `backend/tests/test_setup_link_disabled_user.py`:

- Disabled user gets HTTP 403 from `complete_user_setup`
- Disabled user's status stays \"disabled\" after the attempt
- Pending user is still activated (regression guard)
- Active user (password reset via link) still works (regression guard)
- Disabled user gets HTTP 400 from `generate_setup_link`
- Active user can still get a setup link (regression guard)

Full suite: 421 tests pass.

**Before:** `POST /api/auth/user/setup/TOKEN` with a valid token and a disabled user returned `{"status": "configured"}` and set the user active.

**After:** Same request returns HTTP 403 `{"detail": "Account is disabled"}`. User status unchanged.