### PR TITLE
[Design] show weekday name for dates 2-6 days ahead

### DIFF
--- a/frontend/src/utils/channelTime.js
+++ b/frontend/src/utils/channelTime.js
@@ -98,5 +98,10 @@ export function formatAirDateTime(program, kind = 'start', guideOffsetHours = 0)
   if (displayDate === yesterdayDate) {
     return `Yesterday at ${timeStr}`
   }
+  for (let d = 2; d <= 6; d++) {
+    if (displayDate === now.add(d, 'day').format('YYYY-MM-DD')) {
+      return `${displayTime.format('dddd')} at ${timeStr}`
+    }
+  }
   return `${displayTime.format('ddd, MMM D, YYYY')} at ${timeStr}`
 }


### PR DESCRIPTION
## What changed

Scheduled and Downloads cards for shows airing in the next 2-6 days now show the weekday name instead of the full date.

Before: **Wed, Jun 10, 2026 at 8:00 PM**
After: **Wednesday at 8:00 PM**

## Why

`formatAirDateTime` already handled Today, Tomorrow, and Yesterday but fell back to a full date (e.g. "Wed, Jun 10, 2026") for everything else. Showing that for a show airing in 2 days makes users do mental math. On mobile (390px), the full date also caused "Download starts: Wed, Jun 10, 2026 at 9:30 PM (1h 30m recording)" to wrap mid-sentence, leaving "recording)" alone on its own line.

## What changed

Five-line addition to `frontend/src/utils/channelTime.js`. Dates 7+ days out keep the full absolute date. No other files changed.

## Before / After

Screenshots in #design (Pixel iteration 18 thread).

## Test plan

- Scheduled > Upcoming: show airing within the week shows weekday name
- Downloads > Upcoming: same
- Today and Tomorrow labels unchanged
- Dates 7+ days out still show full absolute date
- History cards with old dates unaffected