### PR TITLE
[Design] Confirm before deleting a scheduled recording

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -79,6 +79,7 @@ function ScheduleCard({
   onOpenFileLocation,
   onPlayFile,
 }) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
   const activeStatuses = ['scheduled', 'queued', 'downloading', 'processing', 'paused_low_space']
   const isActive = activeStatuses.includes(schedule.status)
   const canDelete = !isActive
@@ -129,7 +130,7 @@ function ScheduleCard({
                   <Menu.Item
                     color="red"
                     leftSection={<IconTrash size={14} />}
-                    onClick={() => onDelete(schedule)}
+                    onClick={() => setConfirmingDelete(true)}
                   >
                     Delete
                   </Menu.Item>
@@ -196,6 +197,26 @@ function ScheduleCard({
                 </Button>
               </>
             )}
+          </Group>
+        )}
+
+        {confirmingDelete && (
+          <Group gap="xs" justify="flex-end" pt={4} style={{ borderTop: '1px solid var(--mantine-color-dark-4)' }}>
+            <Text size="sm" c="dimmed">Delete this schedule?</Text>
+            <Button
+              size="xs"
+              color="red"
+              onClick={() => { onDelete(schedule); setConfirmingDelete(false) }}
+            >
+              Yes, delete
+            </Button>
+            <Button
+              size="xs"
+              variant="subtle"
+              onClick={() => setConfirmingDelete(false)}
+            >
+              Cancel
+            </Button>
           </Group>
         )}
       </Stack>


### PR DESCRIPTION
## What a user would notice

Clicking the Delete option on a scheduled recording now shows an inline prompt with **Yes, delete** and **Cancel** instead of removing the record immediately. Accidentally deleting a schedule required going back to Browse and re-scheduling the show. Now a single extra click prevents that.

## What changed

One state variable (`confirmingDelete`) added to `ScheduleCard`. Clicking Delete from the menu sets that flag instead of firing the delete immediately. An inline confirmation row appears at the bottom of the card with a subtle divider. Confirming calls the existing `DELETE /api/schedules/{id}` endpoint. Cancelling resets the flag and the card returns to normal. No logic changes.

**Affected file:** `frontend/src/pages/Scheduled.jsx` only.

## Before

Clicking the three-dot menu shows a red Delete item. Clicking it deletes the schedule immediately with no confirmation.

## After

Clicking Delete shows an inline row: "Delete this schedule?" with a red **Yes, delete** and a plain **Cancel**. Works at both desktop and mobile widths.

## How it was tested

Playwright screenshots at 1280x800 (desktop) and 390x844 (mobile). Verified menu opens, Delete triggers the confirm row, Cancel dismisses it, and the confirm row layout fits both widths cleanly. Frontend-only change, no new API calls.