### PR TITLE
[Design] drop redundant "recording" word from Download starts line on mobile

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -695,7 +695,7 @@ export default function Downloads() {
                         Airs: {airStart || 'Unknown'} - {airEnd || 'Unknown'} ({formatDuration(rec.duration_minutes || 0)})
                       </Text>
                       <Text size="xs" c="dimmed">
-                        Download starts: {downloadAt || 'Unknown'} ({formatDuration(totalDuration)} recording)
+                        Download starts: {downloadAt || 'Unknown'} ({formatDuration(totalDuration)})
                       </Text>
                     </Stack>
                   </Card>

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -147,7 +147,7 @@ function ScheduleCard({
 
         {(isActive || schedule.status === 'completed') && (
           <Text size="xs" c="dimmed">
-            Download starts: {availableAt || 'Unknown'} ({formatDuration(totalDuration)} recording)
+            Download starts: {availableAt || 'Unknown'} ({formatDuration(totalDuration)})
           </Text>
         )}
 


### PR DESCRIPTION
## What changed

On mobile (narrow screens), the "Download starts:" line on Scheduled and Downloads Upcoming cards ended with "(1h 30m recording)". For a show with a 1.5-hour recording like Great British Bake Off, this text was too long to fit on one line at 390px width. The word "recording)" wrapped to a second line, sitting orphaned below the rest of the text.

The label "Download starts:" already tells the user a recording is happening, so the word "recording" adds nothing. Removing it is enough to fix the wrap.

Two lines changed: one in `Scheduled.jsx` and one in `Downloads.jsx`.

## Before

On mobile, the third card's last line wrapped: "Download starts: Wednesday at 9:30 PM (1h 30m" with "recording)" alone on the next line.

## After

"Download starts: Wednesday at 9:30 PM (1h 30m)" fits on one line. All three cards are the same height and read cleanly.

## Screens tested

Desktop (1280px) and mobile (390px) on Scheduled Upcoming and Downloads Upcoming tabs.