### PR TITLE
[Design] hide right panel header on Browse EPG when provider unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -987,29 +987,31 @@ export default function Browse() {
 
               <Card shadow="sm" padding="md" radius="md" withBorder style={{ height: '100%' }}>
                 <Stack style={{ height: '100%' }}>
-                  <Group justify="space-between">
-                    <Group gap="xs">
-                      {selectedChannel?.stream_icon ? (
-                        <Image
-                          src={selectedChannel.stream_icon}
-                          alt={selectedChannel.name}
-                          w={32}
-                          h={32}
-                          fit="contain"
-                        />
-                      ) : (
-                        <IconVideo size={28} opacity={0.4} />
+                  {(selectedChannel || !channelsIsError) && (
+                    <Group justify="space-between">
+                      <Group gap="xs">
+                        {selectedChannel?.stream_icon ? (
+                          <Image
+                            src={selectedChannel.stream_icon}
+                            alt={selectedChannel.name}
+                            w={32}
+                            h={32}
+                            fit="contain"
+                          />
+                        ) : (
+                          <IconVideo size={28} opacity={0.4} />
+                        )}
+                        <Text fw={500}>
+                          {selectedChannel ? selectedChannel.name : 'No channel selected'}
+                        </Text>
+                      </Group>
+                      {selectedChannel && (
+                        <Badge variant="light" leftSection={<IconClock size={12} />}>
+                          {formatArchiveDuration(selectedChannel.tv_archive_duration)}
+                        </Badge>
                       )}
-                      <Text fw={500}>
-                        {selectedChannel ? selectedChannel.name : 'No channel selected'}
-                      </Text>
                     </Group>
-                    {selectedChannel && (
-                      <Badge variant="light" leftSection={<IconClock size={12} />}>
-                        {formatArchiveDuration(selectedChannel.tv_archive_duration)}
-                      </Badge>
-                    )}
-                  </Group>
+                  )}
 
                   {selectedChannel ? (
                     <Stack style={{ flex: 1, minHeight: 0 }}>


### PR DESCRIPTION
## What a user sees

When the IPTV provider is unreachable, Browse EPG shows the connection error in the left panel. After this change, the right panel is blank. Before this change, it showed a camera icon and "No channel selected" header even though there were no channels to select.

## What changed

PR #212 (merged today) already suppressed the placeholder body text in the right panel during error state. The header row (camera icon plus "No channel selected" text) was still rendering because it had no error-state guard.

One change in `Browse.jsx`: the desktop right-panel header group is now wrapped in `(selectedChannel || !channelsIsError)`. When the provider is unreachable and no channel is loaded, the condition is false and the header does not render. The right panel becomes a blank card. When a channel is selected (or the provider is reachable), the header renders as before.

Mobile Browse is not affected: mobile uses a single-panel layout and the right panel never appears in error state.

## Before

Right panel showed camera icon and "No channel selected" header alongside the provider error. A non-technical user might interpret this as an instruction to select a channel, which is impossible when the provider is down.

## After

Right panel is blank in error state. User's attention goes to the error message and Settings link in the left panel.

Screenshots posted in #design.

## Testing

Ran locally with provider unreachable (dev environment). Verified the right panel header no longer renders in error state. Verified the header still renders correctly when a channel is selected (normal operation). No backend changes, no auth paths.