### PR TITLE
[Design] Fix badge layout in Downloads Upcoming cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -654,20 +654,22 @@ export default function Downloads() {
             <Stack gap="sm">
               {upcomingRecordings.map((rec) => (
                 <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
-                  <Group justify="space-between" wrap="nowrap">
-                    <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
-                      <Text fw={500}>{rec.program_title}</Text>
-                      <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
-                      <Text size="xs" c="dimmed">
-                        Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
-                      </Text>
-                    </Stack>
-                    {rec.status === 'paused_low_space' && (
-                      <Badge color="yellow" variant="light" size="sm" leftSection={<IconAlertCircle size={12} />}>
-                        Paused (Low Space)
-                      </Badge>
-                    )}
-                  </Group>
+                  <Stack gap={2}>
+                    <Group justify="space-between" wrap="nowrap" align="flex-start">
+                      <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
+                        <Text fw={500}>{rec.program_title}</Text>
+                        <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
+                      </Stack>
+                      {rec.status === 'paused_low_space' && (
+                        <Badge color="yellow" variant="light" size="sm" leftSection={<IconAlertCircle size={12} />}>
+                          Paused (Low Space)
+                        </Badge>
+                      )}
+                    </Group>
+                    <Text size="xs" c="dimmed">
+                      Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
+                    </Text>
+                  </Stack>
                 </Card>
               ))}
             </Stack>


### PR DESCRIPTION
## What changed

The PAUSED (LOW SPACE) badge on Downloads > Upcoming cards was positioned as a flex sibling to the entire text stack. On mobile (390px), the badge stole enough width that the air timestamp split across two lines: "Airs: Wed Jun 10, 2026 8:00" on one line and "PM (1h 30m)" on the next. A user glancing at the card saw "8:00" with no AM/PM context until they read the line below.

The Scheduled Recordings page already handles this correctly by putting the badge in the title row and keeping the airs text at full card width. The Downloads Upcoming card used a different layout that broke under badge presence.

## What was changed

Restructured the Upcoming recording card in `Downloads.jsx` to match the Scheduled page layout: badge moves into a Group alongside the title and channel (top row), airs timestamp moves below that Group on its own full-width line. One component restructure, no logic touched.

## Before and after

### Before (mobile) — air time wraps mid-string

The badge sits beside the whole text block, leaving too little width for the timestamp.

![Before mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1513379394020970659/downloads_upcoming_mobile.png)

### After (mobile) — badge in title row, air time on its own line

![After mobile](https://cdn.discordapp.com/attachments/1512706418778570873/1513379414698885140/after_upcoming_mobile.png)

### Before (desktop)

![Before desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1513379436303618204/downloads_upcoming_desktop.png)

### After (desktop)

![After desktop](https://cdn.discordapp.com/attachments/1512706418778570873/1513379458478772294/after_upcoming_desktop.png)

## Testing

Verified at 1280x800 and 390x844 with Playwright. No regressions on Browse, Scheduled, Settings, or Accounts pages.