### PR TITLE
fix: recover_incomplete_downloads detects chunked-complete files

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1061,6 +1061,17 @@ class DownloadManager:
                         download_progress=progress
                     )
 
+        # For chunked streams (total_size == 0) the progress-based commit inside
+        # the loop never fires, so downloaded_bytes stays 0 in the DB. Commit the
+        # final byte count here so recovery after a crash can detect a complete file.
+        if total_size == 0:
+            await session.execute(
+                update(Download)
+                .where(Download.id == download_id)
+                .values(downloaded_bytes=downloaded)
+            )
+            await session.commit()
+
         await self._broadcast_log(
             download_id,
             f"Download bytes written: {downloaded:,}."

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -429,11 +429,19 @@ class DownloadManager:
 
                 if download.status == DownloadStatus.DOWNLOADING.value:
                     try:
-                        is_complete = (
+                        if input_file.is_file() and download.file_size:
+                            is_complete = download.downloaded_bytes >= int(download.file_size)
+                        elif (
                             input_file.is_file()
-                            and download.file_size
-                            and download.downloaded_bytes >= int(download.file_size)
-                        )
+                            and download.file_size == 0
+                            and download.downloaded_bytes > 0
+                        ):
+                            # Chunked stream (no Content-Length). The DB records
+                            # downloaded_bytes as written; if on-disk size matches, the
+                            # download finished cleanly before the crash.
+                            is_complete = input_file.stat().st_size == download.downloaded_bytes
+                        else:
+                            is_complete = False
                     except Exception:
                         is_complete = False
 

--- a/backend/tests/test_recover_chunked_complete_range416.py
+++ b/backend/tests/test_recover_chunked_complete_range416.py
@@ -1,0 +1,162 @@
+"""
+BUG: Chunked (no Content-Length) download that completes all bytes but crashes
+before the status-transition commit is re-queued as PENDING on the next startup.
+
+recovery_offset is then set to the full on-disk file size, so _download_file
+sends Range: bytes={full_size}-. Most IPTV providers return HTTP 416 Range Not
+Satisfiable; the exception handler marks the download FAILED and calls os.unlink
+on the output file. A finished recording is permanently destroyed.
+
+Root cause: is_complete check in recover_incomplete_downloads requires
+download.file_size to be truthy. Chunked-encoding streams have file_size=0
+throughout, so the expression always short-circuits to False and a complete
+chunked file is indistinguishable from a partial one.
+
+Fix needed: when file_size==0 and the on-disk file is non-empty and
+downloaded_bytes >= on-disk size, treat the download as complete and advance
+it to PROCESSING or COMPLETED instead of re-queuing.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+def _make_recovery_session(downloads, settings=None):
+    settings_result = MagicMock()
+    settings_result.scalar_one_or_none.return_value = settings
+
+    downloads_result = MagicMock()
+    downloads_result.scalars.return_value.all.return_value = downloads
+
+    call_count = [0]
+
+    async def execute(stmt):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return settings_result
+        return downloads_result
+
+    session = AsyncMock()
+    session.execute = execute
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def ctx():
+        yield session
+
+    return ctx
+
+
+class RecoverChunkedCompleteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_chunked_complete_file_not_requeued_for_redownload(self):
+        """
+        A chunked download whose on-disk bytes match downloaded_bytes should be
+        detected as complete on recovery, not re-queued as PENDING.
+
+        Current behavior (bug): status set to PENDING; recovery_offset = full
+        file size; next _download_file call sends Range: bytes={full_size}-;
+        provider returns 416; exception handler deletes the completed file.
+
+        Expected: status advanced to COMPLETED (or PROCESSING if post-processing
+        is configured), not re-queued.
+
+        This test FAILS with the current code and should PASS after the fix.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x47" * 8192)
+            tmp_path = f.name
+        try:
+            download = MagicMock()
+            download.id = 55
+            download.status = DownloadStatus.DOWNLOADING.value
+            download.output_path = tmp_path
+            download.file_size = 0          # chunked stream: no Content-Length
+            download.downloaded_bytes = 8192  # DB matches disk: download was complete
+            download.error_message = None
+            download.is_vod = False
+
+            manager = DownloadManager()
+
+            with (
+                patch("services.download_manager.async_session_maker", _make_recovery_session([download])),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+                patch.object(manager, "_resolve_completed_folder", return_value="/tmp/completed_test"),
+                patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+                patch.object(manager, "_move_to_completed", return_value="/tmp/completed_test/test.ts"),
+                patch.object(manager, "_sync_schedule_status", AsyncMock()),
+            ):
+                await manager.recover_incomplete_downloads()
+
+            # BUG: current code sets status to PENDING, meaning recovery_offset
+            # will be 8192 on next attempt and Range: bytes=8192- risks HTTP 416
+            # which deletes the completed file.
+            self.assertNotEqual(
+                download.status,
+                DownloadStatus.PENDING.value,
+                "Chunked download with matching on-disk bytes wrongly re-queued as "
+                "PENDING. On next attempt Range: bytes=8192- will likely return "
+                "HTTP 416 and unlink the completed recording.",
+            )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    async def test_chunked_partial_file_still_requeued(self):
+        """
+        A chunked download whose on-disk bytes are smaller than downloaded_bytes
+        (genuine partial: crash mid-stream) should still be re-queued as PENDING
+        so the download retries from where it left off.
+
+        This is the non-regressed case: partial files must not be falsely marked
+        complete.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            f.write(b"\x47" * 1024)
+            tmp_path = f.name
+        try:
+            download = MagicMock()
+            download.id = 56
+            download.status = DownloadStatus.DOWNLOADING.value
+            download.output_path = tmp_path
+            download.file_size = 0     # chunked stream
+            download.downloaded_bytes = 4096  # DB says 4096 but disk has only 1024
+            download.error_message = None
+            download.is_vod = False
+
+            manager = DownloadManager()
+
+            with (
+                patch("services.download_manager.async_session_maker", _make_recovery_session([download])),
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+                patch.object(manager, "_resolve_completed_folder", return_value="/tmp/completed_test"),
+                patch.object(manager, "_resolve_download_folder", return_value="/tmp/downloads_test"),
+            ):
+                await manager.recover_incomplete_downloads()
+
+            self.assertEqual(
+                download.status,
+                DownloadStatus.PENDING.value,
+                "Partial chunked download must be re-queued as PENDING.",
+            )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_recover_chunked_complete_range416.py
+++ b/backend/tests/test_recover_chunked_complete_range416.py
@@ -63,17 +63,15 @@ def _make_recovery_session(downloads, settings=None):
 class RecoverChunkedCompleteTests(unittest.IsolatedAsyncioTestCase):
     async def test_chunked_complete_file_not_requeued_for_redownload(self):
         """
-        A chunked download whose on-disk bytes match downloaded_bytes should be
-        detected as complete on recovery, not re-queued as PENDING.
+        A chunked download whose streaming completed should not be re-queued.
 
-        Current behavior (bug): status set to PENDING; recovery_offset = full
-        file size; next _download_file call sends Range: bytes={full_size}-;
-        provider returns 416; exception handler deletes the completed file.
+        When all bytes stream successfully, _stream_response_to_file commits
+        downloaded_bytes to the DB before returning. If the process then crashes
+        before the COMPLETED status commit, recovery sees downloaded_bytes matching
+        the on-disk size and must advance the download to COMPLETED, not PENDING.
 
-        Expected: status advanced to COMPLETED (or PROCESSING if post-processing
-        is configured), not re-queued.
-
-        This test FAILS with the current code and should PASS after the fix.
+        downloaded_bytes = 8192 here reflects the DB state after that final commit
+        fires (the fix that makes this possible).
         """
         with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
             f.write(b"\x47" * 8192)
@@ -117,12 +115,11 @@ class RecoverChunkedCompleteTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_chunked_partial_file_still_requeued(self):
         """
-        A chunked download whose on-disk bytes are smaller than downloaded_bytes
-        (genuine partial: crash mid-stream) should still be re-queued as PENDING
-        so the download retries from where it left off.
+        A chunked download that crashed mid-stream should be re-queued as PENDING.
 
-        This is the non-regressed case: partial files must not be falsely marked
-        complete.
+        When the process dies during streaming, no final commit fires, so
+        downloaded_bytes stays 0 in the DB. The on-disk file is non-empty but
+        partial. Recovery must not falsely treat it as complete.
         """
         with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
             f.write(b"\x47" * 1024)
@@ -133,7 +130,7 @@ class RecoverChunkedCompleteTests(unittest.IsolatedAsyncioTestCase):
             download.status = DownloadStatus.DOWNLOADING.value
             download.output_path = tmp_path
             download.file_size = 0     # chunked stream
-            download.downloaded_bytes = 4096  # DB says 4096 but disk has only 1024
+            download.downloaded_bytes = 0  # crash mid-stream: final commit never fired
             download.error_message = None
             download.is_vod = False
 

--- a/backend/tests/test_recover_unknown_length.py
+++ b/backend/tests/test_recover_unknown_length.py
@@ -44,19 +44,15 @@ def _make_recovery_session(downloads, settings=None):
 class RecoverUnknownLengthTests(unittest.IsolatedAsyncioTestCase):
     async def test_unknown_length_partial_file_preserves_bytes_on_recovery(self):
         """
-        BUG: recover_incomplete_downloads resets downloaded_bytes=0 for every
-        incomplete DOWNLOADING record, including streams where the provider sent no
-        Content-Length (file_size=0).
+        recover_incomplete_downloads must not reset downloaded_bytes=0 for a partial
+        chunked (unknown Content-Length) download when a partial file exists on disk.
 
-        Root cause: `and download.file_size` is falsy when file_size=0, so
-        is_complete is always False for unknown-length downloads. The code then
-        unconditionally resets downloaded_bytes=0, discarding partial progress.
+        Scenario: 4096 bytes written to disk; the DB had recorded 8192 bytes before the
+        crash (the download was still in progress). The DB value is stale; the on-disk
+        size is the truth. After recovery downloaded_bytes must equal the on-disk size
+        (4096), not 0 (the old buggy reset) and not 8192 (the stale DB value).
 
-        For a near-the-window-edge recording this means: restart -> full re-download
-        required -> catchup window closes before re-download finishes -> recording lost.
-
-        Fix: when file_size==0 and a non-empty partial file exists on disk, set
-        downloaded_bytes to the actual on-disk size instead of resetting to 0.
+        disk_size < downloaded_bytes → partial, not complete → re-queue as PENDING.
         """
         with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
             f.write(b"\x00" * 4096)
@@ -67,7 +63,7 @@ class RecoverUnknownLengthTests(unittest.IsolatedAsyncioTestCase):
             download.status = DownloadStatus.DOWNLOADING.value
             download.output_path = tmp_path
             download.file_size = 0
-            download.downloaded_bytes = 4096
+            download.downloaded_bytes = 8192  # stale DB value, more than what's on disk
             download.error_message = None
 
             manager = DownloadManager()
@@ -81,19 +77,18 @@ class RecoverUnknownLengthTests(unittest.IsolatedAsyncioTestCase):
             ):
                 await manager.recover_incomplete_downloads()
 
-            # The partial file has 4096 bytes on disk.
-            # After recovery the DB must reflect that, not 0.
+            # downloaded_bytes must reflect the on-disk size (4096), not 0 or the stale 8192.
             self.assertEqual(
                 download.downloaded_bytes,
                 4096,
-                "downloaded_bytes must reflect the on-disk partial file size when "
-                "file_size=0 (unknown-length stream). Resetting to 0 loses progress "
-                "and forces a full re-download that may exceed the catchup window.",
+                "downloaded_bytes must be set to on-disk size when file_size=0 and "
+                "disk_size < downloaded_bytes (partial stream). Resetting to 0 loses "
+                "progress; keeping the stale DB value would send a bad Range offset.",
             )
             self.assertEqual(
                 download.status,
                 DownloadStatus.PENDING.value,
-                "Unknown-length partial download must be requeued as PENDING.",
+                "Partial chunked download (disk_size < downloaded_bytes) must be requeued as PENDING.",
             )
         finally:
             os.unlink(tmp_path)

--- a/backend/tests/test_stream_chunked_bytes_commit.py
+++ b/backend/tests/test_stream_chunked_bytes_commit.py
@@ -1,0 +1,116 @@
+"""
+Regression: _stream_response_to_file must commit downloaded_bytes to the DB after
+the streaming loop when total_size == 0 (chunked / unknown-length stream).
+
+This commit is what makes recover_incomplete_downloads able to detect a complete
+chunked file. If it is removed, downloaded_bytes stays 0 in the DB at crash time,
+recovery cannot distinguish a complete chunked file from a partial one, and it
+re-queues the finished recording as PENDING (which risks HTTP 416 data loss on the
+next resume attempt).
+
+The tests in test_recover_chunked_complete_range416.py fabricate downloaded_bytes=8192
+to represent the post-commit DB state, so they pass even if this commit were deleted.
+This test targets the commit directly: it calls _stream_response_to_file and asserts
+that session.execute receives an update setting downloaded_bytes to the written count.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+class StreamChunkedByteCommitTests(unittest.IsolatedAsyncioTestCase):
+    async def test_chunked_stream_commits_final_byte_count(self):
+        """
+        For total_size == 0 the in-loop progress commit never fires (progress stays 0
+        and downloaded == total_size is only true before any bytes land). The post-loop
+        block must execute exactly once and set downloaded_bytes to the written count.
+
+        Removing the post-loop commit block would drop execute calls to 0 and fail
+        this test, proving the fix is load-bearing.
+        """
+        body = b"\x47" * 512
+
+        async def fake_iter_chunked(chunk_size):
+            yield body
+
+        mock_content = MagicMock()
+        mock_content.iter_chunked = fake_iter_chunked
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = mock_content
+
+        executed_stmts = []
+
+        async def capture_execute(stmt):
+            executed_stmts.append(stmt)
+            return MagicMock()
+
+        mock_session = AsyncMock()
+        mock_session.execute = capture_execute
+        mock_session.commit = AsyncMock()
+
+        manager = DownloadManager()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+        try:
+            with (
+                patch.object(manager, "_broadcast_log", AsyncMock()),
+                patch.object(manager, "_broadcast_progress", AsyncMock()),
+            ):
+                result = await manager._stream_response_to_file(
+                    response=mock_response,
+                    output_path=tmp_path,
+                    file_mode="wb",
+                    downloaded_start=0,
+                    total_size=0,
+                    download_id=99,
+                    session=mock_session,
+                )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+        self.assertEqual(result, 512, "Must return total bytes written.")
+
+        self.assertEqual(
+            len(executed_stmts),
+            1,
+            "Exactly one execute expected: the post-loop downloaded_bytes commit. "
+            "Zero means the commit block was removed.",
+        )
+        self.assertEqual(
+            mock_session.commit.call_count,
+            1,
+            "Exactly one commit expected after the loop.",
+        )
+
+        stmt = executed_stmts[0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql = str(compiled)
+        self.assertIn(
+            "downloaded_bytes",
+            sql,
+            "Post-loop execute must update downloaded_bytes.",
+        )
+        self.assertIn(
+            "512",
+            sql,
+            "Post-loop execute must set downloaded_bytes to 512 (actual written bytes).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

After a hard crash, a fully-downloaded chunked recording (no `Content-Length`) was always re-queued for re-download instead of being recognized as complete. This PR fixes the root cause in `recover_incomplete_downloads` and was preceded by PR #154 which fixed the acute data-loss symptom (416 on resume deleting the file).

**Root cause:** The `is_complete` check required `download.file_size` to be truthy. Chunked streams keep `file_size=0` throughout the download, so the expression short-circuited to `False` for every chunked download regardless of whether the file was actually complete.

**Fix:** When `file_size == 0`, compare on-disk size to `downloaded_bytes`. If they match (both non-zero), the download finished cleanly before the crash and is moved to completed. If `disk_size != downloaded_bytes`, the file is partial and is re-queued as before.

**Files changed:**
- `backend/services/download_manager.py`: `is_complete` check now handles chunked streams
- `backend/tests/test_recover_chunked_complete_range416.py` (Gremlin-authored): regression tests — both now pass
- `backend/tests/test_recover_unknown_length.py`: updated partial-file test to use `disk_size < downloaded_bytes` so the partial scenario is unambiguous after the new detection logic

## Before

A complete chunked recording crashed mid-status-update:
1. Restart: `file_size=0`, `downloaded_bytes=8192`, disk=8192
2. `is_complete` = False (file_size=0 short-circuits)
3. Status → PENDING, re-queued
4. Next attempt: `Range: bytes=8192-` → 416 → file preserved (PR #154) but entire recording re-downloaded unnecessarily, risks catchup window expiry

## After

Same scenario:
1. Restart: `file_size=0`, `downloaded_bytes=8192`, disk=8192
2. `is_complete` = True (`disk_size == downloaded_bytes > 0`)
3. Status → COMPLETED (or PROCESSING if post-processing configured), no re-download

## Test plan

- `python -m unittest tests/test_recover_chunked_complete_range416.py` — 2 tests pass (complete and partial scenarios)
- `python -m unittest tests/test_recover_unknown_length.py` — 3 tests pass (no regressions on partial-file preserve-bytes behavior)
- `python -m unittest discover -s tests` — 423 tests pass