### PR TITLE
fix: show ComSkip settings panel when onboarding sets remux_comskip profile

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -228,12 +228,13 @@ async def update_settings(
             value = int(value)
         setattr(settings, field, value)
 
-    # Enforce ComSkip constraints on the final stored state, not just the
-    # current request, so a subsequent request cannot disable transcode or
-    # enable remux-only while ComSkip is already on.
+    # Enforce ComSkip constraint on the final stored state: comskip requires
+    # FFmpeg, so transcode_enabled must stay True.  remux_only is NOT forced
+    # off: the pipeline supports stream-copy commercial removal (segment
+    # extraction + concat with -c copy), so remux_only=True + comskip_enabled=True
+    # is the valid "fast remux + skip commercials" profile written by onboarding.
     if settings.comskip_enabled:
         settings.transcode_enabled = True
-        settings.remux_only = False
 
     await session.commit()
     await session.refresh(settings)

--- a/backend/tests/test_comskip_constraint.py
+++ b/backend/tests/test_comskip_constraint.py
@@ -1,8 +1,6 @@
 """
 Regression tests for ComSkip settings constraints.
 
-Two related bugs:
-
 Bug 1 (HIGH): update_settings only enforced "comskip_enabled=True forces
 transcode_enabled=True" when the current request contained comskip_enabled.
 A second request setting transcode_enabled=False bypassed the constraint,
@@ -10,13 +8,11 @@ leaving comskip_enabled=True + transcode_enabled=False in the DB. ComSkip
 ran and produced an EDL that was silently ignored; commercials stayed in
 the output with no user-visible error.
 
-Bug 2 (MEDIUM): No constraint enforced "comskip_enabled=True forces
-remux_only=False". A user could store comskip_enabled=True + remux_only=True.
-FFmpeg ran in stream-copy mode and never applied EDL cut points. All
-commercial segments remained in the output file while the UI showed COMPLETED.
-
-Fix: constraints now apply to the final stored state after all field updates,
-not just to the fields present in the current request body.
+Fix: transcode_enabled=True is enforced on the final stored state after all
+field updates.  remux_only is intentionally NOT constrained: the pipeline
+supports stream-copy commercial removal (segment extraction + concat -c copy),
+so remux_only=True + comskip_enabled=True is the valid fast "remux + skip
+commercials" profile written by the Docker onboarding flow.
 """
 import sys
 import unittest
@@ -73,19 +69,20 @@ class ComSkipConstraintTests(unittest.IsolatedAsyncioTestCase):
             "transcode_enabled must stay True when comskip_enabled is already True")
         self.assertTrue(result["comskip_enabled"])
 
-    async def test_second_request_cannot_enable_remux_while_comskip_on(self):
-        """PUT remux_only=True must be rejected when comskip_enabled is already True.
+    async def test_remux_allowed_with_comskip_on(self):
+        """PUT remux_only=True is accepted when comskip_enabled is already True.
 
-        Before fix: settings stored comskip_enabled=True, remux_only=True. ComSkip
-        ran but FFmpeg stream-copied; commercials remained in output.
-        After fix: remux_only stays False regardless of what the request sets.
+        The pipeline supports stream-copy commercial removal: segment extraction
+        runs with -c copy, then concat with -c copy.  remux_only=True +
+        comskip_enabled=True is the fast "remux + skip commercials" profile that
+        Docker onboarding writes and that users can select explicitly.
         """
         result = await self._apply(
             initial={"comskip_enabled": True, "remux_only": False},
             update={"remux_only": True},
         )
-        self.assertFalse(result["remux_only"],
-            "remux_only must stay False when comskip_enabled is already True")
+        self.assertTrue(result["remux_only"],
+            "remux_only=True must be accepted when comskip_enabled is already True")
         self.assertTrue(result["comskip_enabled"])
 
     async def test_enabling_comskip_forces_transcode_on(self):
@@ -98,18 +95,18 @@ class ComSkipConstraintTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["transcode_enabled"],
             "enabling comskip must force transcode_enabled=True")
 
-    async def test_enabling_comskip_forces_remux_off(self):
-        """Single request enabling comskip must auto-disable remux_only."""
+    async def test_enabling_comskip_preserves_remux_state(self):
+        """Enabling comskip does not change remux_only; both True and False are valid."""
         result = await self._apply(
             initial={"comskip_enabled": False, "remux_only": True},
             update={"comskip_enabled": True},
         )
         self.assertTrue(result["comskip_enabled"])
-        self.assertFalse(result["remux_only"],
-            "enabling comskip must force remux_only=False")
+        self.assertTrue(result["remux_only"],
+            "enabling comskip must not clear remux_only; fast remux+comskip is a supported profile")
 
-    async def test_enabling_comskip_with_conflicting_values_in_same_request(self):
-        """comskip_enabled=True + transcode_enabled=False in the same request: comskip wins."""
+    async def test_enabling_comskip_with_conflicting_transcode_in_same_request(self):
+        """comskip_enabled=True + transcode_enabled=False in the same request: comskip wins for transcode."""
         result = await self._apply(
             initial={"comskip_enabled": False, "transcode_enabled": True},
             update={"comskip_enabled": True, "transcode_enabled": False, "remux_only": True},
@@ -117,8 +114,8 @@ class ComSkipConstraintTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["comskip_enabled"])
         self.assertTrue(result["transcode_enabled"],
             "comskip constraint must win over explicit transcode_enabled=False in same request")
-        self.assertFalse(result["remux_only"],
-            "comskip constraint must win over explicit remux_only=True in same request")
+        self.assertTrue(result["remux_only"],
+            "remux_only=True is valid alongside comskip_enabled=True; it is not overridden")
 
     async def test_transcode_can_be_disabled_when_comskip_is_off(self):
         """transcode_enabled=False is accepted normally when comskip is off."""
@@ -137,6 +134,24 @@ class ComSkipConstraintTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(result["comskip_enabled"])
         self.assertTrue(result["remux_only"])
+
+    async def test_remux_comskip_profile_survives_settings_save(self):
+        """remux_only=True + comskip_enabled=True is preserved on any settings save.
+
+        Regression: before this fix, any PUT /settings call while this profile
+        was active forced remux_only=False, silently downgrading the user from
+        fast stream-copy commercial removal to full re-encode.  Docker onboarding
+        writes this exact profile (remux_comskip) as the recommended path.
+        """
+        result = await self._apply(
+            initial={"comskip_enabled": True, "remux_only": True, "transcode_enabled": True},
+            update={"comskip_path": "/usr/bin/comskip"},
+        )
+        self.assertTrue(result["comskip_enabled"])
+        self.assertTrue(result["remux_only"],
+            "remux_only must survive a settings save; silently clobbering it "
+            "would downgrade Docker onboarding users from fast remux to full re-encode")
+        self.assertTrue(result["transcode_enabled"])
 
 
 if __name__ == "__main__":

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -553,13 +553,18 @@ export default function Settings() {
       description: 'Re-encode to MP4 using ffmpeg. Best compatibility with most devices and media players.',
     },
     {
+      value: 'remux_mkv_comskip',
+      label: 'MKV container + skip commercials (fast)',
+      description: 'Wrap the stream in MKV without re-encoding and remove commercials with ComSkip.',
+    },
+    {
       value: 'transcode_comskip',
-      label: 'MKV + skip commercials',
+      label: 'MKV + skip commercials (re-encode)',
       description: 'Re-encode to MKV and remove commercials with ComSkip.',
     },
     {
       value: 'transcode_mp4_comskip',
-      label: 'MP4 + skip commercials',
+      label: 'MP4 + skip commercials (re-encode)',
       description: 'Re-encode to MP4 and remove commercials with ComSkip.',
     },
   ]
@@ -567,6 +572,7 @@ export default function Settings() {
   function getRecordingFormat(data) {
     if (!data) return 'keep_original'
     if (!data.transcode_enabled) return 'keep_original'
+    if (data.remux_only && data.comskip_enabled) return 'remux_mkv_comskip'
     if (data.remux_only) return data.transcode_format === 'mp4' ? 'remux_mp4' : 'remux_mkv'
     const isMp4 = data.transcode_format === 'mp4'
     if (data.comskip_enabled) return isMp4 ? 'transcode_mp4_comskip' : 'transcode_comskip'
@@ -578,6 +584,7 @@ export default function Settings() {
       keep_original: { transcode_enabled: false, remux_only: false, comskip_enabled: false },
       remux_mkv: { transcode_enabled: true, remux_only: true, comskip_enabled: false, transcode_format: 'mkv' },
       remux_mp4: { transcode_enabled: true, remux_only: true, comskip_enabled: false, transcode_format: 'mp4' },
+      remux_mkv_comskip: { transcode_enabled: true, remux_only: true, comskip_enabled: true, transcode_format: 'mkv' },
       transcode_mkv: { transcode_enabled: true, remux_only: false, comskip_enabled: false, transcode_format: 'mkv' },
       transcode_mp4: { transcode_enabled: true, remux_only: false, comskip_enabled: false, transcode_format: 'mp4' },
       transcode_comskip: { transcode_enabled: true, remux_only: false, comskip_enabled: true, transcode_format: 'mkv' },
@@ -746,6 +753,7 @@ export default function Settings() {
     const currentFormat = getRecordingFormat(formData)
     const isTranscoding = currentFormat !== 'keep_original'
     const isFullTranscode = ['transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(currentFormat)
+    const isComskipFormat = ['remux_mkv_comskip', 'transcode_comskip', 'transcode_mp4_comskip'].includes(currentFormat)
     const ffmpegReady = toolsStatus?.ffmpeg?.available
     const comskipReady = toolsStatus?.comskip?.available
 
@@ -826,7 +834,7 @@ export default function Settings() {
               value: f.value,
               label: f.label,
               disabled:
-                ['remux_mkv', 'remux_mp4', 'transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && !ffmpegReady
+                ['remux_mkv', 'remux_mp4', 'remux_mkv_comskip', 'transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && !ffmpegReady
                   ? true
                   : false,
             }))}
@@ -842,7 +850,7 @@ export default function Settings() {
             </Alert>
           )}
 
-          {!comskipReady && (currentFormat === 'transcode_comskip' || currentFormat === 'transcode_mp4_comskip') && (
+          {!comskipReady && isComskipFormat && (
             <Alert color="yellow" variant="light">
               <Text size="sm">
                 Comskip binary not found in the default PATH. Enter the path to your comskip binary below, or see{' '}
@@ -887,7 +895,7 @@ export default function Settings() {
             </SettingRow>
           )}
 
-          {(currentFormat === 'transcode_comskip' || currentFormat === 'transcode_mp4_comskip') && (
+          {isComskipFormat && (
             <Stack gap="xs">
               <Text size="xs" c="dimmed">
                 Commercials are detected and removed, then the result is saved as {currentFormat === 'transcode_mp4_comskip' ? 'MP4' : 'MKV'}.


### PR DESCRIPTION
## What a user notices

On Docker installs where ComSkip is detected, the onboarding wizard recommends and applies the **MKV container + skip commercials** profile. After completing onboarding, opening **Settings > Post-Processing** showed **MKV container (fast, no re-encode)** in the dropdown and no ComSkip settings panel below it. There was no way to see or change the ComSkip binary path or .ini path. Saving any setting (such as updating the ComSkip binary path) silently downgraded the profile from fast stream-copy + commercial removal to slow full re-encode + commercial removal.

## What changed

**Frontend (Settings.jsx):** `getRecordingFormat` checked `remux_only` before `comskip_enabled`, so the database state `remux_only=True, comskip_enabled=True` mapped silently to the plain `remux_mkv` format. Three changes:
1. `getRecordingFormat` now checks `remux_only && comskip_enabled` first and returns `'remux_mkv_comskip'`.
2. A new **MKV container + skip commercials (fast)** option is added to the dropdown.
3. The ComSkip binary path and .ini path panel renders for all three ComSkip formats.

**Backend (api/settings.py):** `update_settings` forced `remux_only=False` whenever `comskip_enabled=True`. This clobbered the fast profile on every settings save. The pipeline has supported stream-copy commercial removal since the `remove_commercials` rewrite: it extracts segments with `-c copy`, then concatenates with `-c copy` when `remux_only=True`. The constraint is removed. The `transcode_enabled=True` constraint stays (FFmpeg is still required).

**Tests (test_comskip_constraint.py):** Updated tests that asserted the old `remux_only=False` enforcement to now assert that `remux_only=True + comskip_enabled=True` is a valid, preserved state. Added a regression test: the remux_comskip profile survives any settings save without being silently downgraded.

## Before / after

**Before:** Docker user completes onboarding with ComSkip present. Settings shows "MKV container (fast, no re-encode)". No ComSkip panel. Saving any setting with this profile active silently converts it to full re-encode.

**After:** Settings shows "MKV container + skip commercials (fast)". ComSkip binary path and .ini path fields appear. Saving settings preserves the profile.

## How it was tested

Traced through `getRecordingFormat` with the onboarding state (`remux_only=True, comskip_enabled=True`): old code returned `'remux_mkv'`; new code returns `'remux_mkv_comskip'`.

Backend: all 608 tests pass, including the updated `test_comskip_constraint.py` with 8 tests.

Verified `remove_commercials` in `post_processor.py`: with `remux_only=True`, it extracts keep segments with `-c copy` then concatenates with `-c copy -avoid_negative_ts make_zero`. EDL cut points ARE applied. The old constraint was stale.