### PR TITLE
fix: parse 12-char XMLTV timestamps (YYYYMMDDHHmm) in EPG ingest

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -575,27 +575,45 @@ class EPGIngestManager:
         if not value:
             return None
         value = value.strip()
-        if len(value) >= 14:
+        # Split on first space to separate date digits from optional timezone.
+        # Providers may omit seconds (12-digit YYYYMMDDHHmm) per the XMLTV spec.
+        if " " in value:
+            date_part, tz_part = value.split(" ", 1)
+            tz_part = tz_part.strip()
+        elif len(value) >= 14:
             date_part = value[:14]
             tz_part = value[14:].strip()
+        elif len(value) >= 12:
+            date_part = value[:12]
+            tz_part = value[12:].strip()
+        else:
+            return None
+
+        if len(date_part) == 14:
+            fmt = "%Y%m%d%H%M%S"
+        elif len(date_part) == 12:
+            fmt = "%Y%m%d%H%M"
+        else:
+            return None
+
+        try:
+            dt = datetime.strptime(date_part, fmt)
+        except ValueError:
+            return None
+
+        if tz_part:
             try:
-                dt = datetime.strptime(date_part, "%Y%m%d%H%M%S")
-            except ValueError:
-                return None
-            if tz_part:
-                try:
-                    if tz_part[0] not in "+-":
-                        tz_part = tz_part.replace(" ", "")
-                    if tz_part.upper() == "Z":
-                        return dt.replace(tzinfo=timezone.utc)
-                    if len(tz_part) == 6 and tz_part[3] == ":":
-                        tz_part = tz_part.replace(":", "")
-                    offset = datetime.strptime(tz_part, "%z").tzinfo
-                    return dt.replace(tzinfo=offset)
-                except ValueError:
+                if tz_part[0] not in "+-":
+                    tz_part = tz_part.replace(" ", "")
+                if tz_part.upper() == "Z":
                     return dt.replace(tzinfo=timezone.utc)
-            return dt.replace(tzinfo=timezone.utc)
-        return None
+                if len(tz_part) == 6 and tz_part[3] == ":":
+                    tz_part = tz_part.replace(":", "")
+                offset = datetime.strptime(tz_part, "%z").tzinfo
+                return dt.replace(tzinfo=offset)
+            except ValueError:
+                return dt.replace(tzinfo=timezone.utc)
+        return dt.replace(tzinfo=timezone.utc)
 
     def _extract_text(self, elem: Element, tag: str) -> Optional[str]:
         child = elem.find(tag)

--- a/backend/tests/test_epg_xmltv_12char_timestamps.py
+++ b/backend/tests/test_epg_xmltv_12char_timestamps.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for 12-char XMLTV timestamps silently dropping all programs.
+
+XMLTV allows omitting seconds: YYYYMMDDHHmm (12 digits). The prior code
+gated on len >= 14 so bare 12-char values returned None, and
+"202306011200 +0000" passed the gate but sliced value[:14] = "202306011200 +"
+which failed strptime. Both cases caused _iter_programs to silently skip every
+program from providers using this format.
+
+_parse_xmltv_time now splits on the first space to isolate the date digits
+before checking length, and accepts both 12-digit and 14-digit date parts.
+"""
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class ParseXmltvTime12CharTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager.__new__(EPGIngestManager)
+
+    def test_12_char_bare_returns_utc(self):
+        result = self.mgr._parse_xmltv_time("202306011200")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, datetime(2023, 6, 1, 12, 0, tzinfo=timezone.utc))
+
+    def test_12_char_with_utc_offset_returns_utc(self):
+        result = self.mgr._parse_xmltv_time("202306011200 +0000")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, datetime(2023, 6, 1, 12, 0, tzinfo=timezone.utc))
+
+    def test_12_char_with_positive_offset_applied(self):
+        result = self.mgr._parse_xmltv_time("202306011200 +0200")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.utcoffset().total_seconds(), 7200)
+        self.assertEqual(result.hour, 12)
+
+    def test_12_char_with_negative_offset_applied(self):
+        result = self.mgr._parse_xmltv_time("202306011200 -0500")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.utcoffset().total_seconds(), -18000)
+
+    def test_14_char_bare_still_works(self):
+        result = self.mgr._parse_xmltv_time("20230601120000")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, datetime(2023, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_14_char_with_offset_still_works(self):
+        result = self.mgr._parse_xmltv_time("20230601120000 +0000")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, datetime(2023, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_14_char_with_z_suffix_still_works(self):
+        result = self.mgr._parse_xmltv_time("20230601120000Z")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.tzinfo, timezone.utc)
+
+    def test_none_input_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time(None))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time(""))
+
+    def test_too_short_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time("2023060112"))
+
+    def test_garbage_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time("notadate"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Providers that send 12-digit XMLTV timestamps (omitting the seconds field, e.g. `202306011200`) had their entire EPG guide silently dropped. The guide page would appear empty for those channels with no error shown.

## What changed

`_parse_xmltv_time` in `epg_ingest_manager.py` now handles 12-digit date parts (`YYYYMMDDHHmm`) in addition to the existing 14-digit format (`YYYYMMDDHHmmss`). The function now splits on the first space to correctly separate the date digits from the timezone offset before checking length, which also fixes a secondary bug where `"202306011200 +0000"` (12 digits + space + offset) passed the old length gate but sliced into the timezone string, producing a strptime failure.

## Root cause

The old code gated on `len(value) >= 14` and extracted `value[:14]` as the date part. A bare 12-char timestamp failed the gate immediately. A 12-char timestamp with a space-separated timezone offset (e.g. `"202306011200 +0000"`, length 18) passed the gate but `value[:14]` captured `"202306011200 +"`, which failed `strptime("%Y%m%d%H%M%S")`. Both paths returned `None`. `_iter_programs` silently skips any program whose start or end is `None`, so a provider using this format lost its entire guide with no log entry.

## How it was tested

11 new regression tests in `backend/tests/test_epg_xmltv_12char_timestamps.py` cover: bare 12-char, 12-char with UTC offset, 12-char with positive and negative offsets, all existing 14-char cases (bare, with offset, Z suffix), and edge cases (None, empty, too short, garbage). Full suite: 528 tests pass.

**Before:** `_parse_xmltv_time("202306011200")` returned `None`. `_parse_xmltv_time("202306011200 +0000")` returned `None`.

**After:** Both return a valid UTC-aware datetime. All 528 tests pass.