### PR TITLE
fix: commit expiry FAILED mutations before early return in scheduler

### DIFF
--- a/backend/services/scheduled_manager.py
+++ b/backend/services/scheduled_manager.py
@@ -80,6 +80,7 @@ class ScheduledManager:
                     ready.append(schedule)
 
             if not ready:
+                await session.commit()
                 return
 
             free_gb = self._get_free_space_gb(download_folder)

--- a/backend/tests/test_scheduler_stale_dispatch.py
+++ b/backend/tests/test_scheduler_stale_dispatch.py
@@ -214,6 +214,66 @@ class StaleScheduleDispatchTests(unittest.IsolatedAsyncioTestCase):
             "A schedule for a show that ended 5 minutes ago must be dispatched.",
         )
 
+    async def test_expired_schedule_failed_status_committed(self):
+        """REGRESSION: Expired schedule FAILED status must be committed to DB.
+
+        When only expired schedules exist, _queue_ready_recordings hits
+        'if not ready: return' (line 82) before calling session.commit().
+        SQLAlchemy discards the uncommitted FAILED status on session close,
+        leaving the schedule permanently SCHEDULED in the DB.
+
+        This test fails before the fix and passes after.
+        """
+        schedule = _make_stale_schedule(hours_ago=48)
+
+        # Build the session mock directly so we can inspect commit() calls.
+        scalars_result = MagicMock()
+        scalars_result.all.return_value = [schedule]
+        schedules_exec_result = MagicMock()
+        schedules_exec_result.scalars.return_value = scalars_result
+
+        settings_obj = AppSettings()
+        settings_obj.download_folder = "/tmp/downloads"
+        settings_obj.min_free_space_gb = 1
+        settings_exec_result = MagicMock()
+        settings_exec_result.scalar_one_or_none.return_value = settings_obj
+
+        call_count = [0]
+
+        async def execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return schedules_exec_result
+            return settings_exec_result
+
+        session = AsyncMock()
+        session.execute = execute
+        session.commit = AsyncMock()
+
+        @asynccontextmanager
+        async def session_ctx():
+            yield session
+
+        manager = ScheduledManager()
+
+        with (
+            patch("services.scheduled_manager.async_session_maker", session_ctx),
+            patch.object(
+                manager,
+                "_get_catchup_window_days",
+                new=AsyncMock(return_value=1),
+            ),
+        ):
+            await manager._queue_ready_recordings()
+
+        self.assertEqual(
+            schedule.status,
+            ScheduledStatus.FAILED.value,
+            "Expired schedule must be marked FAILED.",
+        )
+        # FAILS before fix: commit is skipped by "if not ready: return"
+        session.commit.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fixes a bug where expired scheduled recordings stayed permanently \"Scheduled\" in the UI and DB.
- Adds the failing regression test from Gremlin's PR #251 (cherry-picked), then applies the one-line fix.

## Bug

`_queue_ready_recordings` in `backend/services/scheduled_manager.py` marks expired schedules as FAILED in memory, then hits `if not ready: return` (line 82) before `session.commit()` on line 135. SQLAlchemy discards all uncommitted changes when the session closes, so the FAILED status was never written to the database.

Result: a schedule whose catchup window had expired would show as \"Scheduled\" forever. On every 30-second scheduler tick it would be re-fetched, marked FAILED in memory, and discarded again.

## What changed

Added `await session.commit()` before the early return at line 82. This ensures any expiry-FAILED mutations are persisted to the DB before exiting.

**Before (one scheduler poll, expired recording):**
```
schedule.status set to FAILED in memory
if not ready: return           <-- session closes without commit
DB still shows: SCHEDULED      <-- happens every 30 seconds forever
```

**After:**
```
schedule.status set to FAILED in memory
if not ready:
    await session.commit()     <-- mutations flushed to DB
    return
DB now shows: FAILED           <-- correct, never polled again
```

## How it was tested

Regression test `test_expired_schedule_failed_status_committed` in `backend/tests/test_scheduler_stale_dispatch.py` (cherry-picked from Gremlin PR #251):

**Before fix:**
```
FAIL: test_expired_schedule_failed_status_committed
AssertionError: Expected 'commit' to have been called once. Called 0 times.
```

**After fix:**
```
Ran 6 tests in 0.017s
OK
```

Closes #251 (regression test PR, superseded by this combined fix+test PR).