### PR TITLE
[Design] fix inaccurate .ts extension claim in File Naming description

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -918,7 +918,7 @@ export default function Settings() {
       <Stack gap={2}>
         <Text fw={600} size="lg">File Naming</Text>
         <Text size="sm" c="dimmed">
-          Templates for how downloaded files are named. Files get the .ts extension automatically.
+          Templates for how downloaded files are named. The file extension is added automatically based on your Recording Format, so don&apos;t include one in the template.
         </Text>
       </Stack>
 


### PR DESCRIPTION
## What changed

The File Naming settings page described itself with: "Files get the .ts extension automatically."

This is only true when Recording Format is set to **Keep original (.ts)**. When a user picks MP4 or MKV (remux or re-encode), their files get `.mp4` or `.mkv` extensions. The old text would mislead those users into expecting `.ts` files.

**New text:** "Templates for how downloaded files are named. The file extension is added automatically based on your Recording Format, so don't include one in the template."

This tells the user two things: the extension comes from their Recording Format setting, and they should not add an extension to their template manually.

One line changed. No logic touched.

## Before

The subtitle read: "Files get the .ts extension automatically." This is wrong for users who chose MP4 or MKV Recording Format.

## After

The subtitle reads: "The file extension is added automatically based on your Recording Format, so don't include one in the template."

Before and after screenshots attached to the #design thread.

## How it was tested

Ran the frontend dev server, navigated to Settings > File Naming, confirmed new text renders correctly at 1280px (desktop) and 390px (mobile).

Design WIP after this PR: 1 of 3.