### PR TITLE
docs: changelog for PR #241, add CATCHUP_FFPROBE_PATH to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-08
 
+### Fixed: ComSkip now correctly cuts all commercials when EDL segments overlap
+
+**What you would notice:** If you use commercial removal and your provider's ComSkip EDL file contained one commercial block fully inside another (overlapping segments), a slice of commercial video would slip through into the final recording. The recording would look complete but still contain ads. After this fix, overlapping commercial segments are handled correctly and all commercial content is removed.
+
+**What changed:** The logic that converts commercial markers into keep-segments was advancing its position backward when it encountered a contained segment, causing the outer commercial's tail to be included in the output. The fix ensures the position always moves forward, so no commercial content is ever included between contained segments. Most users will not notice any difference; users who had this specific issue will get cleaner recordings.
+
+---
+
 ### Improved: File Naming settings now show real example filenames
 
 **What you would notice:** Under Settings > File Naming, each template section used to show the raw template syntax as an example, such as `{show} - S{season:02d}E{episode:02d} - {title}`. That text was identical to what was already in the input field above it and gave no useful information, especially to users who do not know what `{season:02d}` means. The example line now shows what a real downloaded file would actually be named, such as `Breaking Bad - S01E05 - Gray Matter` for TV shows or `Inception (2010)` for movies. You can see exactly what your filename settings will produce before saving anything.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Most users never need to touch these. Set them in `docker-compose.yml` or a `bac
 | `CATCHUP_SESSION_COOKIE_SECURE_MODE` | When to mark session cookies as HTTPS-only: `auto` (default, detects HTTPS including reverse-proxy setups), `always`, or `never` | `auto` |
 | `CATCHUP_ALLOW_REMOTE_SETUP` | Allow password setup from non-local IPs | `false` |
 | `CATCHUP_FFMPEG_PATH` | Path to ffmpeg binary | *(auto-detected)* |
+| `CATCHUP_FFPROBE_PATH` | Path to ffprobe binary (required for commercial removal) | *(auto-detected)* |
 | `CATCHUP_COMSKIP_PATH` | Path to comskip binary | *(auto-detected)* |
 | `CATCHUP_DATABASE_URL` | SQLite database URL | `sqlite+aiosqlite:////app/config/catchup_dvr.db` |
 | `CATCHUP_DEBUG` | Enable debug logging | `false` |


### PR DESCRIPTION
## What a user would notice

Two documentation updates:

1. The changelog now includes the PR #241 fix: ComSkip correctly cuts all commercials when EDL segments overlap. Users who had commercial content slipping through due to nested segments now have that change documented.

2. The README configuration table was missing the `CATCHUP_FFPROBE_PATH` environment variable. This variable has been in the code since PR #229 added the ffprobe-required check for commercial removal, but it was never added to the docs. Users who need to point Mustarrd at a non-standard ffprobe location can now find this variable in the README.

## What changed

- `CHANGELOG.md`: Added entry at the top of the 2026-06-08 section for PR #241 (skip contained EDL segments in _invert_segments).
- `README.md`: Added `CATCHUP_FFPROBE_PATH` row between `CATCHUP_FFMPEG_PATH` and `CATCHUP_COMSKIP_PATH` in the environment variables table.

## How it was tested

Both files verified by reading the current backend code (`post_processor.py:109` for the env var) and the merged PR #241 description for the changelog wording. No code changes.