### PR TITLE
[Design] sort Scheduled Upcoming by air time, soonest first

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -342,9 +342,9 @@ export default function Scheduled() {
     }
   }
 
-  const activeSchedules = localItems?.filter((s) =>
+  const activeSchedules = (localItems?.filter((s) =>
     ['scheduled', 'queued', 'downloading', 'processing', 'paused_low_space'].includes(s.status)
-  ) || []
+  ) || []).sort((a, b) => new Date(a.program_start || 0) - new Date(b.program_start || 0))
 
   const historySchedules = localItems?.filter((s) =>
     ['completed', 'failed', 'cancelled'].includes(s.status)


### PR DESCRIPTION
## What changed

The Scheduled Recordings > Upcoming tab was showing recordings in reverse order: the show airing furthest in the future appeared first, and the show airing soonest appeared last. A user with three recordings scheduled would have to scroll to the bottom to find what is recording next.

The Downloads > Upcoming tab (same data, different view) already sorted soonest first. This PR makes Scheduled Upcoming match.

**One-line change:** add `.sort((a, b) => new Date(a.program_start || 0) - new Date(b.program_start || 0))` to the `activeSchedules` filter in `Scheduled.jsx`. No backend changes.

## Before

Scheduled Upcoming shows furthest-away recording first (Great British Bake Off on Wednesday at top, EastEnders airing *today* at bottom):

![Before (desktop)](https://cdn.discordapp.com/attachments/1512586038969765908/placeholder-before-desktop)

## After

Scheduled Upcoming shows soonest recording first (EastEnders airing today at top):

![After (desktop)](https://cdn.discordapp.com/attachments/1512586038969765908/placeholder-after-desktop)

Before/after screenshots also posted in #design.

## Testing

Verified locally at desktop (1280px) and mobile (390px) widths. Downloads Upcoming and Scheduled Upcoming now show identical sort order.

No tests required: frontend-only sort, no logic change.