### PR TITLE
[Design] fix button order on Settings Accounts mobile

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -3,6 +3,7 @@ import {
   Title,
   Button,
   Card,
+  Flex,
   Group,
   Text,
   Stack,
@@ -502,7 +503,7 @@ export default function AccountsSection({ showTitle = true }) {
       <Group justify="space-between">
         {showTitle ? <Title order={2}>Accounts</Title> : <Title order={4}>Accounts</Title>}
         {accounts?.length > 0 && (
-          <Group>
+          <Flex direction={{ base: 'column-reverse', sm: 'row' }} gap="xs">
             <Button
               variant="light"
               color="orange"
@@ -516,7 +517,7 @@ export default function AccountsSection({ showTitle = true }) {
             <Button leftSection={<IconPlus size={16} />} onClick={handleAddClick}>
               Add Another Account
             </Button>
-          </Group>
+          </Flex>
         )}
       </Group>
 


### PR DESCRIPTION
## What a user would notice

On a phone, Settings > Accounts used to show "Force EPG Refresh" above "+ Add Another Account". The less-important action was on top. Now the primary action ("Add Another Account") appears first and the utility action ("Force EPG Refresh") is below it. Desktop is unchanged.

## What changed

When the two header buttons stack on narrow screens, column-reverse flex direction reverses the visual order so the primary action (orange "Add Another Account") appears at the top.

One component, one import, one prop change. No backend changes.

## Before (mobile)

Force EPG Refresh (secondary) on top, + Add Another Account (primary) below. See #design thread.

## After (mobile)

+ Add Another Account (primary, orange) on top, Force EPG Refresh (secondary) below. See #design thread.

## Desktop

Unchanged: Force EPG Refresh (left) | + Add Another Account (right).

## How it was tested

Playwright screenshots at 390x844 (mobile) and 1280x800 (desktop).