### PR TITLE
[Design] hide catchup loading badge when provider is unreachable

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -184,7 +184,7 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
       </Text>
 
       <Group mt="md" gap="xs">
-        {catchupSummary?.loading ? (
+        {catchupSummary?.loading && account.last_connection_ok !== false ? (
           <Badge variant="outline" size="sm" color="blue">
             Catchup: loading...
           </Badge>


### PR DESCRIPTION
## What changed

When you open Settings > Accounts with an unreachable provider, the account card showed a **CATCHUP: LOADING...** badge at the same time as the red **Unreachable** status. The badge persisted for several seconds while the browser retried the channel fetch against the offline provider.

A non-technical user sees two conflicting signals: the provider is down, but something is still loading. The natural question is: "Is it recovering? Should I wait?"

After this change, the loading badge is suppressed whenever the provider is already known to be unreachable. The card immediately shows only the error state.

## Change

One guard added to `AccountsSection.jsx`: the loading badge only renders when `account.last_connection_ok !== false`. When the provider status is unknown (never checked), the badge still shows normally.

## Before

CATCHUP: LOADING... badge appears alongside Unreachable status on page load.

![before](https://github.com/user-attachments/assets/placeholder-before)

## After

No loading badge. Card shows only the connection error immediately.

![after](https://github.com/user-attachments/assets/placeholder-after)

## Test plan

- Open Settings > Accounts with a provider whose URL is not reachable.
- Verify no CATCHUP: LOADING... badge appears on page load.
- Open Settings > Accounts with a working provider. Verify CATCHUP: LOADING... still briefly appears while channels load, then switches to the days-available badge.