### PR TITLE
fix: return 409 when VOD download conflicts with active output file

### DIFF
--- a/backend/api/vod.py
+++ b/backend/api/vod.py
@@ -147,7 +147,10 @@ async def download_movie(
         raise HTTPException(status_code=400, detail="Unable to queue movie download")
 
     await check_disk_space(session)
-    download = await download_manager.queue_download(download)
+    try:
+        download = await download_manager.queue_download(download)
+    except ValueError:
+        raise HTTPException(status_code=409, detail="A download for this file is already active.")
     return download.to_dict()
 
 
@@ -245,7 +248,10 @@ async def download_series(
             raise HTTPException(status_code=400, detail="Unable to queue series download")
 
         await check_disk_space(session)
-        download = await download_manager.queue_download(download)
+        try:
+            download = await download_manager.queue_download(download)
+        except ValueError:
+            raise HTTPException(status_code=409, detail="A download for this file is already active.")
         downloads.append(download.to_dict())
 
     return {

--- a/backend/tests/test_vod_download_dedup.py
+++ b/backend/tests/test_vod_download_dedup.py
@@ -1,0 +1,132 @@
+"""
+Regression tests: VOD download endpoints must return 409 when a duplicate download
+is already active for the same output file.
+
+Before fix: queue_download raises ValueError when an active (PENDING/DOWNLOADING/
+PROCESSING) download exists for the same output_path. That ValueError was not caught
+in vod.py, so both download_movie and download_series returned HTTP 500 instead of
+409. A user who double-clicked Download (or sent two parallel requests) got a 500
+error and two concurrent write tasks corrupting the same output file.
+
+After fix: both endpoints wrap queue_download in try/except ValueError and raise
+HTTPException(status_code=409).
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+
+
+def _make_auth():
+    auth = MagicMock()
+    auth.user_id = 1
+    auth.provider = "admin_local"
+    auth.is_admin = True
+    return auth
+
+
+def _make_session():
+    session = AsyncMock()
+    return session
+
+
+def _fake_download(output_path="/downloads/Die Hard (1988).mp4"):
+    d = MagicMock()
+    d.to_dict.return_value = {"id": 1, "output_path": output_path, "status": "completed"}
+    return d
+
+
+class MovieDownloadDedupTests(unittest.IsolatedAsyncioTestCase):
+    """download_movie returns 409 when queue_download detects a conflict."""
+
+    async def test_duplicate_movie_returns_409(self):
+        """Second download of the same movie returns 409, not 500.
+
+        Before fix: ValueError from queue_download propagated as HTTP 500.
+        After fix: ValueError is caught and re-raised as HTTP 409.
+        """
+        from api.vod import download_movie, MovieDownloadRequest
+
+        data = MovieDownloadRequest(account_id=1, vod_id="42", name="Die Hard",
+                                    container_extension="mp4")
+
+        with patch("api.vod.build_movie_download", new=AsyncMock(return_value=_fake_download())), \
+             patch("api.vod.check_disk_space", new=AsyncMock()), \
+             patch("api.vod.download_manager.queue_download",
+                   new=AsyncMock(side_effect=ValueError("already active for this output file: Die Hard (1988).mp4"))):
+            with self.assertRaises(HTTPException) as ctx:
+                await download_movie(data=data, auth=_make_auth(), session=_make_session())
+
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    async def test_first_movie_download_succeeds(self):
+        """First download with no existing active download proceeds normally."""
+        from api.vod import download_movie, MovieDownloadRequest
+
+        data = MovieDownloadRequest(account_id=1, vod_id="42", name="Die Hard",
+                                    container_extension="mp4")
+        fake = _fake_download()
+
+        with patch("api.vod.build_movie_download", new=AsyncMock(return_value=fake)), \
+             patch("api.vod.check_disk_space", new=AsyncMock()), \
+             patch("api.vod.download_manager.queue_download", new=AsyncMock(return_value=fake)):
+            result = await download_movie(data=data, auth=_make_auth(), session=_make_session())
+
+        self.assertIn("id", result)
+
+
+class SeriesDownloadDedupTests(unittest.IsolatedAsyncioTestCase):
+    """download_series returns 409 when queue_download detects a conflict."""
+
+    async def test_duplicate_episode_returns_409(self):
+        """Second download of the same episode returns 409, not 500.
+
+        Before fix: ValueError from queue_download propagated as HTTP 500.
+        After fix: ValueError is caught and re-raised as HTTP 409.
+        """
+        from api.vod import download_series, SeriesDownloadRequest, EpisodeItem
+
+        data = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Breaking Bad",
+            episodes=[EpisodeItem(id="e1", season=1, episode_num=1, title="Pilot")],
+        )
+
+        with patch("api.vod.build_episode_download", new=AsyncMock(return_value=_fake_download())), \
+             patch("api.vod.check_disk_space", new=AsyncMock()), \
+             patch("api.vod.download_manager.queue_download",
+                   new=AsyncMock(side_effect=ValueError("already active for this output file: S01E01.mp4"))):
+            with self.assertRaises(HTTPException) as ctx:
+                await download_series(data=data, auth=_make_auth(), session=_make_session())
+
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    async def test_first_episode_download_succeeds(self):
+        """First episode download with no conflict proceeds normally."""
+        from api.vod import download_series, SeriesDownloadRequest, EpisodeItem
+
+        data = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Breaking Bad",
+            episodes=[EpisodeItem(id="e1", season=1, episode_num=1, title="Pilot")],
+        )
+        fake = _fake_download()
+
+        with patch("api.vod.build_episode_download", new=AsyncMock(return_value=fake)), \
+             patch("api.vod.check_disk_space", new=AsyncMock()), \
+             patch("api.vod.download_manager.queue_download", new=AsyncMock(return_value=fake)):
+            result = await download_series(data=data, auth=_make_auth(), session=_make_session())
+
+        self.assertEqual(result["count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`download_movie` and `download_series` did not catch the `ValueError` raised by `queue_download` when an active download already exists for the same output file. That ValueError propagated as HTTP 500, and two concurrent write tasks could open the same file simultaneously, corrupting the recording.

This PR wraps both `queue_download` calls in `try/except ValueError` and returns HTTP 409, matching the behaviour of the catchup download endpoint added in PR #185.

## Root cause

PR #185 added the output-path dedup guard inside `queue_download` (download_manager.py). The catchup endpoint (downloads.py) was already updated to catch the resulting ValueError and return 409. The VOD endpoints (vod.py) were not updated, leaving the guard in place but its 409 response unreachable.

## Before

Double-clicking Download on a movie or series episode, or sending two parallel requests for the same item:
- Second request receives HTTP 500 (unhandled ValueError)
- With max_concurrent >= 2, both tasks open the same `.mp4` file with `'wb'`, interleaving writes
- File is corrupted; both tasks complete as COMPLETED

## After

Second request receives HTTP 409 "A download for this file is already active." No second download is queued and no file corruption occurs.

## How to test

```
# Start a movie download
POST /api/vod/movies/download {"account_id":1,"vod_id":"42","name":"Die Hard","container_extension":"mp4"}
# 200 OK

# Repeat immediately while the first is still pending/downloading
POST /api/vod/movies/download {"account_id":1,"vod_id":"42","name":"Die Hard","container_extension":"mp4"}
# Before: 500 Internal Server Error
# After:  409 Conflict - "A download for this file is already active."
```

Automated regression tests in `backend/tests/test_vod_download_dedup.py` cover both movie and series episode duplicate cases.

## Tests

```
Ran 495 tests in 2.124s
OK (expected failures=2)
```

Closes: #1513224097012777017 (task: "VOD downloads bypass dedup guard")