### PR TITLE
[Design] Hide "Enabled" badge on active account cards

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -142,9 +142,11 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
               Default
             </Badge>
           )}
-          <Badge color={account.is_active ? 'green' : 'gray'} variant="light">
-            {account.is_active ? 'Enabled' : 'Disabled'}
-          </Badge>
+          {!account.is_active && (
+            <Badge color="gray" variant="light">
+              Disabled
+            </Badge>
+          )}
           <Menu shadow="md" width={150}>
             <Menu.Target>
               <ActionIcon variant="subtle">


### PR DESCRIPTION
## What changed

Each account card in Settings > Accounts used to display a green **ENABLED** badge regardless of whether the account was working. Active is the expected state, so the badge communicated nothing useful. Worse, it created a confusing visual conflict: a green badge next to a red "Unreachable" dot implies everything is fine when it is not.

Now the badge only appears when an account is **Disabled** (gray), which is the state worth flagging. Active accounts show only their connection status dot and error message.

## Before

Both accounts show green **ENABLED** alongside a red **Unreachable** status. The green badge competes with the red dot and draws the eye to the wrong signal.

## After

No badge on active accounts. The **Unreachable** dot and error message are now the first things a user sees when something is wrong.

## How it was tested

Playwright screenshots at 1280x800 (desktop) and 390x844 (mobile) from a live local dev instance. Before/after screenshots attached to the #design Discord thread.

One-line conditional change in `AccountsSection.jsx`. No logic touched.

## Design WIP count

PR #150 open (1 of 3). This PR is #2 of 3.