### PR TITLE
fix: unique output paths for zero-metadata series episodes

### DIFF
--- a/backend/services/vod_namer.py
+++ b/backend/services/vod_namer.py
@@ -38,16 +38,24 @@ def series_episode_output_path(
     episode: int,
     episode_title: Optional[str],
     extension: Optional[str],
+    episode_id: Optional[str] = None,
 ) -> str:
     safe_show = _sanitize_component(show_name)
     safe_title = _sanitize_component(episode_title) if episode_title else ""
-    season_num = max(int(season or 0), 0)
-    episode_num = max(int(episode or 0), 0)
+    # Preserve raw values so negative season/episode numbers (common with
+    # non-conforming providers) produce distinct paths rather than colliding
+    # with genuine season=0/episode=0 entries.
+    season_num = int(season or 0)
+    episode_num = int(episode or 0)
 
     season_folder = f"Season {season_num:02d}"
     base_name = f"S{season_num:02d}E{episode_num:02d} - {safe_show}"
     if safe_title:
         base_name = f"{base_name} - {safe_title}"
+    elif season_num == 0 and episode_num == 0 and episode_id:
+        # No usable metadata: append the provider episode ID so multiple
+        # zero-metadata episodes of the same show get distinct output paths.
+        base_name = f"{base_name} - {_sanitize_component(str(episode_id))}"
 
     filename = f"{base_name}.{_safe_extension(extension)}"
 

--- a/backend/services/vod_service.py
+++ b/backend/services/vod_service.py
@@ -123,6 +123,7 @@ async def build_episode_download(
         episode_num,
         episode_title,
         container_extension,
+        episode_id=episode_id,
     )
 
     trusted_direct_source = _trusted_direct_source(direct_source, account.server_url)

--- a/backend/tests/test_series_episode_path_collision.py
+++ b/backend/tests/test_series_episode_path_collision.py
@@ -1,0 +1,99 @@
+"""
+Regression test: series_episode_output_path must produce unique paths for
+distinct episodes even when all available metadata is identical (season=0,
+episode_num=0, no episode title).
+
+Non-conforming IPTV providers commonly return episodes with no season or
+episode numbers and no episode title. When a user selects multiple such
+episodes for download, build_episode_download() calls
+series_episode_output_path() for each with the same metadata values.
+All calls produce the same output path, for example:
+
+    /downloads/My Show/Season 00/S00E00 - My Show.mkv
+
+The second and subsequent downloads silently overwrite or corrupt the first.
+The user sees N "Completed" entries in the Downloads list but only one actual
+file on disk. No error is raised.
+
+Fix requires series_episode_output_path to accept an episode_id fallback so
+it can produce unique filenames when season/episode_num/title are all missing.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.vod_namer import series_episode_output_path
+
+
+class SeriesEpisodePathCollisionTests(unittest.TestCase):
+
+    def _batch_paths(self, episodes):
+        """Simulate what vod.py:download_series does when building output paths."""
+        return [
+            series_episode_output_path(
+                "/downloads",
+                ep["show_name"],
+                ep["season"],
+                ep["episode_num"],
+                ep.get("title"),
+                ep.get("extension", "mkv"),
+            )
+            for ep in episodes
+        ]
+
+    def test_multiple_zero_season_zero_episode_no_title_unique_paths(self):
+        """
+        Three distinct provider episodes with season=0, episode_num=0, no title
+        must produce three unique output paths. Currently all map to the same
+        path, causing silent overwrite of completed downloads.
+        """
+        episodes = [
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
+        ]
+        paths = self._batch_paths(episodes)
+        unique_paths = set(paths)
+        self.assertEqual(
+            len(unique_paths),
+            len(paths),
+            f"Output path collision: all {len(paths)} episodes map to "
+            f"{next(iter(unique_paths))!r}. Each episode must have a unique path.",
+        )
+
+    def test_two_episodes_same_zero_metadata_unique_paths(self):
+        """
+        Two distinct provider episodes with season=0, episode_num=0, no title
+        must produce different output paths.
+        """
+        path_a = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4")
+        path_b = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4")
+        self.assertNotEqual(
+            path_a,
+            path_b,
+            f"Both episodes map to {path_a!r}; second download silently "
+            "overwrites the first.",
+        )
+
+    def test_negative_season_episode_treated_as_zero_still_collides(self):
+        """
+        Providers sending season=-1 or episode_num=-1 are clamped to 0 by
+        series_episode_output_path, producing the same path as genuine 0/0
+        episodes and exacerbating the collision.
+        """
+        path_negative = series_episode_output_path("/downloads", "My Show", -1, -1, None, "mkv")
+        path_zero = series_episode_output_path("/downloads", "My Show", 0, 0, None, "mkv")
+        self.assertNotEqual(
+            path_negative,
+            path_zero,
+            f"season=-1/episode_num=-1 and season=0/episode_num=0 both produce "
+            f"{path_zero!r}. Negative values from the provider expand the collision surface.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_series_episode_path_collision.py
+++ b/backend/tests/test_series_episode_path_collision.py
@@ -7,16 +7,11 @@ Non-conforming IPTV providers commonly return episodes with no season or
 episode numbers and no episode title. When a user selects multiple such
 episodes for download, build_episode_download() calls
 series_episode_output_path() for each with the same metadata values.
-All calls produce the same output path, for example:
+Without the episode_id fallback, all calls produce the same output path.
 
-    /downloads/My Show/Season 00/S00E00 - My Show.mkv
-
-The second and subsequent downloads silently overwrite or corrupt the first.
-The user sees N "Completed" entries in the Downloads list but only one actual
-file on disk. No error is raised.
-
-Fix requires series_episode_output_path to accept an episode_id fallback so
-it can produce unique filenames when season/episode_num/title are all missing.
+Also covers negative season/episode values: providers sometimes send -1 for
+unknown values. Before the fix, these were clamped to 0, colliding with
+genuine season=0/episode=0 entries and expanding the corruption surface.
 """
 import sys
 import unittest
@@ -41,6 +36,7 @@ class SeriesEpisodePathCollisionTests(unittest.TestCase):
                 ep["episode_num"],
                 ep.get("title"),
                 ep.get("extension", "mkv"),
+                episode_id=ep.get("id"),
             )
             for ep in episodes
         ]
@@ -48,30 +44,29 @@ class SeriesEpisodePathCollisionTests(unittest.TestCase):
     def test_multiple_zero_season_zero_episode_no_title_unique_paths(self):
         """
         Three distinct provider episodes with season=0, episode_num=0, no title
-        must produce three unique output paths. Currently all map to the same
-        path, causing silent overwrite of completed downloads.
+        must produce three unique output paths when episode IDs differ.
         """
         episodes = [
-            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
-            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
-            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None},
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None, "id": "ep1"},
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None, "id": "ep2"},
+            {"show_name": "My Show", "season": 0, "episode_num": 0, "title": None, "id": "ep3"},
         ]
         paths = self._batch_paths(episodes)
         unique_paths = set(paths)
         self.assertEqual(
             len(unique_paths),
             len(paths),
-            f"Output path collision: all {len(paths)} episodes map to "
-            f"{next(iter(unique_paths))!r}. Each episode must have a unique path.",
+            f"Output path collision: {len(paths) - len(unique_paths)} episodes share a path. "
+            f"Paths: {paths}",
         )
 
     def test_two_episodes_same_zero_metadata_unique_paths(self):
         """
         Two distinct provider episodes with season=0, episode_num=0, no title
-        must produce different output paths.
+        must produce different output paths when episode IDs differ.
         """
-        path_a = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4")
-        path_b = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4")
+        path_a = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4", episode_id="e100")
+        path_b = series_episode_output_path("/downloads", "Drama Series", 0, 0, None, "mp4", episode_id="e101")
         self.assertNotEqual(
             path_a,
             path_b,
@@ -79,11 +74,11 @@ class SeriesEpisodePathCollisionTests(unittest.TestCase):
             "overwrites the first.",
         )
 
-    def test_negative_season_episode_treated_as_zero_still_collides(self):
+    def test_negative_season_episode_not_clamped_to_zero(self):
         """
-        Providers sending season=-1 or episode_num=-1 are clamped to 0 by
-        series_episode_output_path, producing the same path as genuine 0/0
-        episodes and exacerbating the collision.
+        season=-1 and episode_num=-1 must produce paths distinct from season=0
+        and episode_num=0. Previously these were clamped to 0, expanding the
+        collision surface.
         """
         path_negative = series_episode_output_path("/downloads", "My Show", -1, -1, None, "mkv")
         path_zero = series_episode_output_path("/downloads", "My Show", 0, 0, None, "mkv")
@@ -91,7 +86,7 @@ class SeriesEpisodePathCollisionTests(unittest.TestCase):
             path_negative,
             path_zero,
             f"season=-1/episode_num=-1 and season=0/episode_num=0 both produce "
-            f"{path_zero!r}. Negative values from the provider expand the collision surface.",
+            f"{path_zero!r}. Negative provider values collide with zero-indexed entries.",
         )
 
 


### PR DESCRIPTION
## What changed

Series episodes from non-conforming IPTV providers often arrive with no season number, no episode number, and no episode title. Previously, every such episode from the same show produced the same output path (e.g. \`Season 00/S00E00 - My Show.mkv\`), so multiple downloads silently overwrote each other with no error.

Also fixed: providers sometimes send \`season=-1\` or \`episode_num=-1\` to indicate an unknown index. These were clamped to 0, making them collide with genuine Season 0/Episode 0 entries.

## Root cause

\`series_episode_output_path\` had no way to distinguish episodes when all metadata (season, episode number, title) was absent or zero. Negative values were clamped with \`max(..., 0)\`, discarding the distinguishing information.

## After

- \`series_episode_output_path\` accepts an optional \`episode_id\` parameter. When season=0, episode_num=0, and no title are all present, the episode_id is appended to the filename, producing unique paths per episode.
- Negative season/episode values are preserved as-is, producing paths like \`Season -1/S-1E-1\` that do not collide with \`Season 00/S00E00\`.
- \`vod_service.py\` passes the provider's \`episode_id\` through to the namer.

## Before

Multiple zero-metadata episodes all write to the same file. No error raised. User sees N completed entries but only one file on disk.

## After

Each episode gets a unique path using its provider ID as a tiebreaker.

## How to test

Send two concurrent series download requests for episodes with the same show name, season=0, episode_num=0, no title. Before: both queue successfully and the second corrupts the first. After: each gets a distinct filename.

Automated regression in \`backend/tests/test_series_episode_path_collision.py\` covers all three scenarios.

## Tests

```
Ran 501 tests in 2.240s
OK (expected failures=2)
```