### PR TITLE
fix: return 422 (not 500) for out-of-range since param in failed-count endpoint

### DIFF
--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -193,7 +193,7 @@ async def _attach_requested_by(
 async def get_failed_download_count(
     auth: AuthContext = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session),
-    since: Optional[float] = Query(default=None),
+    since: Optional[float] = Query(default=None, ge=0, le=253402300799000),
 ):
     """Count permanently failed downloads since a given Unix timestamp in milliseconds."""
     query = select(func.count()).select_from(Download).where(Download.status == DownloadStatus.FAILED.value)
@@ -201,7 +201,10 @@ async def get_failed_download_count(
         query = query.where(Download.requested_by_user_id == auth.user_id)
     query = query.where(Download.completed_at.is_not(None))
     if since is not None:
-        cutoff = datetime.utcfromtimestamp(since / 1000.0)
+        try:
+            cutoff = datetime.utcfromtimestamp(since / 1000.0)
+        except (OSError, OverflowError, ValueError):
+            raise HTTPException(status_code=422, detail="since: timestamp out of range")
         query = query.where(Download.completed_at >= cutoff)
     result = await session.execute(query)
     return {"count": result.scalar() or 0}

--- a/backend/tests/test_failed_count_endpoint.py
+++ b/backend/tests/test_failed_count_endpoint.py
@@ -133,6 +133,16 @@ class FailedCountTests(unittest.TestCase):
         compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
         self.assertIn("42", compiled, "user_id filter must appear for non-admin")
 
+    def test_out_of_range_since_raises_422(self):
+        """since=99999999999999999999 must raise HTTPException(422), not crash with 500."""
+        from fastapi import HTTPException
+        from api.downloads import get_failed_download_count
+        session = self._make_session(count=0)
+        auth = self._make_admin_auth()
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(get_failed_download_count(auth=auth, session=session, since=99999999999999999999.0))
+        self.assertEqual(ctx.exception.status_code, 422)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

`GET /api/downloads/failed-count?since=<timestamp>` crashed with HTTP 500 when the timestamp was too large (any value beyond year 9999).

## Why it happened

The `since` query parameter was passed directly to `datetime.utcfromtimestamp()` with no bounds check. On Linux, values beyond approximately year 9999 cause `OSError: [Errno 22] Invalid argument`, which FastAPI did not catch, so it became a 500.

## What is fixed

Two layers of protection now reject out-of-range values:

1. **FastAPI `Query(ge=0, le=253402300799000)`** rejects the value at the HTTP layer and returns 422 before the function body runs.
2. **`try/except (OSError, OverflowError, ValueError)`** inside the function body raises `HTTPException(422)` as a fallback, so the endpoint can never return 500 for a bad timestamp even if the query constraint is bypassed (e.g., when calling the function directly in tests).

## Before / After

**Before:**
```
GET /api/downloads/failed-count?since=99999999999999999999
→ HTTP 500 Internal Server Error
```

**After:**
```
GET /api/downloads/failed-count?since=99999999999999999999
→ HTTP 422 Unprocessable Entity
```

## Testing

- Added `test_out_of_range_since_raises_422` to the existing `test_failed_count_endpoint.py` test file. It calls the handler directly with `since=99999999999999999999.0` and asserts `HTTPException(422)` is raised.
- All 518 backend tests pass.

## Files changed

- `backend/api/downloads.py`: added `ge=0, le=253402300799000` to the `since` Query parameter, added try/except around `utcfromtimestamp`.
- `backend/tests/test_failed_count_endpoint.py`: new regression test.