### PR TITLE
fix: restrict POST /epg/refresh to admin users only

### DIFF
--- a/backend/api/epg.py
+++ b/backend/api/epg.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_, func
 
-from auth import require_admin_or_download_user, AuthContext
+from auth import require_admin, require_admin_or_download_user, AuthContext
 from database import get_session
 from models import XtreamAccount, EPGProgram
 from services.epg_service import epg_service
@@ -83,7 +83,7 @@ async def epg_status(_admin: None = Depends(require_admin_or_download_user)):
 @router.post("/epg/refresh")
 async def trigger_epg_refresh(
     request: EPGRefreshRequest,
-    _admin: None = Depends(require_admin_or_download_user),
+    _admin: None = Depends(require_admin),
 ):
     status = epg_ingest_manager.get_status()
     if status.get("running"):

--- a/backend/tests/test_epg_refresh_admin_only.py
+++ b/backend/tests/test_epg_refresh_admin_only.py
@@ -1,0 +1,66 @@
+"""
+Regression test: POST /epg/refresh must be admin-only.
+
+Before fix: trigger_epg_refresh used require_admin_or_download_user.
+Any authenticated user, including Plex-provisioned download_only accounts,
+could trigger a full EPG refresh, hammering the IPTV provider and the host
+with repeated XMLTV ingests.
+
+After fix: trigger_epg_refresh uses require_admin.
+Download-only sessions receive HTTP 403.
+"""
+import inspect
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+
+from auth import require_admin, AuthContext
+
+
+class EPGRefreshWiringTest(unittest.TestCase):
+
+    def test_trigger_epg_refresh_uses_require_admin(self):
+        """trigger_epg_refresh must declare require_admin as its auth dependency."""
+        from api.epg import trigger_epg_refresh
+        sig = inspect.signature(trigger_epg_refresh)
+        admin_param = sig.parameters.get("_admin")
+        self.assertIsNotNone(admin_param, "_admin parameter missing from handler")
+        dep = admin_param.default
+        self.assertEqual(
+            dep.dependency,
+            require_admin,
+            "trigger_epg_refresh must use require_admin, not require_admin_or_download_user",
+        )
+
+
+class EPGRefreshAuthGuardTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_download_only_user_gets_403(self):
+        """require_admin must reject a download_only session with HTTP 403."""
+        ctx = AuthContext(authenticated=True, is_admin=False, role="download_only")
+        with self.assertRaises(HTTPException) as cm:
+            await require_admin(context=ctx)
+        self.assertEqual(cm.exception.status_code, 403)
+
+    async def test_unauthenticated_gets_403(self):
+        """require_admin must reject an unauthenticated context."""
+        ctx = AuthContext(authenticated=False)
+        with self.assertRaises(HTTPException) as cm:
+            await require_admin(context=ctx)
+        self.assertEqual(cm.exception.status_code, 403)
+
+    async def test_admin_passes_guard(self):
+        """require_admin must allow an admin session through."""
+        ctx = AuthContext(authenticated=True, is_admin=True, role="admin")
+        result = await require_admin(context=ctx)
+        self.assertIs(result, ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`POST /api/epg/refresh` was protected by `require_admin_or_download_user`, which means any logged-in user, including Plex-provisioned accounts, could trigger a full EPG refresh. This PR changes the guard to `require_admin`. `GET /epg/status` and `GET /epg/search` are unchanged and remain accessible to all authenticated users.

## Why this matters for operators

A Mustarrd instance with Plex login enabled and `auto_allow_all_server_users = true` exposes the refresh endpoint to every Plex server member. A user (or a misbehaving app) could chain back-to-back force-refreshes, repeatedly hitting the IPTV provider for the full channel list and XMLTV data for every account. This can exhaust the provider's connection quota, trigger rate limits, and block legitimate downloads.

## Before

Any authenticated user can POST to `/api/epg/refresh`:
```
curl -X POST /api/epg/refresh -d '{"force":true}'
# -> HTTP 200, full refresh starts
```

## After

Only admin sessions succeed:
```
# download_only session
curl -X POST /api/epg/refresh -d '{"force":true}'
# -> HTTP 403 Admin access required

# admin session
curl -X POST /api/epg/refresh -d '{"force":true}'
# -> HTTP 200, refresh starts
```

## Tests

Added `backend/tests/test_epg_refresh_admin_only.py`:
- `test_trigger_epg_refresh_uses_require_admin`: inspects the handler signature and asserts `require_admin` is the declared dependency, so a revert would turn this red
- `test_download_only_user_gets_403`: calls `require_admin` with a download_only AuthContext, asserts HTTP 403
- `test_unauthenticated_gets_403`: unauthenticated context also gets 403
- `test_admin_passes_guard`: admin context passes through

Full suite: 463 tests, OK.