### PR TITLE
test: failing regression for vod_namer season=N, ep=0 path collision

### DIFF
--- a/backend/tests/test_vod_namer_ep0_season_n_collision.py
+++ b/backend/tests/test_vod_namer_ep0_season_n_collision.py
@@ -1,0 +1,95 @@
+"""
+Regression test: series_episode_output_path episode_id fallback too narrow.
+
+Bug: The episode_id dedup guard fires only when season_num == 0 AND episode_num == 0.
+Two distinct provider episodes with season=N (N>0), episode_num=0, and no title
+produce the same output path. The second download silently overwrites the first.
+
+Root cause in vod_namer.py:
+    elif season_num == 0 and episode_num == 0 and episode_id:
+        base_name = f"{base_name} - {_sanitize_component(str(episode_id))}"
+
+The season_num == 0 guard means season=2, episode=0 never reaches the fallback.
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "vod_namer.py"
+_SPEC = importlib.util.spec_from_file_location("vod_namer_ep0_season_n_test", _MODULE_PATH)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(_MOD)
+
+series_episode_output_path = _MOD.series_episode_output_path
+
+
+class VodNamerEp0SeasonNCollisionTests(unittest.TestCase):
+    def test_season_n_episode_zero_no_title_unique_paths(self):
+        """season=2, ep=0, no title, different IDs must not produce the same path.
+
+        This is the failing case: the episode_id fallback only fires for (0,0),
+        so two extras in season 2 with no title collide.
+        """
+        path_a = series_episode_output_path(
+            "/dl", "My Show", 2, 0, None, "mp4", episode_id="ep_aaa"
+        )
+        path_b = series_episode_output_path(
+            "/dl", "My Show", 2, 0, None, "mp4", episode_id="ep_bbb"
+        )
+        self.assertNotEqual(
+            path_a,
+            path_b,
+            f"Collision at {path_a!r}: episode_id fallback not applied for season=2, "
+            "episode=0. Both files map to the same path; second download overwrites first.",
+        )
+
+    def test_season_1_episode_zero_no_title_unique_paths(self):
+        """Same collision is reproducible with season=1."""
+        path_a = series_episode_output_path(
+            "/dl", "Another Show", 1, 0, None, "mkv", episode_id="id1"
+        )
+        path_b = series_episode_output_path(
+            "/dl", "Another Show", 1, 0, None, "mkv", episode_id="id2"
+        )
+        self.assertNotEqual(
+            path_a,
+            path_b,
+            f"Collision at {path_a!r}: season=1, episode=0 also affected.",
+        )
+
+    def test_season_zero_episode_zero_still_unique(self):
+        """The original (0,0) fix must still hold after any correction."""
+        path_a = series_episode_output_path(
+            "/dl", "My Show", 0, 0, None, "mp4", episode_id="ep1"
+        )
+        path_b = series_episode_output_path(
+            "/dl", "My Show", 0, 0, None, "mp4", episode_id="ep2"
+        )
+        self.assertNotEqual(
+            path_a,
+            path_b,
+            "Regression: (0,0) case should still produce unique paths.",
+        )
+
+    def test_episode_with_title_not_affected(self):
+        """Episodes with a title must not be modified by the fallback."""
+        path_a = series_episode_output_path(
+            "/dl", "My Show", 2, 0, "Bonus Clip", "mp4", episode_id="ep1"
+        )
+        path_b = series_episode_output_path(
+            "/dl", "My Show", 2, 0, "Bonus Clip", "mp4", episode_id="ep2"
+        )
+        # Same title -> same path is acceptable (title already disambiguates show vs show,
+        # but two episodes with identical title/season/ep numbers genuinely do collide;
+        # that is a pre-existing separate concern).
+        # The important thing here is the title-present path does NOT include episode_id.
+        self.assertNotIn(
+            "ep1",
+            path_a,
+            "episode_id must not appear in path when episode title is present.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

When a provider returns multiple bonus episodes or extras in a non-zero season (e.g. season 2) all labeled episode number 0 with no episode title, Mustarrd downloads them all to the same filename. The second episode silently overwrites the first, and content is permanently lost.

## What changed

Added a failing regression test (`backend/tests/test_vod_namer_ep0_season_n_collision.py`) to document the bug. No fix is included; this PR establishes coverage so a fix can be verified.

## Root cause

In `backend/services/vod_namer.py`, `series_episode_output_path` appends `episode_id` to the filename only when `season_num == 0 AND episode_num == 0`. Any other season value with `episode_num=0` and no title produces a collision.

```python
# Current code, too narrow:
elif season_num == 0 and episode_num == 0 and episode_id:
    base_name = f"{base_name} - {_sanitize_component(str(episode_id))}"
```

Collision confirmed:
```
/dl/My Show/Season 02/S02E00 - My Show.mp4  (episode_id=ep_aaa)
/dl/My Show/Season 02/S02E00 - My Show.mp4  (episode_id=ep_bbb)  <- overwrites
```

Fix direction for maintainer: change condition to `elif not safe_title and episode_id:`.

## Test results

- 2 new tests fail (the collision cases, expected before fix)
- 2 new tests pass (original 0,0 guard still holds; titled episodes unaffected)
- Full suite otherwise green

## Severity

MEDIUM. Data loss (file overwrite) when provider returns multiple zero-numbered extras in a non-zero season. Correlates with #tasks thread 1513529834133782550.