### PR TITLE
[Design] show Retry button inline on failed and cancelled download cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -365,6 +365,18 @@ function DownloadCard({
             <Text size="xs">{download.error_message}</Text>
           </Alert>
         )}
+        {canRetry && (
+          <Group gap="xs">
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<IconRefresh size={14} />}
+              onClick={() => onRetry(download)}
+            >
+              Retry
+            </Button>
+          </Group>
+        )}
       </Stack>
     </Card>
   )


### PR DESCRIPTION
## What a user sees

When a download fails or is cancelled, the Downloads History tab now shows a **Retry** button directly on the card. Before this change, the only way to retry was through the three-dot menu, which non-technical users are unlikely to discover.

## What changed

One change in `Downloads.jsx`: added a `<Button>Retry</Button>` group below the error message on cards where `canRetry` is true (status is `failed` or `cancelled`). The button calls the same `onRetry` handler already wired up for the three-dot menu item. No logic change.

Consistent with the pattern COMPLETED cards use for their "Download" and "Play" buttons.

## Before

FAILED and CANCELLED cards showed only a three-dot menu. The Retry action was hidden inside it with no visual hint it existed. A non-technical user seeing a red FAILED card with an error message had no obvious next step.

## After

FAILED and CANCELLED cards show a Retry button directly below the error message. The next step is immediately clear.

Screenshots posted in #design.

## Testing

Ran locally. Verified Retry button appears on FAILED and CANCELLED cards. Verified COMPLETED cards still show Download and Play as before. No backend changes, no auth paths.