### PR TITLE
fix: transcode() MP4/MKV-to-same-format with non-CPU hwaccel destroys recording

### DIFF
--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -788,13 +788,10 @@ class PostProcessor:
         input_file = Path(input_path)
         output_path = input_file.with_suffix(f".{output_format.value}")
 
-        # TS output always uses -c copy regardless of hw_accel, so TS-to-TS is always a
-        # no-op. Without this guard, non-CPU hw_accel misses the check below, ffmpeg
-        # writes to the same path as its input, and truncates the recording to 0 bytes.
-        if output_format == OutputFormat.TS and input_file.suffix.lower() == ".ts":
-            return str(input_path)
-        # If same format and no transcoding needed, skip
-        if input_file.suffix.lower() == f".{output_format.value}" and hw_accel == HardwareAccel.CPU:
+        # Same input and output format is always a no-op regardless of hw_accel.
+        # Without this guard, non-CPU hw_accel falls through and ffmpeg writes to the
+        # same path as its input, truncating the recording to 0 bytes before reading.
+        if input_file.suffix.lower() == f".{output_format.value}":
             return str(input_path)
 
         if not self.ffmpeg_available:

--- a/backend/tests/test_transcode_mp4_mkv_hwaccel_noop.py
+++ b/backend/tests/test_transcode_mp4_mkv_hwaccel_noop.py
@@ -1,0 +1,111 @@
+"""
+Regression test: transcode() with MP4 or MKV output and non-CPU hw_accel used to
+truncate the recording to 0 bytes.
+
+Root cause: the same-format early-exit guard had an `and hw_accel == CPU` condition,
+so VAAPI/NVIDIA/AMD fell through. ffmpeg was called with the same file as both input
+and output, which truncates the input to 0 bytes on open. Recording permanently
+destroyed.
+
+Fix: drop the hw_accel restriction. Same input/output format is always a no-op
+regardless of hw_accel.
+
+Related: test_transcode_ts_hwaccel_noop.py covers the identical bug for TS output
+(fixed earlier with a dedicated TS-to-TS guard, now unified into one check).
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+MODULE_PATH = BACKEND_ROOT / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_under_test", MODULE_PATH)
+POST_PROCESSOR_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(POST_PROCESSOR_MODULE)
+
+HardwareAccel = POST_PROCESSOR_MODULE.HardwareAccel
+OutputFormat = POST_PROCESSOR_MODULE.OutputFormat
+PostProcessor = POST_PROCESSOR_MODULE.PostProcessor
+
+
+class TranscodeMp4MkvHwAccelNoopTests(unittest.IsolatedAsyncioTestCase):
+    """transcode() must return the input path unchanged for same-format output, regardless of hw_accel."""
+
+    async def _assert_same_format_skips_ffmpeg(
+        self, suffix: str, output_format: "OutputFormat", hw_accel: "HardwareAccel"
+    ):
+        processor = PostProcessor()
+        processor._ffmpeg_path = "ffmpeg"
+        file_content = b"\x00" * 4096
+
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+            f.write(file_content)
+            tmp_path = f.name
+
+        try:
+            with patch.object(
+                processor, "_run_ffmpeg_with_progress", new_callable=AsyncMock
+            ) as mock_ffmpeg:
+                result = await processor.transcode(
+                    tmp_path, output_format, hw_accel=hw_accel
+                )
+
+            mock_ffmpeg.assert_not_called()
+            self.assertEqual(result, tmp_path, "Must return original path unchanged.")
+            self.assertEqual(
+                Path(tmp_path).stat().st_size,
+                len(file_content),
+                "Input file must not be truncated.",
+            )
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    # MP4 cases
+
+    async def test_mp4_to_mp4_cpu_skips_ffmpeg(self):
+        """Baseline: CPU already worked before the fix."""
+        await self._assert_same_format_skips_ffmpeg(".mp4", OutputFormat.MP4, HardwareAccel.CPU)
+
+    async def test_mp4_to_mp4_vaapi_skips_ffmpeg(self):
+        """VAAPI must not call ffmpeg for MP4-to-MP4 (was data-loss bug)."""
+        await self._assert_same_format_skips_ffmpeg(".mp4", OutputFormat.MP4, HardwareAccel.VAAPI)
+
+    async def test_mp4_to_mp4_nvidia_skips_ffmpeg(self):
+        """NVIDIA must not call ffmpeg for MP4-to-MP4."""
+        await self._assert_same_format_skips_ffmpeg(".mp4", OutputFormat.MP4, HardwareAccel.NVIDIA)
+
+    async def test_mp4_to_mp4_amd_skips_ffmpeg(self):
+        """AMD must not call ffmpeg for MP4-to-MP4."""
+        await self._assert_same_format_skips_ffmpeg(".mp4", OutputFormat.MP4, HardwareAccel.AMD)
+
+    # MKV cases
+
+    async def test_mkv_to_mkv_cpu_skips_ffmpeg(self):
+        """Baseline: CPU already worked before the fix."""
+        await self._assert_same_format_skips_ffmpeg(".mkv", OutputFormat.MKV, HardwareAccel.CPU)
+
+    async def test_mkv_to_mkv_vaapi_skips_ffmpeg(self):
+        """VAAPI must not call ffmpeg for MKV-to-MKV (was data-loss bug)."""
+        await self._assert_same_format_skips_ffmpeg(".mkv", OutputFormat.MKV, HardwareAccel.VAAPI)
+
+    async def test_mkv_to_mkv_nvidia_skips_ffmpeg(self):
+        """NVIDIA must not call ffmpeg for MKV-to-MKV."""
+        await self._assert_same_format_skips_ffmpeg(".mkv", OutputFormat.MKV, HardwareAccel.NVIDIA)
+
+    async def test_mkv_to_mkv_amd_skips_ffmpeg(self):
+        """AMD must not call ffmpeg for MKV-to-MKV."""
+        await self._assert_same_format_skips_ffmpeg(".mkv", OutputFormat.MKV, HardwareAccel.AMD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If you use VAAPI, NVIDIA, or AMD hardware acceleration and your Recording Format is MP4 or MKV, any VOD download was being permanently destroyed during post-processing. The download would show as FAILED with no recovery possible.

## What was broken

`transcode()` in `post_processor.py` has an early exit for same-format output (e.g. an MP4 file being transcoded to MP4 is a no-op). But the check had an `and hw_accel == CPU` restriction, so VAAPI/NVIDIA/AMD fell through to ffmpeg. ffmpeg received the same file path for both `-i` (input) and output, truncating the input to 0 bytes before it could read a single byte. The recording was gone.

The TS-to-TS case was fixed in PR #136 with a dedicated guard. MP4-to-MP4 and MKV-to-MKV were left open.

## Before

With VAAPI hwaccel and MP4 output format, a VOD download produces `Movie (2020).mp4`. Post-processing calls `transcode("Movie.mp4", OutputFormat.MP4, HardwareAccel.VAAPI)`. Neither guard fires. ffmpeg: `-i Movie.mp4 -y ... Movie.mp4`. File truncated to 0 bytes. Download marked FAILED.

## After

The same-format guard now applies to all hw_accel values. `transcode("Movie.mp4", OutputFormat.MP4, HardwareAccel.VAAPI)` returns the input path unchanged without calling ffmpeg.

## Change

`backend/services/post_processor.py`: removed `and hw_accel == HardwareAccel.CPU` from line 797; unified the TS-specific guard and the general guard into one check.

## Tests

8 new regression tests in `test_transcode_mp4_mkv_hwaccel_noop.py`: MP4-to-MP4 and MKV-to-MKV for CPU (baseline), VAAPI, NVIDIA, and AMD. Each asserts ffmpeg is not called and the file is not truncated. Existing TS tests all still pass.

429 tests pass.

## How to test

1. Configure Settings: Hardware Acceleration = VAAPI (or NVIDIA/AMD), Recording Format = MP4.
2. Queue a VOD download.
3. After download completes, confirm post-processing succeeds and the `.mp4` file is intact.
4. Before this fix: post-processing would destroy the file.