### PR TITLE
fix: ComSkip format options blocked first-time setup

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -826,9 +826,7 @@ export default function Settings() {
               value: f.value,
               label: f.label,
               disabled:
-                ['remux_mkv', 'remux_mp4', 'transcode_mkv', 'transcode_mp4'].includes(f.value) && !ffmpegReady
-                  ? true
-                  : ['transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && (!ffmpegReady || !comskipReady)
+                ['remux_mkv', 'remux_mp4', 'transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && !ffmpegReady
                   ? true
                   : false,
             }))}
@@ -847,7 +845,7 @@ export default function Settings() {
           {!comskipReady && (currentFormat === 'transcode_comskip' || currentFormat === 'transcode_mp4_comskip') && (
             <Alert color="yellow" variant="light">
               <Text size="sm">
-                Comskip is unavailable. See{' '}
+                Comskip binary not found in the default PATH. Enter the path to your comskip binary below, or see{' '}
                 <a href="https://github.com/erikkaashoek/Comskip" target="_blank" rel="noopener noreferrer">
                   github.com/erikkaashoek/Comskip
                 </a>{' '}


### PR DESCRIPTION
## What changed

The \"MKV + skip commercials\" and \"MP4 + skip commercials\" options in the Recording Format dropdown were disabled whenever the comskip binary was not found in the default PATH. The binary path field only appears **after** one of those formats is selected, so there was no way to enter a custom binary path. Chicken-and-egg: you need to select a ComSkip format to see the path field, but the format was grayed out until comskip was already installed at a known path.

Fix: remove `!comskipReady` from the disabled condition. ComSkip format options are now disabled only when **ffmpeg** is unavailable (same as the other ffmpeg-requiring formats). When ffmpeg is present but comskip is not in PATH (the common first-time setup scenario), the options are selectable.

Also updated the alert message from \"Comskip is unavailable\" to \"Comskip binary not found in the default PATH. Enter the path to your comskip binary below...\" so users know what to do.

## What a user sees

**Before:** Opening the dropdown showed \"MKV + skip commercials\" and \"MP4 + skip commercials\" grayed out. Clicking them did nothing. No binary path field ever appeared.

**After:** The ComSkip format options are selectable when ffmpeg is available. Selecting one reveals the Comskip Binary Path and Comskip INI Path fields, plus an alert explaining the binary was not found and where to enter a custom path.

## Files changed

- `frontend/src/pages/Settings.jsx`: 4 lines changed (disabled condition simplified, alert message improved)

## How tested

Reproduced the bug on a local dev instance with no comskip binary in PATH. Verified the format options were grayed out and the binary path field was inaccessible. Applied fix, forced comskip_enabled=true in the dev DB to confirm the panel renders correctly with the updated alert message. Screenshots in the #design channel.