### PR TITLE
[Design] fix Accounts heading appearing below buttons on mobile

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -500,10 +500,15 @@ export default function AccountsSection({ showTitle = true }) {
 
   return (
     <Stack>
-      <Group justify="space-between">
+      <Flex
+        direction={{ base: 'column', sm: 'row' }}
+        justify={{ sm: 'space-between' }}
+        align={{ sm: 'center' }}
+        gap="xs"
+      >
         {showTitle ? <Title order={2}>Accounts</Title> : <Title order={4}>Accounts</Title>}
         {accounts?.length > 0 && (
-          <Flex direction={{ base: 'column-reverse', sm: 'row' }} gap="xs">
+          <Group gap="xs">
             <Button
               variant="light"
               color="orange"
@@ -517,9 +522,9 @@ export default function AccountsSection({ showTitle = true }) {
             <Button leftSection={<IconPlus size={16} />} onClick={handleAddClick}>
               Add Another Account
             </Button>
-          </Flex>
+          </Group>
         )}
-      </Group>
+      </Flex>
 
       {accounts?.length === 0 ? (
         <Card shadow="sm" padding="xl" radius="md" withBorder>


### PR DESCRIPTION
## What changed

On mobile (narrow screen), the **Settings > Accounts** and **Accounts** pages showed the action buttons above the "Accounts" heading. A non-technical user opening the page on their phone would see two buttons with no context about what page they were on.

## Root cause

The header row used `<Group justify="space-between">` with an inner `<Flex direction={{ base: 'column-reverse' }}>` for the buttons. On narrow screens the outer Group wrapped its children, and because the button Flex was taller (two stacked items), it ended up on top in the visual flow.

## Fix

Replace the outer `Group` with a responsive `Flex`:
- Mobile: column layout, so "Accounts" heading always renders first and buttons appear below it
- Desktop: row layout with space-between, identical to the previous desktop appearance

The inner `column-reverse` Flex becomes a plain `Group` because the outer Flex now controls vertical stacking.

## Changes

- `frontend/src/components/settings/AccountsSection.jsx`: 9 lines changed

## Test plan

- Settings > Accounts on mobile (390px): heading is above buttons
- /accounts on mobile: heading is above buttons
- Settings > Accounts on desktop: heading on left, buttons on right (unchanged)
- Force EPG Refresh and Add Another Account both still work