### PR TITLE
[Design] show air end time and download start time on Downloads Upcoming cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -672,22 +672,32 @@ export default function Downloads() {
             </Card>
           ) : (
             <Stack gap="sm">
-              {upcomingRecordings.map((rec) => (
-                <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
-                  <Stack gap={2}>
-                    <Group justify="space-between" wrap="nowrap" align="flex-start">
-                      <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
-                        <Text fw={500}>{rec.program_title}</Text>
-                        <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
-                      </Stack>
-                      {getScheduledStatusBadge(rec.status)}
-                    </Group>
-                    <Text size="xs" c="dimmed">
-                      Airs: {formatAirDateTime(rec, 'start', accountGuideOffsets[Number(rec.account_id)] || 0) || 'Unknown time'}{' '}({formatDuration(rec.duration_minutes)})
-                    </Text>
-                  </Stack>
-                </Card>
-              ))}
+              {upcomingRecordings.map((rec) => {
+                const guideOffset = accountGuideOffsets[Number(rec.account_id)] || 0
+                const airStart = formatAirDateTime(rec, 'start', guideOffset)
+                const airEnd = formatChannelDateTime(rec, 'end', guideOffset, 'h:mm A')
+                const downloadAt = formatAirDateTime(rec, 'available', guideOffset)
+                const totalDuration = (rec.duration_minutes || 0) + (rec.pre_padding_minutes || 0) + (rec.post_padding_minutes || 0)
+                return (
+                  <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
+                    <Stack gap={2}>
+                      <Group justify="space-between" wrap="nowrap" align="flex-start">
+                        <Stack gap={2} style={{ flex: 1, overflow: 'hidden' }}>
+                          <Text fw={500}>{rec.program_title}</Text>
+                          <Text size="sm" c="dimmed" truncate>{rec.channel_name}</Text>
+                        </Stack>
+                        {getScheduledStatusBadge(rec.status)}
+                      </Group>
+                      <Text size="xs" c="dimmed">
+                        Airs: {airStart || 'Unknown'} - {airEnd || 'Unknown'} ({formatDuration(rec.duration_minutes || 0)})
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        Download starts: {downloadAt || 'Unknown'} ({formatDuration(totalDuration)} recording)
+                      </Text>
+                    </Stack>
+                  </Card>
+                )
+              })}
             </Stack>
           )}
         </Tabs.Panel>


### PR DESCRIPTION
## What changed

The Downloads > Upcoming tab showed each recording with only its start time:

> Airs: Today at 7:30 PM (30m)

A user had no way to tell when the download would actually begin. The Scheduled page already shows both the full air window and when the download kicks off, but the Downloads Upcoming cards were missing both.

After this change each card matches the Scheduled page:

> Airs: Today at 7:30 PM - 8:00 PM (30m)
> Download starts: Today at 8:00 PM (30m recording)

No logic was changed. Only the card template in Downloads.jsx was updated.

## Files changed

- frontend/src/pages/Downloads.jsx: expanded Upcoming card to show air end time and download start time, matching the Scheduled Upcoming card format.

## How it was tested

Backend and frontend started locally. Playwright screenshots taken before and after at 1280px (desktop) and 390px (mobile). Before and after screenshots are in the #design thread.