### PR TITLE
docs: README reflects Retry button on cancelled downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Then open **http://localhost:4177** in your browser.
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - When any scheduled recording is paused for low disk space, or when free space drops below the configured minimum, an orange banner appears at the top of every page, not just Downloads, so you are alerted no matter where you are in the app
 - The **History** tab shows past downloads. Use the status filter dropdown at the top to show only Completed, Failed, or Cancelled entries
-- Failed downloads can be retried from the same page
-- Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries stay so you can retry them)
+- Failed and cancelled downloads show a **Retry** button directly on the card
+- Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries are not cleared so you can still retry them)
 
 | Desktop | Mobile |
 |---------|--------|


### PR DESCRIPTION
## What a user would notice

The README said "Failed downloads can be retried from the same page." After PR #249 shipped, the Retry button also appears directly on cancelled download cards. The old wording missed cancelled downloads entirely, and separately noted they could be retried in a different bullet -- which was redundant and slightly confusing.

## What changed

Two lines in the Monitor Downloads section of the README were updated:

- Before: "Failed downloads can be retried from the same page"
- After: "Failed and cancelled downloads show a **Retry** button directly on the card"

The parenthetical note about cancelled entries being kept for retry was rephrased to match ("are not cleared so you can still retry them") but remains in place.

## How it was tested

Diff reviewed against PR #249 (merged) to confirm the new wording matches what shipped.

No code was changed.