### PR TITLE
fix: correct ComSkip failure error message when .ts file is kept on disk

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1407,7 +1407,7 @@ class DownloadManager:
             except Exception as e:
                 logger.exception("Comskip error")
                 raise RuntimeError(
-                    f"ComSkip failed: {e}. Recording not saved to avoid producing a file with commercials intact."
+                    f"ComSkip failed: {e}. The raw recording is still in the download folder and was not deleted."
                 ) from e
 
         # Transcode if enabled (and not already done by commercial removal)

--- a/backend/tests/test_comskip_failure_error_message.py
+++ b/backend/tests/test_comskip_failure_error_message.py
@@ -10,12 +10,11 @@ overwriting the still-intact original.
 Fix: the error message now says the raw recording is still in the
 download folder.
 """
-import asyncio
 import os
 import sys
 import tempfile
 import unittest
-from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,105 +22,116 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
 from services.download_manager import DownloadManager
-from models import DownloadStatus
 
 
-class ComSkipFailureErrorMessageTests(unittest.TestCase):
-    def setUp(self):
+class ComSkipFailureErrorMessageTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
         self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
 
-    def _make_session(self, download):
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = download
-        mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.commit = AsyncMock()
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-        @asynccontextmanager
-        async def ctx():
-            yield mock_session
-
-        return ctx
-
-    def test_comskip_failure_error_mentions_download_folder_not_deleted(self):
-        """ComSkip failure error must say the file is still present, not that it was not saved."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            input_path = os.path.join(tmpdir, "show.ts")
-            with open(input_path, "wb") as f:
-                f.write(b"\x00" * 1024)
-
-            mock_download = MagicMock()
-            mock_download.id = 1
-            mock_download.status = DownloadStatus.PROCESSING.value
-            mock_download.output_path = input_path
-            mock_download.progress = 0.0
-            mock_download.completed_at = None
-
-            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
-                with patch.object(self.manager, "_needs_post_processing", return_value=True):
-                    with patch.object(
-                        self.manager,
-                        "_post_process",
-                        side_effect=RuntimeError(
-                            "ComSkip failed: Comskip exited with code 1. "
-                            "The raw recording is still in the download folder and was not deleted."
-                        ),
-                    ):
-                        with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
-                            with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
-                                with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
-                                    with patch.object(self.manager, "_broadcast_log", AsyncMock()):
-                                        asyncio.run(self.manager._execute_post_process(1))
-
-            self.assertEqual(mock_download.status, DownloadStatus.FAILED.value)
-            error = mock_download.error_message
-            self.assertIsNotNone(error)
-            self.assertNotIn(
-                "not saved",
-                error,
-                "Error message must not say 'not saved': the raw .ts is still on disk",
+    async def _seed_db(self, ts_path: str) -> int:
+        async with self.session_factory() as session:
+            settings = AppSettings(
+                comskip_enabled=True,
+                transcode_enabled=True,
+                remux_only=False,
+                download_folder=self.tmpdir,
+                completed_folder=self.tmpdir,
             )
-            self.assertIn(
-                "download folder",
-                error,
-                "Error message must mention the download folder so operators know where to find the file",
-            )
+            session.add(settings)
+            await session.flush()
 
-    def test_comskip_failure_raw_file_still_present_on_disk(self):
+            download = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=ts_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id
+
+    def _make_mock_pp(self):
+        mock_pp = MagicMock()
+        mock_pp.comskip_available = True
+        mock_pp.ffmpeg_available = False
+        mock_pp.get_comskip_path.return_value = "/usr/bin/comskip"
+        mock_pp.detect_commercials = AsyncMock(
+            side_effect=RuntimeError("Comskip exited with code 1")
+        )
+        mock_pp.remove_commercials = AsyncMock()
+        mock_pp.transcode = AsyncMock()
+        return mock_pp
+
+    async def _run_post_process(self, download_id: int):
+        with patch("services.download_manager.async_session_maker",
+                   side_effect=lambda: self.session_factory()), \
+             patch("services.post_processor.post_processor", self._make_mock_pp()), \
+             patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+             patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock):
+            await self.manager._execute_post_process(download_id)
+
+    async def test_comskip_failure_error_mentions_download_folder_not_deleted(self):
+        """download.error_message must say file is in download folder, not that it was not saved."""
+        ts_path = os.path.join(self.tmpdir, "show.ts")
+        Path(ts_path).write_bytes(b"\x47" * 188)
+
+        download_id = await self._seed_db(ts_path)
+        await self._run_post_process(download_id)
+
+        async with self.session_factory() as session:
+            result = await session.execute(select(Download).where(Download.id == download_id))
+            dl = result.scalar_one()
+
+        self.assertEqual(dl.status, DownloadStatus.FAILED.value)
+        self.assertIsNotNone(dl.error_message)
+        self.assertNotIn(
+            "not saved",
+            dl.error_message,
+            "Error must not say 'not saved': the raw .ts is still on disk",
+        )
+        self.assertIn(
+            "download folder",
+            dl.error_message,
+            "Error must mention the download folder so operators know where to find the file",
+        )
+
+    async def test_comskip_failure_raw_file_still_present_on_disk(self):
         """The .ts file must remain on disk after ComSkip failure, not be deleted."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            input_path = os.path.join(tmpdir, "show.ts")
-            with open(input_path, "wb") as f:
-                f.write(b"\x00" * 1024)
+        ts_path = os.path.join(self.tmpdir, "show.ts")
+        Path(ts_path).write_bytes(b"\x47" * 188)
 
-            mock_download = MagicMock()
-            mock_download.id = 2
-            mock_download.status = DownloadStatus.PROCESSING.value
-            mock_download.output_path = input_path
-            mock_download.progress = 0.0
-            mock_download.completed_at = None
+        download_id = await self._seed_db(ts_path)
+        await self._run_post_process(download_id)
 
-            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
-                with patch.object(self.manager, "_needs_post_processing", return_value=True):
-                    with patch.object(
-                        self.manager,
-                        "_post_process",
-                        side_effect=RuntimeError(
-                            "ComSkip failed: Comskip exited with code 1. "
-                            "The raw recording is still in the download folder and was not deleted."
-                        ),
-                    ):
-                        with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
-                            with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
-                                with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
-                                    with patch.object(self.manager, "_broadcast_log", AsyncMock()):
-                                        asyncio.run(self.manager._execute_post_process(2))
-
-            self.assertTrue(
-                os.path.exists(input_path),
-                "Raw .ts must still exist on disk after ComSkip failure",
-            )
+        self.assertTrue(
+            os.path.exists(ts_path),
+            "Raw .ts must still exist on disk after ComSkip failure",
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_comskip_failure_error_message.py
+++ b/backend/tests/test_comskip_failure_error_message.py
@@ -1,0 +1,128 @@
+"""
+Regression test for misleading ComSkip failure error message.
+
+When ComSkip fails during post-processing, the error used to say
+"Recording not saved to avoid producing a file with commercials intact."
+This was false: the raw .ts file is still in the download folder,
+not deleted. Operators were re-downloading unnecessarily, sometimes
+overwriting the still-intact original.
+
+Fix: the error message now says the raw recording is still in the
+download folder.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+class ComSkipFailureErrorMessageTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def _make_session(self, download):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = download
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def ctx():
+            yield mock_session
+
+        return ctx
+
+    def test_comskip_failure_error_mentions_download_folder_not_deleted(self):
+        """ComSkip failure error must say the file is still present, not that it was not saved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, "show.ts")
+            with open(input_path, "wb") as f:
+                f.write(b"\x00" * 1024)
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PROCESSING.value
+            mock_download.output_path = input_path
+            mock_download.progress = 0.0
+            mock_download.completed_at = None
+
+            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
+                with patch.object(self.manager, "_needs_post_processing", return_value=True):
+                    with patch.object(
+                        self.manager,
+                        "_post_process",
+                        side_effect=RuntimeError(
+                            "ComSkip failed: Comskip exited with code 1. "
+                            "The raw recording is still in the download folder and was not deleted."
+                        ),
+                    ):
+                        with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
+                            with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
+                                with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                                    with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                                        asyncio.run(self.manager._execute_post_process(1))
+
+            self.assertEqual(mock_download.status, DownloadStatus.FAILED.value)
+            error = mock_download.error_message
+            self.assertIsNotNone(error)
+            self.assertNotIn(
+                "not saved",
+                error,
+                "Error message must not say 'not saved': the raw .ts is still on disk",
+            )
+            self.assertIn(
+                "download folder",
+                error,
+                "Error message must mention the download folder so operators know where to find the file",
+            )
+
+    def test_comskip_failure_raw_file_still_present_on_disk(self):
+        """The .ts file must remain on disk after ComSkip failure, not be deleted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, "show.ts")
+            with open(input_path, "wb") as f:
+                f.write(b"\x00" * 1024)
+
+            mock_download = MagicMock()
+            mock_download.id = 2
+            mock_download.status = DownloadStatus.PROCESSING.value
+            mock_download.output_path = input_path
+            mock_download.progress = 0.0
+            mock_download.completed_at = None
+
+            with patch("services.download_manager.async_session_maker", self._make_session(mock_download)):
+                with patch.object(self.manager, "_needs_post_processing", return_value=True):
+                    with patch.object(
+                        self.manager,
+                        "_post_process",
+                        side_effect=RuntimeError(
+                            "ComSkip failed: Comskip exited with code 1. "
+                            "The raw recording is still in the download folder and was not deleted."
+                        ),
+                    ):
+                        with patch.object(self.manager, "_resolve_completed_folder", return_value=tmpdir):
+                            with patch.object(self.manager, "_resolve_download_folder", return_value=tmpdir):
+                                with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                                    with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                                        asyncio.run(self.manager._execute_post_process(2))
+
+            self.assertTrue(
+                os.path.exists(input_path),
+                "Raw .ts must still exist on disk after ComSkip failure",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

When ComSkip fails during post-processing, the error message used to say:

> ComSkip failed: [reason]. **Recording not saved** to avoid producing a file with commercials intact.

That was wrong. The raw `.ts` file stays in the download folder exactly where it was downloaded. Nothing deletes it. The error only meant "not moved to the completed folder," but operators read it as "deleted."

## Why it matters

Operators were seeing "not saved," assuming the recording was gone, and queuing a fresh re-download. When they hit Retry, the new download overwrites the still-intact `.ts` before they can rescue it. This is especially painful for recordings with large catchup windows or slow providers.

## What it says now

> ComSkip failed: [reason]. **The raw recording is still in the download folder and was not deleted.**

## How to test

1. Enable ComSkip and point `comskip_path` to a binary that always exits non-zero (e.g. `false`).
2. Queue a catchup download. Let the transfer complete.
3. Watch the download fail during post-processing.
4. **Before fix:** error reads "Recording not saved."
5. **After fix:** error reads "The raw recording is still in the download folder and was not deleted."
6. Verify the `.ts` is actually still present in the download folder.

## Tests

2 new regression tests in `test_comskip_failure_error_message.py`. 588 total pass.

- `test_comskip_failure_error_mentions_download_folder_not_deleted`: asserts the error message does not contain "not saved" and does mention "download folder."
- `test_comskip_failure_raw_file_still_present_on_disk`: asserts the `.ts` still exists on disk after `_execute_post_process` marks the download FAILED.