### PR TITLE
[Design] Fix Downloads tab bar wrapping on mobile

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -589,7 +589,7 @@ export default function Downloads() {
       </Group>
 
       <Tabs defaultValue="active">
-        <Tabs.List>
+        <Tabs.List grow style={{ flexWrap: 'nowrap' }}>
           <Tabs.Tab value="active" leftSection={<IconDownload size={16} />}>
             Active {activeDownloads.length > 0 && `(${activeDownloads.length})`}
           </Tabs.Tab>


### PR DESCRIPTION
## What a user sees

On a phone (390px wide), the Downloads page shows three tabs: Active, Upcoming, and History. Before this change, the History tab fell to a second row because the three tabs together were wider than the screen. The page looked broken and an operator might not notice all three sections exist.

## What changed

One-line change in Downloads.jsx: added grow and style={{ flexWrap: 'nowrap' }} to Tabs.List. This distributes the three tabs equally across the available width and prevents the second-row fallback.

## Before / After

Mobile (390px) before: "Active" and "Upcoming (3)" on row 1, "History (5)" dropped to row 2.
Mobile (390px) after: all three tabs on a single row, each taking one-third of the width.
Desktop (1280px): tabs spread evenly across the full tab bar (no change in usability).

## Testing

Playwright screenshots at 390px and 1280px confirm the fix. No logic changed.