### PR TITLE
design: show Edit Account button inline on unreachable provider cards

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -252,6 +252,18 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
             {account.last_connection_error}
           </Text>
         )}
+        {account.last_connection_ok === false && (
+          <Group gap="xs" mt={4}>
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<IconEdit size={14} />}
+              onClick={() => onEdit(account)}
+            >
+              Edit Account
+            </Button>
+          </Group>
+        )}
       </Stack>
     </Card>
   )


### PR DESCRIPTION
## What changed

When a provider account shows as Unreachable, an **Edit Account** button now appears directly below the error message. Before this change, the only way to edit the server URL or credentials was through the three-dot context menu, which is not obvious to non-technical users.

This follows the same pattern as PR #249, which added an inline Retry button to failed download cards.

## Before

Both provider cards show the red dot, "Unreachable", and the error text. No visible next step.

## After

An **Edit Account** button appears immediately below the error. One tap/click opens the edit form.

Works correctly at desktop and mobile widths. The button only appears when `last_connection_ok === false`, so connected accounts are unaffected.

## Files changed

- `frontend/src/components/settings/AccountsSection.jsx`: 12 lines added to `AccountCard`

## How it was tested

Started the app locally, confirmed button renders on both desktop (1280x800) and mobile (390x844) with two unreachable accounts. Clicking the button opens the Edit Account modal. Connected accounts show no button.