### PR TITLE
[Design] hide misleading prompt on Browse EPG when provider is unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1040,7 +1040,7 @@ export default function Browse() {
                         </Text>
                       )}
                     </Stack>
-                  ) : (
+                  ) : channelsIsError ? null : (
                     <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
                       <IconVideo size={48} opacity={0.3} />
                       <Text c="dimmed">Select a channel to view its EPG</Text>


### PR DESCRIPTION
## What a user would notice

On the Browse EPG page with a provider that cannot be reached, the right panel showed a camera icon and **"Select a channel to view its EPG"**. There are no channels available in this state, so the instruction creates a confusing mixed signal: the left panel says the connection is broken, but the right panel implies the user should do something. A non-technical user might wonder why they cannot see any channels or what they are supposed to select.

After this change, the prompt is suppressed. The right panel shows only the "No channel selected" header and empty space. The user's attention stays on the actionable error message in the left panel.

## What changed

One condition added in `Browse.jsx` at the desktop EPG layout. When `channelsIsError` is true and no channel is selected, the empty-state stack renders `null` instead.

Mobile is unaffected: on narrow screens the channel list and EPG panel do not render side by side, so this state does not occur.

## Before

Right panel shows "Select a channel to view its EPG" while the left panel shows the provider error. See #design for screenshots.

## After

Right panel is empty below the header. User sees only the actionable error in the left panel. See #design for screenshots.

## How it was tested

Playwright screenshots at 1280x800 (desktop) and 390x844 (phone) before and after the change, with a provider configured but unreachable.