### PR TITLE
[Design] Show minimum threshold in low-disk space banner

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -504,8 +504,8 @@ function App() {
             styles={{ message: { fontSize: 'var(--mantine-font-size-sm)' } }}
           >
             {hasPausedLowSpace
-              ? `Recordings paused: low disk space.${diskSpace?.disk_free_gb != null ? ` ${diskSpace.disk_free_gb} GB free.` : ''} Free up space on your recordings drive to resume.`
-              : `Disk space is low.${diskSpace?.disk_free_gb != null ? ` ${diskSpace.disk_free_gb} GB free.` : ''} Recordings may pause soon.`}
+              ? `Recordings paused: low disk space.${diskSpace?.disk_free_gb != null ? ` ${diskSpace.disk_free_gb} GB free (${diskSpace.min_free_space_gb} GB minimum).` : ''} Free up space on your recordings drive to resume.`
+              : `Disk space is low.${diskSpace?.disk_free_gb != null ? ` ${diskSpace.disk_free_gb} GB free (${diskSpace.min_free_space_gb} GB minimum).` : ''} Recordings may pause soon.`}
           </Alert>
         )}
         <Routes>


### PR DESCRIPTION
## What a user would notice

Before: the banner said \"870.5 GB free\" with no explanation of why recordings are paused. A non-technical user with a large drive sees that number and is confused, because 870 GB sounds like plenty of space.

After: the banner now says \"870.5 GB free (25 GB minimum)\" so the user immediately understands the threshold and can make an informed decision.

## What changed

One line change in `App.jsx`. The `/api/downloads/disk-space` endpoint already returns `min_free_space_gb` alongside `disk_free_gb`, but the frontend never displayed it. Both banner variants (paused and warning) now include the minimum in parentheses.

## Before

Banner: \"Recordings paused: low disk space. 870.5 GB free. Free up space on your recordings drive to resume.\"

![Before desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513425745928523000/browse_desktop.png)

## After

Banner: \"Recordings paused: low disk space. 870.5 GB free (25 GB minimum). Free up space on your recordings drive to resume.\"

![After desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513425778564530000/banner_after_desktop.png)

## How it was tested

- Started backend and frontend locally, logged in as admin.
- Confirmed banner renders the threshold at desktop (1280px) and mobile (390px) widths.
- Confirmed the `diskSpace.min_free_space_gb` value matches the Setting in Settings > Recording.
- No backend changes. No logic changes.