### PR TITLE
docs: add changelog entries for PRs #203 and #204, update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-08
 
+### Improved: Downloads Upcoming cards now show when a show ends and when the download begins
+
+**What you would notice:** On the Downloads > Upcoming tab, each recording card previously showed only the show's start time. The card now shows the full air window, for example "Airs: Today at 7:30 PM - 8:00 PM (30m)", and a separate line showing when Mustarrd will begin downloading, for example "Download starts: Today at 8:00 PM (30m recording)". This makes it easy to see at a glance whether a recording fits your schedule and how long the download will run. The Scheduled Recordings page already showed this information. The Downloads Upcoming tab now matches it.
+
+**What changed:** The Upcoming recording cards were updated to display the air end time and the download start time alongside the air start time. No recording logic was changed.
+
+---
+
+### Fixed: Sending a program request with a numeric timestamp no longer causes a server error in all cases
+
+**What you would notice:** No visible change during normal use. A previous update fixed server errors when a third-party app or script sent a number instead of a text date for a program's start or end time. This update extends that fix to cover an additional path that the earlier change missed, so the same type of invalid input now returns a clear error message in all cases.
+
+**What changed:** The file naming step that runs just before a download starts was not covered by the earlier fix. It now handles integer timestamps correctly instead of crashing with an internal server error.
+
+---
+
 ### Improved: Yesterday's recordings now display as "Yesterday" instead of a full date
 
 **What you would notice:** On the Scheduled page, cancelled or completed recordings from yesterday used to show a full weekday-and-date label like "Sat, Jun 7, 2026 at 7:30 PM". They now show "Yesterday at 7:30 PM", matching the same natural style already used for upcoming recordings that air "Today" or "Tomorrow". Recordings from more than two days ago continue to show the full date.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then open **http://localhost:4177** in your browser.
 ### Monitor Downloads
 
 - Go to the **Downloads** page to see active downloads with progress bars
-- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date, with show name, channel, time, and duration. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
+- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date. Each card shows the show name, channel, full air window (start and end time with duration), and when the download will begin. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - When any scheduled recording is paused for low disk space, or when free space drops below the configured minimum, an orange banner appears at the top of every page, not just Downloads, so you are alerted no matter where you are in the app


### PR DESCRIPTION
## What changed

Adds changelog entries for two PRs merged since the last docs update, and updates the README to match.

**PR #203** - Downloads Upcoming cards now show when a show ends and when the download begins. The README description of the Upcoming tab was updated to mention the full air window and download start time.

**PR #204** - An additional path that caused a server error when a numeric timestamp was sent for program start or end time. This extends the fix from PR #198 to cover the file naming step.

## How it was tested

Entries verified against Herald and Pixel merge announcements in #general. No em dashes used. Format matches existing CHANGELOG entries.