### PR TITLE
test: failing regression for delete_user orphaning schedules and downloads

### DIFF
--- a/backend/tests/test_delete_user_schedule_cleanup.py
+++ b/backend/tests/test_delete_user_schedule_cleanup.py
@@ -1,0 +1,159 @@
+"""
+Regression tests: delete_user must cancel non-terminal scheduled recordings
+and active downloads before removing the user row, and must disconnect any
+open WebSocket connections for that user.
+
+Before fix: session.delete(user) leaves ScheduledRecording and Download rows
+with requested_by_user_id pointing at the deleted user.  On the next scheduler
+poll, those orphaned schedules fire normally and create downloads attributed to
+a ghost user.  Active in-progress downloads continue running after deletion.
+WebSocket connections from the deleted user are not closed.
+
+After fix: non-terminal scheduled recordings (SCHEDULED, QUEUED, DOWNLOADING,
+PROCESSING, PAUSED_LOW_SPACE) are marked CANCELLED with status_message "User
+deleted" before the user row is removed.  Active downloads (PENDING,
+DOWNLOADING, PROCESSING) are passed to download_manager.cancel_download.
+download_manager.disconnect_user_websockets is called for the user.
+
+File:     backend/api/admin_users.py, delete_user
+Severity: MEDIUM -- orphaned schedules silently fire on behalf of deleted
+          users, consuming disk space and IPTV stream slots; in-progress
+          downloads run unrestricted after user removal; live WS connections
+          are not revoked.
+"""
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from api.admin_users import delete_user
+from models import Download, DownloadStatus, ScheduledRecording, ScheduledStatus, User
+
+
+def _scalar_one(value):
+    class R:
+        def scalar_one_or_none(self):
+            return value
+    return R()
+
+
+def _scalar_list(items):
+    return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: items))
+
+
+def _make_user(user_id=1):
+    u = User()
+    u.id = user_id
+    u.role = "download_only"
+    u.username = "testuser"
+    u.status = "active"
+    return u
+
+
+def _make_schedule(sched_id, status, user_id=1):
+    s = ScheduledRecording()
+    s.id = sched_id
+    s.account_id = 1
+    s.channel_id = "ch1"
+    s.channel_name = "Channel 1"
+    s.program_title = "Show"
+    s.program_start = None
+    s.program_end = None
+    s.duration_minutes = 60
+    s.status = status
+    s.status_message = None
+    s.requested_by_user_id = user_id
+    s.download_id = None
+    return s
+
+
+def _make_download(dl_id, status, user_id=1):
+    d = Download()
+    d.id = dl_id
+    d.account_id = 1
+    d.status = status
+    d.requested_by_user_id = user_id
+    return d
+
+
+class DeleteUserScheduleCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    async def _run_delete(self, user, schedules, active_downloads):
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=[
+            _scalar_one(user),            # select(User)
+            AsyncMock(),                  # delete(UserIdentity)
+            AsyncMock(),                  # delete(UserSetupToken)
+            _scalar_list(schedules),      # select(ScheduledRecording) -- added by fix
+            _scalar_list(active_downloads),  # select(Download) -- added by fix
+        ])
+
+        with patch("api.admin_users.download_manager") as mock_dm:
+            mock_dm.cancel_download = AsyncMock()
+            mock_dm.disconnect_user_websockets = AsyncMock()
+            result = await delete_user(user.id, None, session)
+
+        return session, mock_dm, result
+
+    async def test_active_schedule_marked_cancelled_on_user_delete(self):
+        """Active schedule must be CANCELLED when the owning user is deleted."""
+        sched = _make_schedule(10, ScheduledStatus.SCHEDULED.value)
+        session, _, result = await self._run_delete(_make_user(), [sched], [])
+        self.assertEqual(sched.status, ScheduledStatus.CANCELLED.value)
+        self.assertEqual(sched.status_message, "User deleted")
+        self.assertEqual(result, {"status": "deleted"})
+
+    async def test_all_non_terminal_statuses_are_cancelled(self):
+        non_terminal = [
+            ScheduledStatus.SCHEDULED,
+            ScheduledStatus.QUEUED,
+            ScheduledStatus.DOWNLOADING,
+            ScheduledStatus.PROCESSING,
+            ScheduledStatus.PAUSED_LOW_SPACE,
+        ]
+        for status in non_terminal:
+            with self.subTest(status=status.value):
+                sched = _make_schedule(1, status.value)
+                await self._run_delete(_make_user(), [sched], [])
+                self.assertEqual(sched.status, ScheduledStatus.CANCELLED.value)
+                self.assertEqual(sched.status_message, "User deleted")
+
+    async def test_active_download_triggers_cancel(self):
+        """Active download must be cancelled when the owning user is deleted."""
+        dl = _make_download(42, DownloadStatus.DOWNLOADING.value)
+        _, mock_dm, _ = await self._run_delete(_make_user(), [], [dl])
+        mock_dm.cancel_download.assert_awaited_once_with(42)
+
+    async def test_multiple_active_downloads_all_cancelled(self):
+        downloads = [
+            _make_download(1, DownloadStatus.PENDING.value),
+            _make_download(2, DownloadStatus.DOWNLOADING.value),
+            _make_download(3, DownloadStatus.PROCESSING.value),
+        ]
+        _, mock_dm, _ = await self._run_delete(_make_user(), [], downloads)
+        called_ids = [call.args[0] for call in mock_dm.cancel_download.await_args_list]
+        self.assertCountEqual(called_ids, [1, 2, 3])
+
+    async def test_websockets_disconnected_on_user_delete(self):
+        """Open WebSocket connections for the deleted user must be closed."""
+        _, mock_dm, _ = await self._run_delete(_make_user(user_id=7), [], [])
+        mock_dm.disconnect_user_websockets.assert_awaited_once_with(7)
+
+    async def test_no_active_work_no_cancel_called(self):
+        _, mock_dm, _ = await self._run_delete(_make_user(), [], [])
+        mock_dm.cancel_download.assert_not_awaited()
+
+    async def test_session_delete_and_commit_called(self):
+        user = _make_user()
+        session, _, _ = await self._run_delete(user, [], [])
+        session.delete.assert_awaited_with(user)
+        session.commit.assert_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_vod_namer_series_name_max.py
+++ b/backend/tests/test_vod_namer_series_name_max.py
@@ -1,0 +1,88 @@
+"""
+Regression test: series_episode_output_path must produce a filename whose
+basename does not exceed Linux NAME_MAX (255 bytes).
+
+When both show name and episode title are long UTF-8 strings,
+series_episode_output_path combines two independently-capped 200-byte
+components without truncating the result.  The combined filename can reach
+400+ bytes, causing OSError: [Errno 36] File name too long when the download
+manager tries to open the output file, marking the download FAILED with a
+raw OS error that is not actionable by a non-technical operator.
+
+File:     backend/services/vod_namer.py, series_episode_output_path
+Severity: MEDIUM -- affects providers serving CJK-titled series or any series
+          with show names > ~85 bytes combined with episode titles > ~145 bytes.
+"""
+import os
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.vod_namer import series_episode_output_path
+
+NAME_MAX = 255
+
+
+class SeriesEpisodeNameMaxTests(unittest.TestCase):
+
+    def _filename_bytes(self, path: str) -> int:
+        return len(os.path.basename(path).encode("utf-8"))
+
+    def test_long_cjk_show_and_title_within_name_max(self):
+        """
+        Korean show name (195 bytes) + Korean episode title (189 bytes) must
+        produce a filename that fits in 255 bytes.  Before the fix the combined
+        S01E01 prefix + show + separator + title + extension reached 400 bytes,
+        causing [Errno 36] File name too long at download time.
+        """
+        long_show = "한국드라마" * 13    # 65 Korean chars = 195 UTF-8 bytes
+        long_title = "에피소드타이틀" * 9  # 63 Korean chars = 189 UTF-8 bytes
+        path = series_episode_output_path("/downloads", long_show, 1, 1, long_title, "mp4")
+        byte_len = self._filename_bytes(path)
+        self.assertLessEqual(
+            byte_len,
+            NAME_MAX,
+            f"Filename is {byte_len} bytes, exceeds NAME_MAX ({NAME_MAX}). "
+            f"Attempting to write to this path raises "
+            f"OSError: [Errno 36] File name too long.",
+        )
+
+    def test_long_ascii_show_and_title_within_name_max(self):
+        """
+        ASCII show name (100 bytes) + ASCII episode title (200 bytes) must also
+        fit within NAME_MAX.  Before the fix the combined filename was 316 bytes.
+        """
+        long_show = "S" * 100
+        long_title = "T" * 200
+        path = series_episode_output_path("/downloads", long_show, 1, 1, long_title, "mp4")
+        byte_len = self._filename_bytes(path)
+        self.assertLessEqual(
+            byte_len,
+            NAME_MAX,
+            f"Filename is {byte_len} bytes, exceeds NAME_MAX ({NAME_MAX}). "
+            f"Attempting to write to this path raises "
+            f"OSError: [Errno 36] File name too long.",
+        )
+
+    def test_long_show_no_title_within_name_max(self):
+        """
+        A long show name without an episode title should remain within NAME_MAX.
+        (S01E01 + 200-byte show + .mp4 = 216 bytes; already passing before the fix.)
+        Included to confirm short-title case is not regressed by any truncation fix.
+        """
+        long_show = "한국드라마" * 13
+        path = series_episode_output_path("/downloads", long_show, 1, 1, None, "mp4")
+        byte_len = self._filename_bytes(path)
+        self.assertLessEqual(
+            byte_len,
+            NAME_MAX,
+            f"Filename (no episode title) is {byte_len} bytes, exceeds NAME_MAX ({NAME_MAX}).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `DELETE /admin/users/{id}` removes the `User` row but does not cancel `ScheduledRecording` or `Download` rows for that user, and does not disconnect open WebSocket connections.
- Orphaned schedules fire on the next 30-second scheduler poll, creating downloads attributed to a deleted user and consuming disk space and IPTV stream slots.
- In-progress downloads keep running after the user is gone.
- `disconnect_user_websockets` is called when a user is *disabled* (`update_user`) but not when they are *deleted*.
- `delete_account` was fixed for the same pattern (PR history shows that fix), but `delete_user` was not.

Nine regression tests fail against the current `delete_user` in `backend/api/admin_users.py`. Two structural tests (no active work, session.delete called) already pass.

## Failing tests (all 9 expected to pass after fix)

```
test_active_schedule_marked_cancelled_on_user_delete  FAIL
test_all_non_terminal_statuses_are_cancelled          FAIL (x5 statuses)
test_active_download_triggers_cancel                  FAIL
test_multiple_active_downloads_all_cancelled          FAIL
test_websockets_disconnected_on_user_delete           FAIL
```

## Fix guidance (for maintainer, not implemented here)

Mirror the `delete_account` pattern in `admin_users.delete_user`:
1. Query `ScheduledRecording` by `requested_by_user_id`, set `status = CANCELLED`, `status_message = "User deleted"` for non-terminal rows.
2. Query `Download` by `requested_by_user_id`, call `download_manager.cancel_download(dl_id)` for active rows.
3. Call `download_manager.disconnect_user_websockets(user_id)` before committing.

## Test plan

```
cd backend && venv/bin/python -m unittest tests.test_delete_user_schedule_cleanup -v
```

Before fix: 9 failures. After fix: all 9 pass.