### PR TITLE
[Design] linkify provider error on Downloads and Scheduled history cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -48,7 +48,7 @@ import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '.
 
 dayjs.extend(duration)
 
-const ACCOUNT_SETTINGS_SUFFIX = 'in your account settings.'
+const ACCOUNT_SETTINGS_SUFFIX = 'your account settings.'
 
 function renderErrorMessage(msg) {
   if (!msg) return null

--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -18,7 +18,7 @@ import {
   Select,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconDotsVertical,
@@ -47,6 +47,23 @@ import ProgressBar from '../components/ProgressBar'
 import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
 
 dayjs.extend(duration)
+
+const ACCOUNT_SETTINGS_SUFFIX = 'in your account settings.'
+
+function renderErrorMessage(msg) {
+  if (!msg) return null
+  const idx = msg.indexOf(ACCOUNT_SETTINGS_SUFFIX)
+  if (idx === -1) return msg
+  return (
+    <>
+      {msg.slice(0, idx)}
+      <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+        your account settings
+      </Link>
+      .
+    </>
+  )
+}
 
 function formatBytes(bytes) {
   if (!bytes) return '0 B'
@@ -356,13 +373,13 @@ function DownloadCard({
         )}
         {download.status === 'completed' && download.error_message && (
           <Alert color="yellow" variant="light" p="xs">
-            <Text size="xs">{download.error_message}</Text>
+            <Text size="xs">{renderErrorMessage(download.error_message)}</Text>
           </Alert>
         )}
 
         {download.status === 'failed' && download.error_message && (
           <Alert color="red" variant="light" p="xs">
-            <Text size="xs">{download.error_message}</Text>
+            <Text size="xs">{renderErrorMessage(download.error_message)}</Text>
           </Alert>
         )}
         {canRetry && (

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -38,7 +38,7 @@ import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '.
 
 dayjs.extend(duration)
 
-const ACCOUNT_SETTINGS_SUFFIX = 'in your account settings.'
+const ACCOUNT_SETTINGS_SUFFIX = 'your account settings.'
 
 function renderErrorMessage(msg) {
   if (!msg) return null

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -14,7 +14,7 @@ import {
   Button,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconDotsVertical,
@@ -37,6 +37,23 @@ import { accountsApi, schedulesApi } from '../api'
 import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
 
 dayjs.extend(duration)
+
+const ACCOUNT_SETTINGS_SUFFIX = 'in your account settings.'
+
+function renderErrorMessage(msg) {
+  if (!msg) return null
+  const idx = msg.indexOf(ACCOUNT_SETTINGS_SUFFIX)
+  if (idx === -1) return msg
+  return (
+    <>
+      {msg.slice(0, idx)}
+      <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+        your account settings
+      </Link>
+      .
+    </>
+  )
+}
 
 function formatDuration(minutes) {
   const d = dayjs.duration(minutes, 'minutes')
@@ -159,7 +176,7 @@ function ScheduleCard({
 
         {!schedule.status_message && schedule.download_status === 'failed' && schedule.download_error_message && (
           <Alert color="red" variant="light" p="xs">
-            <Text size="xs">{schedule.download_error_message}</Text>
+            <Text size="xs">{renderErrorMessage(schedule.download_error_message)}</Text>
           </Alert>
         )}
 


### PR DESCRIPTION
## What a user notices

On the Downloads and Scheduled history pages, when a recording fails because the provider is unreachable, the error box reads:

> Cannot reach the provider. Check the server URL in your account settings.

Before this change, that last phrase was plain text. A non-technical user had to know to go to Settings themselves. The Browse page already renders this same message with a clickable link, but the history cards did not.

## What changed

"your account settings" is now an orange clickable link that takes the user directly to Settings → Accounts. Two files changed: `Downloads.jsx` and `Scheduled.jsx`. No logic changes.

## Test plan

- Opened Downloads History: EastEnders FAILED card shows orange "your account settings" link, clicking navigates to Settings → Accounts.
- Opened Scheduled History: EastEnders FAILED card shows the same link.
- Other error messages (e.g. "Connection timed out after 30 seconds", "Provider returned error page instead of video stream") are unaffected.
- Desktop and mobile both verified via screenshots below.