### PR TITLE
[Design] Show relative dates on Scheduled and Upcoming cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -44,7 +44,7 @@ import duration from 'dayjs/plugin/duration'
 
 import { accountsApi, authApi, downloadsApi, createDownloadWebSocket } from '../api'
 import ProgressBar from '../components/ProgressBar'
-import { formatChannelDateTime, getGuideOffsetHours } from '../utils/channelTime'
+import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
 
 dayjs.extend(duration)
 
@@ -683,7 +683,7 @@ export default function Downloads() {
                       {getScheduledStatusBadge(rec.status)}
                     </Group>
                     <Text size="xs" c="dimmed">
-                      Airs: {formatChannelDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0, 'ddd MMM D, YYYY h:mm A') || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
+                      Airs: {formatAirDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0) || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
                     </Text>
                   </Stack>
                 </Card>

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -34,7 +34,7 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 
 import { accountsApi, schedulesApi } from '../api'
-import { formatChannelDateTime, getGuideOffsetHours } from '../utils/channelTime'
+import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
 
 dayjs.extend(duration)
 
@@ -87,9 +87,9 @@ function ScheduleCard({
     ? schedule.start_timestamp < Date.now() / 1000
     : false
 
-  const startTime = formatChannelDateTime(schedule, 'start', guideOffsetHours, 'MMM D, YYYY h:mm A')
+  const startTime = formatAirDateTime(schedule, 'start', guideOffsetHours)
   const endTime = formatChannelDateTime(schedule, 'end', guideOffsetHours, 'h:mm A')
-  const availableAt = formatChannelDateTime(schedule, 'available', guideOffsetHours, 'MMM D, YYYY h:mm A')
+  const availableAt = formatAirDateTime(schedule, 'available', guideOffsetHours)
   const totalDuration = (schedule.duration_minutes || 0)
     + (schedule.pre_padding_minutes || 0)
     + (schedule.post_padding_minutes || 0)

--- a/frontend/src/utils/channelTime.js
+++ b/frontend/src/utils/channelTime.js
@@ -78,3 +78,21 @@ export function formatChannelDateTime(
 export function getNowUtc() {
   return dayjs.utc()
 }
+
+export function formatAirDateTime(program, kind = 'start', guideOffsetHours = 0) {
+  const displayTime = getChannelDisplayTime(program, kind, guideOffsetHours)
+  if (!displayTime) return ''
+  const offset = getGuideOffsetHours(guideOffsetHours)
+  const now = getNowUtc().add(offset, 'hour')
+  const todayDate = now.format('YYYY-MM-DD')
+  const tomorrowDate = now.add(1, 'day').format('YYYY-MM-DD')
+  const displayDate = displayTime.format('YYYY-MM-DD')
+  const timeStr = displayTime.format('h:mm A')
+  if (displayDate === todayDate) {
+    return `Today at ${timeStr}`
+  }
+  if (displayDate === tomorrowDate) {
+    return `Tomorrow at ${timeStr}`
+  }
+  return `${displayTime.format('ddd, MMM D, YYYY')} at ${timeStr}`
+}


### PR DESCRIPTION
## What a user would notice

Scheduled recordings and Upcoming download cards now show plain-English dates for shows airing soon. A recording tonight says **\"Today at 7:30 PM\"** instead of **\"Mon Jun 8, 2026 7:30 PM\"**. Tomorrow says **\"Tomorrow at 8:00 PM\"**. Shows further out still show the full date.

A non-technical user can now scan their scheduled recordings at a glance and immediately spot what records tonight or tomorrow, without parsing a full date string.

## What changed

Added `formatAirDateTime()` to `frontend/src/utils/channelTime.js`. It compares the program's display date against today and tomorrow (accounting for guide offset), and returns \"Today at HH:MM\", \"Tomorrow at HH:MM\", or \"Day, Mon DD, YYYY at HH:MM\" for anything further out.

Updated two call sites:
- `Scheduled.jsx` start time and \"Download starts\" line
- `Downloads.jsx` Upcoming tab air time

No backend changes. Three files touched.

## Before / After

**Before (Scheduled, desktop):** all cards show full ISO dates, making \"tonight\" look the same as \"Wednesday\".

**After (Scheduled, desktop):** EastEnders shows \"Today at 7:30 PM\", Coronation Street shows \"Tomorrow at 8:00 PM\", Great British Bake Off shows the full date.

**Before (Downloads Upcoming, mobile):** \"Mon Jun 8, 2026 7:30 PM\"
**After (Downloads Upcoming, mobile):** \"Today at 7:30 PM\"

Screenshots attached in #design (iteration 12).

## How it was tested

Playwright screenshots captured at 1280px (desktop) and 390px (mobile) with the local dev stack. Verified \"Today\", \"Tomorrow\", and full-date paths all render correctly across Scheduled and Downloads Upcoming on both widths.