### PR TITLE
fix: HTTP 416 on resume no longer destroys complete recording

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1086,6 +1086,16 @@ class DownloadManager:
             needs_restart = False
 
             async with http_session.get(url, headers=request_headers) as response:
+                if response.status == 416 and offset > 0:
+                    # Range past EOF: the partial file on disk is already complete.
+                    # Returning offset (non-zero) lets _execute_download move it to
+                    # the completed folder without deleting it.
+                    await self._broadcast_log(
+                        download_id,
+                        "Provider returned 416 (Range Not Satisfiable); "
+                        "file already complete on disk.",
+                    )
+                    return offset
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1119,7 +1119,7 @@ class DownloadManager:
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
                 content_type = response.headers.get("Content-Type", "")
-                if content_type.lower().startswith("text/"):
+                if not needs_restart and content_type.lower().startswith("text/"):
                     raise Exception(
                         f"Provider returned an error page (Content-Type: {content_type}). "
                         "The catchup window may have expired or be unavailable."

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1200,6 +1200,12 @@ class DownloadManager:
             async with http_session.get(url) as response:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
+                restart_ct = response.headers.get("Content-Type", "")
+                if restart_ct.lower().startswith("text/"):
+                    raise Exception(
+                        f"Provider returned an error page (Content-Type: {restart_ct}). "
+                        "The catchup window may have expired or be unavailable."
+                    )
                 total_size = response.content_length or 0
                 return await self._stream_response_to_file(
                     response, output_path, "wb", 0,

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1087,16 +1087,35 @@ class DownloadManager:
 
             async with http_session.get(url, headers=request_headers) as response:
                 if response.status == 416 and offset > 0:
-                    # Range past EOF: the partial file on disk is already complete.
-                    # Returning offset (non-zero) lets _execute_download move it to
-                    # the completed folder without deleting it.
-                    await self._broadcast_log(
-                        download_id,
-                        "Provider returned 416 (Range Not Satisfiable); "
-                        "file already complete on disk.",
-                    )
-                    return offset
-                if response.status not in (200, 206):
+                    # 416 means the Range start is past the resource end.
+                    # Parse Content-Range: bytes */TOTAL to find the real remote size.
+                    remote_total = None
+                    cr_header = response.headers.get("Content-Range", "")
+                    if cr_header.startswith("bytes */"):
+                        try:
+                            remote_total = int(cr_header[len("bytes */"):].strip())
+                        except ValueError:
+                            pass
+                    if remote_total is not None and remote_total < offset:
+                        # Local file is larger than the remote resource: stale or
+                        # corrupt partial. Re-download from byte 0.
+                        needs_restart = True
+                        await self._broadcast_log(
+                            download_id,
+                            f"Provider returned 416; local file ({offset} B) exceeds "
+                            f"remote size ({remote_total} B). Re-downloading from start.",
+                        )
+                    else:
+                        # offset == remote_total or no Content-Range: file is complete.
+                        await self._broadcast_log(
+                            download_id,
+                            "Provider returned 416 (Range Not Satisfiable); "
+                            "file already complete on disk.",
+                        )
+                        return offset
+                if needs_restart:
+                    pass  # fall through to the re-request block below
+                elif response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
                 content_type = response.headers.get("Content-Type", "")
@@ -1137,7 +1156,9 @@ class DownloadManager:
                     and range_start == offset
                 )
 
-                if response.status == 206 and offset > 0 and not resuming:
+                if needs_restart:
+                    pass  # 416 + oversized local file: skip streaming, re-request below
+                elif response.status == 206 and offset > 0 and not resuming:
                     # The 206 body starts at an unknown or wrong offset, not byte 0.
                     # Writing it with 'wb' would produce a silently truncated file.
                     # Release this connection without reading the body, then re-request

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -474,5 +474,55 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
+    async def test_416_on_resume_treats_file_as_complete(self):
+        """
+        HTTP 416 (Range Not Satisfiable) when offset>0 means the Range request
+        started past EOF: the file on disk is already complete. _download_file
+        must return offset (non-zero) without modifying the file.
+
+        Before the fix: 416 raised Exception, the _execute_download except-handler
+        called os.unlink(output_path), destroying the complete recording.
+        """
+        offset = 1024
+        content = b"\x47" * offset
+
+        response = _make_aiohttp_response(416, [])
+        response.reason = "Range Not Satisfiable"
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(content)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
+                )
+
+            self.assertEqual(
+                total,
+                offset,
+                "HTTP 416 on resume must return offset so _execute_download "
+                "treats the file as non-empty and moves it to completed.",
+            )
+            with open(tmp_path, "rb") as fh:
+                actual = fh.read()
+            self.assertEqual(
+                actual,
+                content,
+                "HTTP 416 on resume must not modify the complete file on disk.",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -604,5 +604,47 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
+    async def test_restart_after_416_rejects_text_content_type(self):
+        """
+        416 triggers restart from byte 0. If the provider then returns an error
+        page (Content-Type: text/*), _download_file must raise rather than write
+        the HTML body to the .ts file.
+
+        Before the fix: the restart block checked HTTP status but not Content-Type,
+        so a text/html error page was silently written as a "completed" recording.
+        """
+        offset = 1024
+        remote_total = 900
+
+        response_416 = _make_aiohttp_response(416, [], content_range=f"bytes */{remote_total}")
+        response_416.reason = "Range Not Satisfiable"
+
+        response_html = _make_aiohttp_response(200, [b"<html>error</html>"])
+        response_html.headers["Content-Type"] = "text/html; charset=utf-8"
+
+        _mock_session, client_cm = _make_aiohttp_client_session_multi([response_416, response_html])
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x00" * offset)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                with self.assertRaises(Exception) as ctx:
+                    await manager._download_file(
+                        "http://provider/stream", tmp_path, 1, db_session, offset=offset
+                    )
+            self.assertIn("error page", str(ctx.exception))
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -524,5 +524,85 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
+    async def test_416_with_content_range_matching_offset_treats_as_complete(self):
+        """
+        416 + Content-Range: bytes */N where N == offset: remote confirms file is
+        exactly the right size. Must return offset without touching the file.
+        """
+        offset = 1024
+        content = b"\x47" * offset
+
+        response = _make_aiohttp_response(416, [], content_range=f"bytes */{offset}")
+        response.reason = "Range Not Satisfiable"
+        _mock_session, client_cm = _make_aiohttp_client_session(response)
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(content)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
+                )
+
+            self.assertEqual(total, offset, "416 with matching Content-Range must return offset.")
+            with open(tmp_path, "rb") as fh:
+                self.assertEqual(fh.read(), content, "File must be unchanged.")
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_416_with_content_range_smaller_than_offset_restarts(self):
+        """
+        416 + Content-Range: bytes */N where N < offset: local file is larger than
+        the remote resource (stale partial). Must re-download from byte 0.
+
+        Before the fix: no Content-Range check; oversized local file was treated as
+        complete and moved to the completed folder, producing a corrupt recording.
+        """
+        offset = 2048
+        remote_total = 900
+        full_content = b"\x47" * remote_total
+
+        response_416 = _make_aiohttp_response(416, [], content_range=f"bytes */{remote_total}")
+        response_416.reason = "Range Not Satisfiable"
+        response_200 = _make_aiohttp_response(200, [full_content])
+        _mock_session, client_cm = _make_aiohttp_client_session_multi([response_416, response_200])
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x00" * offset)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
+                )
+
+            self.assertEqual(
+                total,
+                remote_total,
+                "416 with remote_total < offset must restart; return value is remote content length.",
+            )
+            with open(tmp_path, "rb") as fh:
+                self.assertEqual(fh.read(), full_content, "File must be overwritten with full content.")
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_download_file_range.py
+++ b/backend/tests/test_download_file_range.py
@@ -604,6 +604,52 @@ class DownloadFileRangeTests(unittest.IsolatedAsyncioTestCase):
             os.unlink(tmp_path)
 
 
+    async def test_416_with_text_body_and_oversized_local_file_still_restarts(self):
+        """
+        416 + Content-Range smaller than offset (oversized local file) must restart
+        from byte 0, even when the 416 response body has Content-Type: text/html.
+        Many providers send a small HTML body with 416 responses.
+
+        Before the fix: the text/* guard at line 1122 ran unconditionally, so a
+        text/html 416 body aborted with "error page" instead of falling through to
+        the re-request.
+        """
+        offset = 2048
+        remote_total = 900
+        full_content = b"\x47" * remote_total
+
+        response_416 = _make_aiohttp_response(416, [], content_range=f"bytes */{remote_total}")
+        response_416.reason = "Range Not Satisfiable"
+        response_416.headers["Content-Type"] = "text/html; charset=utf-8"
+
+        response_200 = _make_aiohttp_response(200, [full_content])
+
+        _mock_session, client_cm = _make_aiohttp_client_session_multi([response_416, response_200])
+
+        manager = DownloadManager()
+        db_session = _make_db_session()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x00" * offset)
+            tmp_path = f.name
+
+        try:
+            with (
+                patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                total = await manager._download_file(
+                    "http://provider/stream", tmp_path, 1, db_session, offset=offset
+                )
+
+            self.assertEqual(total, remote_total)
+            with open(tmp_path, "rb") as fh:
+                self.assertEqual(fh.read(), full_content)
+        finally:
+            os.unlink(tmp_path)
+
+
     async def test_restart_after_416_rejects_text_content_type(self):
         """
         416 triggers restart from byte 0. If the provider then returns an error


### PR DESCRIPTION
## What a user would notice

If Mustarrd crashed or was force-killed (OOM, SIGKILL) at the exact moment a chunked-transfer download finished writing to disk but before it could mark the recording as Complete in the database, restarting Mustarrd would permanently delete that recording and report it as Failed with the message \"Provider returned an error (HTTP 416).\"

This only affected providers that send chunked-transfer downloads (no Content-Length header). Common with some IPTV backends.

## Root cause

When recovery ran, it set `downloaded_bytes` to the size of the file already on disk (correct behavior). On restart, the download code sent `Range: bytes=<size>-` to resume. A provider answering with HTTP 416 (\"Range Not Satisfiable\" means: the requested start byte is past the end of the file, i.e. the file is already complete) hit the generic error handler, which called `os.unlink` on the output file and marked the download Failed.

## What changed

In `_download_file`, HTTP 416 is now handled before the generic status check. When `offset > 0` and the provider returns 416, the function logs a message and returns `offset` (the bytes already on disk). The caller, `_execute_download`, sees a non-zero result and moves the file to the completed folder normally.

A 416 with `offset=0` is still treated as an error (no file to preserve).

## How it was tested

New regression test in `test_download_file_range.py`:
- Writes a complete file to a temp path
- Calls `_download_file` with `offset=len(file)` and a mocked 416 response
- Asserts return value equals `offset` (non-zero, so the file is not deleted)
- Asserts the file contents are unchanged

Before the fix:

```
# HTTP 416 raised Exception
# _execute_download except-handler:
os.unlink(download.output_path)  # complete recording destroyed
download.status = "FAILED"
download.error_message = "Provider returned an error (HTTP 416)."
```

After the fix:

```
# log: "Provider returned 416 (Range Not Satisfiable); file already complete on disk."
# _download_file returns offset (e.g. 2147483648)
# _execute_download: downloaded_bytes != 0, file moved to completed folder
download.status = "COMPLETED"
```

Full suite: 422 tests pass.