### PR TITLE
[Design] show Yesterday in air-date labels for recent recordings

### DIFF
--- a/frontend/src/utils/channelTime.js
+++ b/frontend/src/utils/channelTime.js
@@ -86,6 +86,7 @@ export function formatAirDateTime(program, kind = 'start', guideOffsetHours = 0)
   const now = getNowUtc().add(offset, 'hour')
   const todayDate = now.format('YYYY-MM-DD')
   const tomorrowDate = now.add(1, 'day').format('YYYY-MM-DD')
+  const yesterdayDate = now.subtract(1, 'day').format('YYYY-MM-DD')
   const displayDate = displayTime.format('YYYY-MM-DD')
   const timeStr = displayTime.format('h:mm A')
   if (displayDate === todayDate) {
@@ -93,6 +94,9 @@ export function formatAirDateTime(program, kind = 'start', guideOffsetHours = 0)
   }
   if (displayDate === tomorrowDate) {
     return `Tomorrow at ${timeStr}`
+  }
+  if (displayDate === yesterdayDate) {
+    return `Yesterday at ${timeStr}`
   }
   return `${displayTime.format('ddd, MMM D, YYYY')} at ${timeStr}`
 }


### PR DESCRIPTION
## What changed

`formatAirDateTime` in `channelTime.js` already returns "Today at..." and "Tomorrow at..." for same-day and next-day programs (added in PR #197). It did not handle yesterday, so history cards from the previous day showed a full date like "Aired: Sun, Jun 7, 2026 at 7:59 PM" even for something that aired 20 hours ago.

This PR adds a `yesterdayDate` check using the same three-line pattern as Today/Tomorrow. Programs that aired yesterday now read "Aired: Yesterday at 7:59 PM". Programs from two or more days ago continue to show the full absolute date.

## What a user would notice

Scheduled History cards for recently cancelled or completed recordings now read "Aired: Yesterday at..." instead of the full weekday-and-date string. The label matches how you would actually describe it in conversation.

## Files changed

- `frontend/src/utils/channelTime.js`: +4 lines, no other files touched.

## How it was tested

Playwright screenshots at 1280x800 (desktop) and 390x844 (mobile). Before and after posted to the #design thread in Discord.

**Before:** "Aired: Sun, Jun 7, 2026 at 7:59 PM - 8:59 PM (1h)"
**After:** "Aired: Yesterday at 7:59 PM - 8:59 PM (1h)"