### PR TITLE
[Design] Fix status badge layout in Scheduled recording cards

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -100,7 +100,7 @@ function ScheduleCard({
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder>
       <Stack gap="xs">
-        <Group justify="space-between" wrap="nowrap">
+        <Group justify="space-between" wrap="nowrap" align="flex-start">
           <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
             <Text fw={500}>
               {schedule.program_title}
@@ -108,36 +108,34 @@ function ScheduleCard({
             <Text size="sm" c="dimmed" truncate>
               {schedule.channel_name}
             </Text>
-          </Stack>
-          <Group gap="xs">
             {getStatusBadge(schedule.status)}
-            <Menu shadow="md" width={160}>
-              <Menu.Target>
-                <ActionIcon variant="subtle">
-                  <IconDotsVertical size={16} />
-                </ActionIcon>
-              </Menu.Target>
-              <Menu.Dropdown>
-                {isActive && (
-                  <Menu.Item
-                    leftSection={<IconPlayerStop size={14} />}
-                    onClick={() => onCancel(schedule)}
-                  >
-                    Cancel
-                  </Menu.Item>
-                )}
-                {canDelete && (
-                  <Menu.Item
-                    color="red"
-                    leftSection={<IconTrash size={14} />}
-                    onClick={() => setConfirmingDelete(true)}
-                  >
-                    Delete
-                  </Menu.Item>
-                )}
-              </Menu.Dropdown>
-            </Menu>
-          </Group>
+          </Stack>
+          <Menu shadow="md" width={160}>
+            <Menu.Target>
+              <ActionIcon variant="subtle">
+                <IconDotsVertical size={16} />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {isActive && (
+                <Menu.Item
+                  leftSection={<IconPlayerStop size={14} />}
+                  onClick={() => onCancel(schedule)}
+                >
+                  Cancel
+                </Menu.Item>
+              )}
+              {canDelete && (
+                <Menu.Item
+                  color="red"
+                  leftSection={<IconTrash size={14} />}
+                  onClick={() => setConfirmingDelete(true)}
+                >
+                  Delete
+                </Menu.Item>
+              )}
+            </Menu.Dropdown>
+          </Menu>
         </Group>
 
         <Text size="xs" c="dimmed">


### PR DESCRIPTION
## What changed

Status badges on Scheduled Recordings cards are now placed below the channel name (left stack) instead of beside the title with the menu button (right side).

**Before:** Badge and menu button shared the right column of the card header. On mobile, long titles like "Great British Bake Off" wrapped to two lines because the badge claimed ~120px of horizontal space.

**After:** Badge sits below the channel name on the left. The menu button is alone at the top-right. Long titles fit on one line at 390px.

## Why

A non-technical operator on a phone screen needs to see the show title at a glance. When "Great British Bake Off" wraps mid-word it is harder to read than "Great British Bake Off" on one line with the badge underneath. This mirrors the fix already applied to Downloads Upcoming cards in PR #171.

## Files changed

- `frontend/src/pages/Scheduled.jsx`: move `getStatusBadge()` call from the right-side `<Group>` into the left-side `<Stack>`, below the channel name. Remove the now-empty wrapping `<Group>` around badge and menu. Add `align="flex-start"` to the outer row Group so the menu button pins to the top.

No backend changes. No logic changes.

## Screenshots

Before and after posted to #design.

**Mobile before:** title wraps, badge and menu button in same right column.
**Mobile after:** title on one line, badge below channel name, menu at top-right.
**Desktop before:** badge inline with menu button in header row.
**Desktop after:** badge below channel name, cleaner visual hierarchy.

## Test plan

- Open Scheduled > Upcoming at 390px. Long titles (Great British Bake Off) fit on one line.
- Status badge (Scheduled, Paused Low Space, etc.) appears below the channel name.
- Menu button (three dots) is alone at top-right, vertically aligned to card top.
- Cards with short titles look correct at 1280px desktop.
- Menu still works: Cancel and Delete items present and functional.