### PR TITLE
[Design] show rendered example output in File Naming settings

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -263,6 +263,7 @@ async def get_template_variables(_admin: None = Depends(require_admin)):
                 {"name": "date", "description": "Air date (YYYY-MM-DD)"},
             ],
             "example": "{show} - S{season:02d}E{episode:02d} - {title}",
+            "rendered_example": "Breaking Bad - S01E05 - Gray Matter",
         },
         "movie": {
             "variables": [
@@ -270,6 +271,7 @@ async def get_template_variables(_admin: None = Depends(require_admin)):
                 {"name": "year", "description": "Release year"},
             ],
             "example": "{title} ({year})",
+            "rendered_example": "Inception (2010)",
         },
         "sports": {
             "variables": [
@@ -278,6 +280,7 @@ async def get_template_variables(_admin: None = Depends(require_admin)):
                 {"name": "channel", "description": "Channel name"},
             ],
             "example": "{title} - {date}",
+            "rendered_example": "FA Cup Final - 2024-01-14",
         },
         "default": {
             "variables": [
@@ -286,6 +289,7 @@ async def get_template_variables(_admin: None = Depends(require_admin)):
                 {"name": "date", "description": "Air date (YYYY-MM-DD)"},
             ],
             "example": "{title} - {date}",
+            "rendered_example": "Planet Earth - 2024-01-14",
         },
     }
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -54,7 +54,7 @@ function isPlexNotConnectedError(message) {
   return (message || '').toLowerCase().includes('plex account is not connected')
 }
 
-function TemplateSection({ label, template, variables, example, onChange }) {
+function TemplateSection({ label, template, variables, example, renderedExample, onChange }) {
   return (
     <Stack gap="xs">
       <TextInput
@@ -71,7 +71,7 @@ function TemplateSection({ label, template, variables, example, onChange }) {
         ))}
       </Group>
       <Text size="xs" c="dimmed">
-        Example: <Code>{example}</Code>
+        Example: <Code>{renderedExample || example}</Code>
       </Text>
     </Stack>
   )
@@ -931,6 +931,7 @@ export default function Settings() {
               template={formData.tv_template}
               variables={templateInfo.tv_show.variables}
               example={templateInfo.tv_show.example}
+              renderedExample={templateInfo.tv_show.rendered_example}
               onChange={(val) => handleChange('tv_template', val)}
             />
           </Stack>
@@ -947,6 +948,7 @@ export default function Settings() {
               template={formData.movie_template}
               variables={templateInfo.movie.variables}
               example={templateInfo.movie.example}
+              renderedExample={templateInfo.movie.rendered_example}
               onChange={(val) => handleChange('movie_template', val)}
             />
           </Stack>
@@ -963,6 +965,7 @@ export default function Settings() {
               template={formData.sports_template}
               variables={templateInfo.sports.variables}
               example={templateInfo.sports.example}
+              renderedExample={templateInfo.sports.rendered_example}
               onChange={(val) => handleChange('sports_template', val)}
             />
           </Stack>
@@ -978,6 +981,7 @@ export default function Settings() {
             template={formData.default_template}
             variables={templateInfo.default.variables}
             example={templateInfo.default.example}
+            renderedExample={templateInfo.default.rendered_example}
             onChange={(val) => handleChange('default_template', val)}
           />
         </Stack>


### PR DESCRIPTION
## What changed

The Example line under each filename template in Settings > File Naming was showing the template syntax itself (e.g. `{show} - S{season:02d}E{episode:02d} - {title}`), which is identical to what the user already sees in the input field above. This gave no additional information, and was especially confusing for non-technical users who do not know what `{season:02d}` means.

The example line now shows real rendered output using sample data, so users can immediately see what their downloaded files will actually be named.

| Section | Before | After |
|---|---|---|
| TV Shows | `{show} - S{season:02d}E{episode:02d} - {title}` | `Breaking Bad - S01E05 - Gray Matter` |
| Movies | `{title} ({year})` | `Inception (2010)` |
| Sports | `{title} - {date}` | `FA Cup Final - 2024-01-14` |
| Default | `{title} - {date}` | `Planet Earth - 2024-01-14` |

## How it works

- Backend: added a `rendered_example` field alongside the existing `example` field in the `/api/settings/templates` response. The existing `example` field is kept unchanged and still serves as the TextInput placeholder (shown when the field is empty).
- Frontend: `TemplateSection` accepts a new `renderedExample` prop and uses it for the displayed example line when present, falling back to the original `example` if absent.

## Test plan

- [x] Opened Settings > File Naming on desktop (1280px): all four sections show real example filenames
- [x] Opened Settings > File Naming on mobile (390px): same rendered examples display correctly

No logic was changed. No backend tests are required. No frontend tests exist.