### PR TITLE
[Design] show placeholder in Browse EPG right panel when provider unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1042,7 +1042,14 @@ export default function Browse() {
                         </Text>
                       )}
                     </Stack>
-                  ) : channelsIsError ? null : (
+                  ) : channelsIsError ? (
+                    <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
+                      <IconVideo size={48} opacity={0.3} />
+                      <Text c="dimmed" ta="center">
+                        Channel guide will appear here once your provider is connected.
+                      </Text>
+                    </Stack>
+                  ) : (
                     <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
                       <IconVideo size={48} opacity={0.3} />
                       <Text c="dimmed">Select a channel to view its EPG</Text>


### PR DESCRIPTION
## What users noticed before

On desktop, the Browse EPG page has a two-column layout: channels on the left, the program guide on the right. When a provider is unreachable, the left panel shows a red error icon and a link to Settings. The right panel showed nothing at all: a blank dark box with no text, no icon, no hint. A non-technical user could mistake the empty space for a rendering glitch or a broken page.

## What changed

One change in `Browse.jsx`: the `channelsIsError ? null :` branch in the desktop EPG right panel now renders a centered dimmed TV icon and the message "Channel guide will appear here once your provider is connected." instead of nothing.

This mirrors the existing pattern used by the same panel when no channel is selected (same icon, same style).

## How it was tested

Started the app locally with an unreachable provider and used Playwright to capture before and after screenshots. Before/after are in #design.

## Files changed

- `frontend/src/pages/Browse.jsx`: 8 lines changed, right panel `null` branch replaced with empty state