### PR TITLE
docs: add changelog entries for PRs #156 and #162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+## 2026-06-08
+
+### Improved: Downloads History now has a filter to show only completed, failed, or cancelled recordings
+
+**What you would notice:** The History tab on the Downloads page used to show all past recordings in one mixed list. Finding the recordings that failed, or checking what you had cancelled, meant scrolling through everything. A filter dropdown now sits at the top of the History panel. Choose from All, Completed, Failed, or Cancelled to narrow the list instantly. This is a display change only and does not affect your recordings.
+
+**What changed:** A status filter dropdown was added to the Downloads > History tab. Selecting a status narrows the list immediately. No backend changes were made.
+
+---
+
+### Fixed: The EPG Offset (minutes) setting now actually shifts program times in the guide
+
+**What you would notice:** Settings has a global "EPG Offset (minutes)" field that is supposed to shift all program times forward or backward to correct for a provider that sends guide data in the wrong timezone. Before this fix, you could save a value there and nothing would change. The setting was stored in the database but never read. Program times in Browse and EPG search now shift by the number of minutes you enter in that field.
+
+**What changed:** The EPG service now reads the global offset and adds it on top of any per-account guide offset when displaying programs in Browse EPG and EPG search. If you previously set this field and noticed it had no effect, it will now work after updating.
+
+---
+
 ## 2026-06-07
 
 ### Fixed: Hardware-accelerated transcoding no longer destroys MP4 and MKV recordings

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Then open **http://localhost:4177** in your browser.
 - The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
+- The **History** tab shows past downloads. Use the status filter dropdown at the top to show only Completed, Failed, or Cancelled entries
 - Failed downloads can be retried from the same page
 - Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries stay so you can retry them)
 


### PR DESCRIPTION
## What changed

Adds changelog entries for two PRs merged on 2026-06-08 that did not have changelog coverage:

- **PR #156** (fix: EPG Offset minutes now applies to guide display times): the global EPG Offset setting was saved but never read, so it had no effect. Now it shifts program times in Browse EPG and EPG search.
- **PR #162** (design: status filter on Downloads History tab): a filter dropdown lets users narrow the History list by All, Completed, Failed, or Cancelled.

Also adds one line to the README "Monitor Downloads" section describing the History tab filter, since that section listed Active and Upcoming behavior but said nothing about History.

## What an operator would notice

- CHANGELOG now covers all PRs through #163 with no gaps.
- README "Monitor Downloads" section now tells users the History tab has a status filter.

## How it was tested

- Changelog entries checked against Herald merge summary and PR descriptions for accuracy.
- No em dashes used anywhere.
- Two files changed: CHANGELOG.md and README.md.