### PR TITLE
docs: fix stale session cookie env var in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-08
 
+### Fixed: Only admins can now trigger a manual EPG guide refresh
+
+**What you would notice:** On a shared Mustarrd instance where Plex login is enabled or multiple users have accounts, any logged-in user could previously trigger a full EPG refresh. This could hammer your IPTV provider repeatedly if a user or an app did it in a loop, risking rate limits that block normal downloads. This is now limited to admin accounts.
+
+**What changed:** The "Force Refresh EPG" button now requires an admin session. Regular users and Plex-provisioned accounts will get a permission error if they try to trigger it. Browsing the channel guide, searching, and all other EPG features are unaffected.
+
+---
+
+### Improved: An orange banner now appears on every page when disk space is low or recordings are paused
+
+**What you would notice:** Before this change, if scheduled recordings were paused because disk space ran low, a warning badge only appeared on the Scheduled recordings page. Browsing the guide or adjusting settings gave no indication that recordings had stopped. An orange banner now appears at the top of every page in those situations, showing the current free disk space and telling you what to do.
+
+**What changed:** A banner was added to the top of every page in the app. It appears when any scheduled recording is in a paused (low space) state, or when free disk space falls below your configured minimum. No backend changes were made.
+
+---
+
+### Fixed: Completed recordings are no longer re-downloaded after a container restart
+
+**What you would notice:** After restarting Mustarrd (for example after an Unraid array operation), some recordings that had finished downloading would be queued to download again from scratch. If the original catchup window had expired by the time the re-download started, the recording would fail. This affected recordings from providers that do not send a file size in the download response (chunked downloads).
+
+**What changed:** Mustarrd now checks whether a recording is complete by comparing the file size on disk to the amount already downloaded, even when the provider did not report a total file size. Recordings that match are moved to completed on restart instead of being re-queued.
+
+---
+
 ### Improved: Downloads History now has a filter to show only completed, failed, or cancelled recordings
 
 **What you would notice:** The History tab on the Downloads page used to show all past recordings in one mixed list. Finding the recordings that failed, or checking what you had cancelled, meant scrolling through everything. A filter dropdown now sits at the top of the History panel. Choose from All, Completed, Failed, or Cancelled to narrow the list instantly. This is a display change only and does not affect your recordings.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Then open **http://localhost:4177** in your browser.
 - The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
+- When any scheduled recording is paused for low disk space, or when free space drops below the configured minimum, an orange banner appears at the top of every page, not just Downloads, so you are alerted no matter where you are in the app
 - The **History** tab shows past downloads. Use the status filter dropdown at the top to show only Completed, Failed, or Cancelled entries
 - Failed downloads can be retried from the same page
 - Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries stay so you can retry them)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Most users never need to touch these. Set them in `docker-compose.yml` or a `bac
 | `CATCHUP_MAX_CONCURRENT_DOWNLOADS` | Max simultaneous downloads | `2` |
 | `CATCHUP_SESSION_SECRET` | Session signing key, auto-generated and persisted to `./config/session_secret` on first run. Only set this manually to rotate or share across instances | *(auto)* |
 | `CATCHUP_CORS_ORIGINS` | Comma-separated allowed frontend origins; only needed when the UI is accessed from a non-localhost address | `http://localhost:4178,...` |
-| `CATCHUP_SESSION_HTTPS_ONLY` | Require HTTPS for session cookies | `true` |
+| `CATCHUP_SESSION_COOKIE_SECURE_MODE` | When to mark session cookies as HTTPS-only: `auto` (default, detects HTTPS including reverse-proxy setups), `always`, or `never` | `auto` |
 | `CATCHUP_ALLOW_REMOTE_SETUP` | Allow password setup from non-local IPs | `false` |
 | `CATCHUP_FFMPEG_PATH` | Path to ffmpeg binary | *(auto-detected)* |
 | `CATCHUP_COMSKIP_PATH` | Path to comskip binary | *(auto-detected)* |


### PR DESCRIPTION
## What a user would notice

Three documentation updates in one PR:

1. **README fix:** The Configuration table listed \`CATCHUP_SESSION_HTTPS_ONLY\` as the way to control whether session cookies require HTTPS. This variable was replaced by \`CATCHUP_SESSION_COOKIE_SECURE_MODE\` in February 2026, but the README was never updated. A user setting \`CATCHUP_SESSION_HTTPS_ONLY=false\` to allow HTTP access would get no effect.

2. **README addition:** The Monitor Downloads section now mentions the app-wide orange banner added in PR #164. Previously the README described the disk space badge on the Downloads page but said nothing about the banner that appears on every page when space is low.

3. **Changelog:** Plain-English entries added for PRs #159, #164, and #167.

## What changed

- README: replaced stale \`CATCHUP_SESSION_HTTPS_ONLY\` row with \`CATCHUP_SESSION_COOKIE_SECURE_MODE\`
- README: added one bullet describing the app-wide low disk space banner (PR #164)
- CHANGELOG: added entries for PRs #159 (chunked-complete re-download fix), #164 (low-disk banner), #167 (EPG refresh admin-only)

No code changes.

## How it was tested

Diff reviewed for correctness. No em dashes present.