### PR TITLE
fix: sync ScheduledRecording to QUEUED when retrying a download

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -11,7 +11,7 @@ from typing import Optional, Callable, Dict, Set, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, update
 
-from models import Download, DownloadStatus, AppSettings, XtreamAccount, PlexServer, ScheduledRecording
+from models import Download, DownloadStatus, AppSettings, XtreamAccount, PlexServer, ScheduledRecording, ScheduledStatus
 from config import settings as app_settings, is_docker_env
 from database import async_session_maker
 from services.log_stream import backend_log_stream
@@ -1507,6 +1507,7 @@ class DownloadManager:
                 download.downloaded_bytes = 0
                 download.error_message = None
                 download.completed_at = None
+                await self._sync_schedule_status(session, download_id, ScheduledStatus.QUEUED.value)
                 await session.commit()
 
                 self._cancelled.discard(download_id)

--- a/backend/tests/test_retry_schedule_dedup.py
+++ b/backend/tests/test_retry_schedule_dedup.py
@@ -1,146 +1,113 @@
+"""
+Regression test: retry_download leaves ScheduledRecording.status stale, bypassing dedup.
+
+Before the fix:
+- retry_download() reset Download.status to PENDING and re-queued the download, but
+  never called _sync_schedule_status. The linked ScheduledRecording stayed
+  failed/cancelled, which is not in create_schedule()'s active_statuses list.
+- A second POST /api/schedules for the same program returned 200 (no 409 conflict),
+  created a duplicate ScheduledRecording, and eventually launched a second download
+  writing to the same output_path, corrupting the file.
+
+After the fix:
+- retry_download() calls _sync_schedule_status(..., ScheduledStatus.QUEUED.value)
+  before committing, so the linked ScheduledRecording enters the active_statuses list
+  and the dedup guard blocks any duplicate schedule creation.
+"""
 import sys
 import unittest
-from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import asynccontextmanager
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from services.download_manager import DownloadManager
 from models import DownloadStatus, ScheduledStatus
+from services.download_manager import DownloadManager
 
 
-def _make_download(dl_id, status):
-    d = MagicMock()
-    d.id = dl_id
-    d.status = status
-    d.progress = 0.0
-    d.downloaded_bytes = 0
-    d.error_message = "provider timeout"
-    d.completed_at = None
-    return d
+def _make_fake_session(download_status):
+    """Return a fake async_session_maker yielding a download with the given status."""
 
+    def make_download(status):
+        d = MagicMock()
+        d.id = 42
+        d.status = status
+        d.progress = 50
+        d.downloaded_bytes = 1000
+        d.error_message = "some error"
+        d.completed_at = "2026-01-01T00:00:00"
+        return d
 
-def _make_session_maker(download):
-    result = MagicMock()
-    result.scalar_one_or_none.return_value = download
-    session = AsyncMock()
-    session.execute = AsyncMock(return_value=result)
-    session.commit = AsyncMock()
+    fake_session = AsyncMock()
+
+    async def fake_execute(stmt, *args, **kwargs):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = make_download(download_status)
+        result.scalars.return_value.all.return_value = []
+        return result
+
+    fake_session.execute = fake_execute
+    fake_session.commit = AsyncMock()
 
     @asynccontextmanager
-    async def ctx():
-        yield session
+    async def maker():
+        yield fake_session
 
-    return ctx
+    return maker, fake_session
 
 
-class RetryScheduleDedupTests(unittest.IsolatedAsyncioTestCase):
-    """
-    BUG: retry_download does not call _sync_schedule_status.
+class RetryDownloadScheduleDedupTests(unittest.IsolatedAsyncioTestCase):
 
-    After a user cancels or fails a scheduled download and then retries it,
-    the linked ScheduledRecording.status stays "cancelled" or "failed".
-    create_schedule() dedup guard checks ScheduledRecording.status IN
-    (scheduled, paused_low_space, queued, downloading, processing).
-    Neither "cancelled" nor "failed" is in that list, so the in-progress
-    retried download is invisible to the guard.
-
-    Result: a second POST /api/schedules for the same show succeeds, the
-    scheduler fires a second download, and both writes go to the same
-    output_path, corrupting the file.
-
-    These tests FAIL on the current codebase because retry_download never
-    calls _sync_schedule_status.
-
-    Fix: call _sync_schedule_status(session, download_id, ScheduledStatus.QUEUED.value)
-    inside retry_download after resetting download.status to PENDING.
-    """
-
-    @unittest.expectedFailure
-    async def test_retry_cancelled_download_resets_schedule_status(self):
-        """
-        retry_download on a CANCELLED download must reset the linked
-        ScheduledRecording status so the dedup guard blocks re-scheduling.
-        """
+    async def _run_retry_and_capture_sync_calls(self, download_status):
         manager = DownloadManager()
-        dl_id = 42
-
-        download = _make_download(dl_id, DownloadStatus.CANCELLED.value)
-
         sync_calls = []
 
         async def spy_sync(session, download_id, new_status):
             sync_calls.append((download_id, new_status))
 
-        manager._sync_schedule_status = spy_sync
+        maker, _ = _make_fake_session(download_status)
 
-        with patch("services.download_manager.async_session_maker", _make_session_maker(download)):
-            result = await manager.retry_download(dl_id)
+        with patch("services.download_manager.async_session_maker", side_effect=maker):
+            manager._sync_schedule_status = spy_sync
+            result = await manager.retry_download(42)
 
-        self.assertTrue(result, "retry_download must return True for a CANCELLED download.")
+        return result, sync_calls
 
-        # This assertion FAILS on the current codebase because retry_download
-        # never calls _sync_schedule_status.
+    async def test_retry_cancelled_download_syncs_schedule_to_queued(self):
+        """retry_download must call _sync_schedule_status(QUEUED) for CANCELLED downloads."""
+        result, sync_calls = await self._run_retry_and_capture_sync_calls(
+            DownloadStatus.CANCELLED.value
+        )
+        self.assertTrue(result, "retry_download must return True for CANCELLED downloads.")
         self.assertTrue(
             sync_calls,
-            "retry_download must call _sync_schedule_status to reset the linked "
-            "ScheduledRecording.status. Currently it does not, leaving the schedule "
-            "as 'cancelled', which lets the dedup guard in create_schedule() be "
-            "bypassed. A second POST /api/schedules for the same show then succeeds "
-            "and a duplicate download is created.",
+            "retry_download must call _sync_schedule_status for CANCELLED downloads.",
         )
-
-        called_download_id, called_status = sync_calls[0]
-        self.assertEqual(called_download_id, dl_id)
+        _, called_status = sync_calls[0]
         self.assertEqual(
             called_status,
             ScheduledStatus.QUEUED.value,
-            "retry_download must reset ScheduledRecording to an active status "
-            "(queued) so the dedup guard recognizes it as in-flight.",
+            f"Expected schedule synced to QUEUED, got {called_status!r}.",
         )
 
-    @unittest.expectedFailure
-    async def test_retry_failed_download_resets_schedule_status(self):
-        """
-        retry_download on a FAILED download must also reset the linked
-        ScheduledRecording status. Failure path is the more common real-world
-        trigger: provider timeout or HTTP error marks the download failed, user
-        retries, then tries to re-schedule thinking it is unscheduled.
-        """
-        manager = DownloadManager()
-        dl_id = 43
-
-        download = _make_download(dl_id, DownloadStatus.FAILED.value)
-
-        sync_calls = []
-
-        async def spy_sync(session, download_id, new_status):
-            sync_calls.append((download_id, new_status))
-
-        manager._sync_schedule_status = spy_sync
-
-        with patch("services.download_manager.async_session_maker", _make_session_maker(download)):
-            result = await manager.retry_download(dl_id)
-
-        self.assertTrue(result, "retry_download must return True for a FAILED download.")
-
+    async def test_retry_failed_download_syncs_schedule_to_queued(self):
+        """retry_download must call _sync_schedule_status(QUEUED) for FAILED downloads."""
+        result, sync_calls = await self._run_retry_and_capture_sync_calls(
+            DownloadStatus.FAILED.value
+        )
+        self.assertTrue(result, "retry_download must return True for FAILED downloads.")
         self.assertTrue(
             sync_calls,
-            "retry_download must call _sync_schedule_status for FAILED downloads too. "
-            "Without this, the same dedup bypass applies: re-scheduling a failed-then-retried "
-            "show creates a duplicate download to the same output_path.",
+            "retry_download must call _sync_schedule_status for FAILED downloads.",
         )
-
-        called_download_id, called_status = sync_calls[0]
-        self.assertEqual(called_download_id, dl_id)
+        _, called_status = sync_calls[0]
         self.assertEqual(
             called_status,
             ScheduledStatus.QUEUED.value,
-            "retry_download must reset ScheduledRecording to QUEUED so the dedup guard "
-            "recognizes it as in-flight.",
+            f"Expected schedule synced to QUEUED, got {called_status!r}.",
         )
 
 


### PR DESCRIPTION
## What a user would notice

If you retried a failed or cancelled recording and then tried to schedule the same program again before the retry finished, Mustarrd would accept the second schedule request instead of saying the recording was already in progress. Both downloads would write to the same file at the same time, corrupting it.

## What changed

`retry_download()` now updates the linked scheduled recording's status back to "queued" before re-queuing the download. Previously it only reset the download itself, leaving the schedule record stuck in "failed" or "cancelled," which the duplicate-schedule guard did not check.

One line added in `download_manager.py` (line 1493):
```python
await self._sync_schedule_status(session, download_id, ScheduledStatus.QUEUED.value)
```

`ScheduledStatus` was not previously imported in `download_manager.py`; that import was also added.

## How it was tested

Manually reproduced the sequence Gremlin described in the #tasks thread:
1. Create a schedule, let it dispatch and start downloading.
2. Cancel the download.
3. Retry the download (`POST /api/downloads/{id}/retry`).
4. Before the retry finishes, try to schedule the same program again.

Before fix: second `POST /api/schedules` returns 200 (duplicate created).
After fix: second request returns 409 "A scheduled recording for this program already exists."

Automated regression tests cover both CANCELLED and FAILED retry paths, asserting `_sync_schedule_status` is called with `QUEUED`.

Full suite: 481 tests pass.

Closes the bug documented in #tasks thread "retry_download leaves ScheduledRecording.status stale, dedup bypassed" (also tracked by gremlin PR #173, which has a complementary failing test against the pre-fix behavior).