### PR TITLE
[Design] add Go to Browse button to Downloads Upcoming empty state

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -668,6 +668,9 @@ export default function Downloads() {
                 <Text c="dimmed" ta="center" size="sm">
                   Schedule a show from the Browse page and it will appear here.
                 </Text>
+                <Button onClick={() => navigate('/browse')}>
+                  Go to Browse
+                </Button>
               </Stack>
             </Card>
           ) : (


### PR DESCRIPTION
## What changed

The Downloads Upcoming tab empty state was missing a call-to-action button. The Active tab and the Scheduled page both show a **Go to Browse** button when empty, but Upcoming only showed text.

A non-technical user landing on the empty Upcoming tab had no obvious next step: the text says to schedule from Browse, but there was no button to get there.

## Fix

Added `<Button onClick={() => navigate('/browse')}>Go to Browse</Button>` to the Upcoming empty state, matching the pattern already used in the Active tab and Scheduled page.

One-line change (three lines with JSX formatting). No logic change.

## Before

Upcoming tab empty state: calendar icon, "No upcoming recordings.", subtitle text. No button.

## After

Upcoming tab empty state: calendar icon, "No upcoming recordings.", subtitle text, orange Go to Browse button.

Before/after screenshots posted to #design.

## Test

Opened Downloads > Upcoming tab in browser. Orange "Go to Browse" button appears in empty state on desktop and mobile. Button navigates to Browse page.