### PR TITLE
fix: flush accumulated EPG batch when XMLTV file is malformed or truncated

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -496,85 +496,91 @@ class EPGIngestManager:
         stream_info = channel_maps["stream_info"]
         xmltv_to_stream: Dict[str, str] = dict(stream_by_xmltv_id)
 
-        for _, elem in ET.iterparse(io.BytesIO(xmltv_bytes), events=("end",)):
-            local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
-            if local_tag == "channel":
-                xmltv_id = elem.get("id")
-                display_name = self._extract_text(elem, "display-name")
-                if xmltv_id and xmltv_id not in xmltv_to_stream:
-                    if xmltv_id in stream_info:
-                        xmltv_to_stream[xmltv_id] = xmltv_id
-                    elif display_name:
-                        name_key = self._normalize_name(display_name)
-                        stream_id = stream_by_name.get(name_key)
-                        if stream_id:
-                            xmltv_to_stream[xmltv_id] = stream_id
-                elem.clear()
-                continue
-
-            if local_tag != "programme":
-                continue
-
-            xmltv_id = elem.get("channel")
-            if not xmltv_id:
-                elem.clear()
-                continue
-
-            stream_id = xmltv_to_stream.get(xmltv_id)
-            if not stream_id or stream_id not in stream_info:
-                elem.clear()
-                continue
-
-            start_raw = elem.get("start")
-            stop_raw = elem.get("stop")
-            start_dt = self._parse_xmltv_time(start_raw)
-            end_dt = self._parse_xmltv_time(stop_raw)
-            if not start_dt or not end_dt:
-                elem.clear()
-                continue
-
-            start_utc = start_dt.astimezone(timezone.utc)
-            end_utc = end_dt.astimezone(timezone.utc)
-            archive_days = int(stream_info[stream_id].get("archive_days") or 0)
-            if archive_days > 0:
-                channel_cutoff = now_utc - timedelta(days=archive_days)
-                if end_utc < channel_cutoff:
+        try:
+            for _, elem in ET.iterparse(io.BytesIO(xmltv_bytes), events=("end",)):
+                local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+                if local_tag == "channel":
+                    xmltv_id = elem.get("id")
+                    display_name = self._extract_text(elem, "display-name")
+                    if xmltv_id and xmltv_id not in xmltv_to_stream:
+                        if xmltv_id in stream_info:
+                            xmltv_to_stream[xmltv_id] = xmltv_id
+                        elif display_name:
+                            name_key = self._normalize_name(display_name)
+                            stream_id = stream_by_name.get(name_key)
+                            if stream_id:
+                                xmltv_to_stream[xmltv_id] = stream_id
                     elem.clear()
                     continue
 
-            duration_minutes = int((end_utc - start_utc).total_seconds() / 60)
-            if duration_minutes <= 0:
+                if local_tag != "programme":
+                    continue
+
+                xmltv_id = elem.get("channel")
+                if not xmltv_id:
+                    elem.clear()
+                    continue
+
+                stream_id = xmltv_to_stream.get(xmltv_id)
+                if not stream_id or stream_id not in stream_info:
+                    elem.clear()
+                    continue
+
+                start_raw = elem.get("start")
+                stop_raw = elem.get("stop")
+                start_dt = self._parse_xmltv_time(start_raw)
+                end_dt = self._parse_xmltv_time(stop_raw)
+                if not start_dt or not end_dt:
+                    elem.clear()
+                    continue
+
+                start_utc = start_dt.astimezone(timezone.utc)
+                end_utc = end_dt.astimezone(timezone.utc)
+                archive_days = int(stream_info[stream_id].get("archive_days") or 0)
+                if archive_days > 0:
+                    channel_cutoff = now_utc - timedelta(days=archive_days)
+                    if end_utc < channel_cutoff:
+                        elem.clear()
+                        continue
+
+                duration_minutes = int((end_utc - start_utc).total_seconds() / 60)
+                if duration_minutes <= 0:
+                    elem.clear()
+                    continue
+
+                title = self._extract_text(elem, "title") or "Unknown"
+                description = self._extract_text(elem, "desc")
+                category = self._extract_text(elem, "category")
+
+                start_ts = int(start_utc.timestamp())
+                stop_ts = int(end_utc.timestamp())
+                epg_id = f"{stream_id}:{start_ts}:{stop_ts}"
+
+                info = stream_info[stream_id]
+                yield {
+                    "channel_id": stream_id,
+                    "channel_name": info["name"],
+                    "xmltv_id": xmltv_id,
+                    "epg_id": epg_id,
+                    "title": title,
+                    "description": description,
+                    "category": category,
+                    "start_time": start_utc,
+                    "end_time": end_utc,
+                    "start_timestamp": start_ts,
+                    "stop_timestamp": stop_ts,
+                    "provider_start": start_raw,
+                    "provider_stop": stop_raw,
+                    "duration_minutes": duration_minutes,
+                    "has_archive": info["has_archive"],
+                }
+
                 elem.clear()
-                continue
-
-            title = self._extract_text(elem, "title") or "Unknown"
-            description = self._extract_text(elem, "desc")
-            category = self._extract_text(elem, "category")
-
-            start_ts = int(start_utc.timestamp())
-            stop_ts = int(end_utc.timestamp())
-            epg_id = f"{stream_id}:{start_ts}:{stop_ts}"
-
-            info = stream_info[stream_id]
-            yield {
-                "channel_id": stream_id,
-                "channel_name": info["name"],
-                "xmltv_id": xmltv_id,
-                "epg_id": epg_id,
-                "title": title,
-                "description": description,
-                "category": category,
-                "start_time": start_utc,
-                "end_time": end_utc,
-                "start_timestamp": start_ts,
-                "stop_timestamp": stop_ts,
-                "provider_start": start_raw,
-                "provider_stop": stop_raw,
-                "duration_minutes": duration_minutes,
-                "has_archive": info["has_archive"],
-            }
-
-            elem.clear()
+        except ET.ParseError as exc:
+            logger.warning(
+                "XMLTV file was truncated or malformed; partial EPG data was imported. (%s)",
+                exc,
+            )
 
     def _maybe_decompress(self, data: bytes) -> bytes:
         if data[:2] == b"\x1f\x8b":

--- a/backend/tests/test_epg_xmltv_malformed_batch_flush.py
+++ b/backend/tests/test_epg_xmltv_malformed_batch_flush.py
@@ -1,0 +1,143 @@
+"""
+Regression tests for malformed XMLTV mid-parse discarding accumulated EPG batch.
+
+When a provider's XMLTV file is truncated or contains invalid XML, ET.iterparse
+raises ParseError inside _iter_programs. Before the fix the exception propagated
+out of the generator, bypassing the caller's flush_batch call. Any programmes
+yielded before the error were never written to the database.
+
+After the fix _iter_programs catches ParseError, logs a warning, and stops
+iteration cleanly. The caller's flush sees the accumulated batch and saves it.
+
+Observable contract tested here: list(_iter_programs(malformed_xmltv)) returns
+all programmes parsed before the malformed element and does NOT raise ParseError.
+"""
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from defusedxml import ElementTree as ET
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_channel(stream_id: str, name: str, epg_channel_id: str = "") -> dict:
+    ch = {
+        "stream_id": stream_id,
+        "name": name,
+        "tv_archive": 1,
+        "tv_archive_duration": 7,
+    }
+    if epg_channel_id:
+        ch["epg_channel_id"] = epg_channel_id
+    return ch
+
+
+XMLTV_TRUNCATED = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<tv>'
+    b'<channel id="bbc1"><display-name>BBC One</display-name></channel>'
+    b'<programme start="20240101120000 +0000" stop="20240101130000 +0000" channel="bbc1">'
+    b'<title>News at Noon</title></programme>'
+    b'<programme start="20240101130000 +0000" stop="20240101140000 +0000" channel="bbc1">'
+    b'<title>Afternoon Show</title></programme>'
+    # Truncated: unclosed start tag, no </tv>
+    b'<programme start="20240101140000 +0000"'
+)
+
+XMLTV_EMBEDDED_NUL = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<tv>'
+    b'<channel id="ch1"><display-name>CNN</display-name></channel>'
+    b'<programme start="20240101100000 +0000" stop="20240101110000 +0000" channel="ch1">'
+    b'<title>World News</title></programme>'
+    # NUL byte is invalid in XML 1.0
+    b'\x00'
+    b'<programme start="20240101110000 +0000" stop="20240101120000 +0000" channel="ch1">'
+    b'<title>This Should Not Appear</title></programme>'
+    b'</tv>'
+)
+
+XMLTV_WELL_FORMED = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<tv>'
+    b'<channel id="bbc1"><display-name>BBC One</display-name></channel>'
+    b'<programme start="20240101120000 +0000" stop="20240101130000 +0000" channel="bbc1">'
+    b'<title>News at Noon</title></programme>'
+    b'<programme start="20240101130000 +0000" stop="20240101140000 +0000" channel="bbc1">'
+    b'<title>Afternoon Show</title></programme>'
+    b'</tv>'
+)
+
+
+class MalformedXmltvBatchFlushTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = EPGIngestManager()
+        self.now = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def _collect(self, channels, xmltv_bytes):
+        channel_maps = self.manager._build_channel_maps(channels)
+        return list(self.manager._iter_programs(xmltv_bytes, channel_maps, self.now))
+
+    def test_truncated_xmltv_does_not_raise(self):
+        """_iter_programs must not propagate ParseError on truncated input.
+
+        Before the fix ET.iterparse raised ParseError which bypassed the
+        caller's flush_batch, silently discarding all programmes parsed so far.
+        """
+        channels = [_make_channel("101", "BBC One", epg_channel_id="bbc1")]
+        try:
+            programs = self._collect(channels, XMLTV_TRUNCATED)
+        except ET.ParseError:
+            self.fail(
+                "_iter_programs raised ParseError on truncated XMLTV. "
+                "Programmes parsed before the truncation point are lost. "
+                "Fix: wrap ET.iterparse loop in try/except ET.ParseError and return."
+            )
+        self.assertEqual(
+            len(programs),
+            2,
+            f"Expected 2 programmes before truncation, got {len(programs)}.",
+        )
+
+    def test_embedded_nul_does_not_raise(self):
+        """_iter_programs must not raise on XML containing an invalid NUL byte.
+
+        Only the programme before the NUL should be returned.
+        """
+        channels = [_make_channel("101", "CNN", epg_channel_id="ch1")]
+        try:
+            programs = self._collect(channels, XMLTV_EMBEDDED_NUL)
+        except ET.ParseError:
+            self.fail(
+                "_iter_programs raised ParseError on XMLTV with embedded NUL. "
+                "Fix: catch ParseError and stop iteration cleanly."
+            )
+        titles = [p["title"] for p in programs]
+        self.assertIn("World News", titles)
+        self.assertNotIn(
+            "This Should Not Appear",
+            titles,
+            "Programme after the malformed byte must not be yielded.",
+        )
+
+    def test_well_formed_xmltv_still_works(self):
+        """Regression: well-formed XMLTV must yield all programmes unchanged."""
+        channels = [_make_channel("101", "BBC One", epg_channel_id="bbc1")]
+        programs = self._collect(channels, XMLTV_WELL_FORMED)
+        self.assertEqual(
+            len(programs),
+            2,
+            f"Expected 2 programmes from well-formed XMLTV, got {len(programs)}.",
+        )
+        titles = {p["title"] for p in programs}
+        self.assertIn("News at Noon", titles)
+        self.assertIn("Afternoon Show", titles)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

When your IPTV provider serves a corrupted or incomplete program guide file, Mustarrd would silently lose all the program listings it had already parsed before hitting the bad part of the file. The guide would appear partially updated (or empty for affected channels), with no error shown. On the next scheduled refresh the same thing would happen again.

After this fix, any programs that were successfully parsed before the malformed section are saved to the database. The server log records a warning that the file was truncated or malformed, so it is visible to an operator checking logs.

## What changed

`_iter_programs` in `epg_ingest_manager.py` uses a streaming XML parser (`ET.iterparse`) to process XMLTV files. When the file is truncated mid-download or contains invalid characters (a NUL byte, an unclosed tag, etc.), the parser raises `ParseError` partway through.

Before this fix, that exception propagated out of the generator without giving the caller a chance to flush its accumulated batch of parsed programs to the database. All programs parsed since the last batch write (up to 999 entries) were silently discarded.

The fix wraps the iterparse loop in a `try/except ET.ParseError`. On error, a warning is logged and the generator stops cleanly. The caller's existing flush-batch code then runs normally and saves everything that was parsed before the error.

No changes to the database schema, API, or frontend.

## Before

1. Provider returns a truncated XMLTV file (network drop mid-download, or a provider bug).
2. EPG refresh appears to complete.
3. Programs near the end of the file are missing from the guide. No error is shown.
4. `list(_iter_programs(truncated_bytes, ...))` raises `ParseError`.

## After

1. Same truncated file.
2. EPG refresh completes; all programs before the truncation point are saved.
3. Server log contains: `XMLTV file was truncated or malformed; partial EPG data was imported.`
4. `list(_iter_programs(truncated_bytes, ...))` returns the programs parsed before the error without raising.

## Tests

`backend/tests/test_epg_xmltv_malformed_batch_flush.py` adds 3 tests:
- Truncated XMLTV (no closing tag): `_iter_programs` must not raise and must return the 2 complete programs before the truncation.
- Embedded NUL byte: same contract, program after the NUL must not appear.
- Well-formed XMLTV regression guard: both programs returned as before.

```
Ran 578 tests in 2.355s
OK
```