### PR TITLE
docs: changelog for PRs #172, #255, #256, and #259; add EPG interval env var to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-08
 
+### Improved: Settings now shows when your program guide last synced, with a Refresh Now button
+
+**What you would notice:** There was no way to tell from Settings whether your program guide data was fresh or stale. You had to go to Settings > Accounts and use the Force EPG Refresh button there. A new Guide section is now available in Settings, between File Naming and Appearance. It shows the date and time your guide last synced (for example, "Last synced: Today at 10:30 PM") and a Refresh Now button you can click without leaving Settings. If the guide has never synced, it says "Guide not yet synced." The button shows a spinner while running and cannot be double-clicked.
+
+**What changed:** A new Guide section was added to the Settings sidebar. It uses the same data already available to the Accounts page, so no backend logic was changed. The change is purely in the settings interface.
+
+---
+
+### Fixed: ComSkip settings panel now appears correctly after the setup wizard runs
+
+**What you would notice:** If you run Mustarrd on Docker and ComSkip is installed, the setup wizard recommends and applies the "MKV container + skip commercials" recording profile. After finishing the wizard and opening Settings > Post-Processing, the dropdown showed "MKV container (fast, no re-encode)" with no ComSkip settings below it. There was no way to see or change the ComSkip binary path or configuration file path. Worse, saving any setting in that state silently switched your recording profile from the fast stream-copy method to a slower full re-encode, which uses more CPU and takes longer. After this fix, the correct profile label appears in the dropdown, the ComSkip binary and configuration file fields are visible, and saving settings preserves the fast stream-copy profile exactly as the wizard set it.
+
+**What changed:** Two bugs were fixed. In the frontend, the recording format detection logic checked the wrong condition first, so a valid "fast stream-copy + commercial removal" state was silently mapped to the plain MKV option. In the backend, settings save incorrectly forced the fast stream-copy flag off whenever ComSkip was enabled, overwriting the profile on every save. Both are now corrected. A regression test was added to verify that the fast ComSkip profile survives a settings save without being changed.
+
+---
+
 ### Improved: Edit Account button now appears directly on unreachable provider cards
 
 **What you would notice:** When an IPTV account shows as unreachable on the Accounts settings page, the next step is almost always to fix the server URL or credentials. Previously the only way to do that was to open the three-dot menu on the card and find the Edit option, which is easy to miss. An "Edit Account" button now appears directly below the error message on any unreachable provider card, so you can correct the details right away without hunting for a menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-08
 
+### Improved: Edit Account button now appears directly on unreachable provider cards
+
+**What you would notice:** When an IPTV account shows as unreachable on the Accounts settings page, the next step is almost always to fix the server URL or credentials. Previously the only way to do that was to open the three-dot menu on the card and find the Edit option, which is easy to miss. An "Edit Account" button now appears directly below the error message on any unreachable provider card, so you can correct the details right away without hunting for a menu.
+
+**What changed:** A direct Edit Account button was added to unreachable provider cards on the Accounts settings page. No account or connection logic was changed.
+
+---
+
 ### Improved: Provider error on failed recordings now links directly to Account Settings
 
 **What you would notice:** When a recording failed because Mustarrd could not reach your IPTV provider, the error message said "Cannot reach the provider. Check the server URL in your account settings." The phrase "your account settings" was plain text with no way to click it. You had to know where to go on your own. That phrase is now a clickable link that takes you directly to Settings > Accounts, where you can correct the server URL or credentials. The same error on the Browse page already had this link; now the Downloads and Scheduled history pages match it.
@@ -27,6 +35,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 **What you would notice:** When an admin deleted a user from the Users page, that user's scheduled recordings would continue to fire (creating new downloads attributed to the deleted account) and any downloads already in progress would keep running, consuming disk space and IPTV stream slots. After this fix, deleting a user immediately cancels all their pending schedules and stops any active downloads. Their browser session is also disconnected.
 
 **What changed:** The admin user-delete action now cancels scheduled recordings, stops active downloads, and closes open browser connections for the deleted user before removing the account. Previously this cleanup only ran when a user deleted their own account. The behavior now matches the existing self-delete path.
+
+---
+
+### Fixed: Disabling a Plex user now actually blocks them from logging in
+
+**What you would notice:** If you disabled a Plex-linked user on the Users page, that user could still complete a Plex sign-in and get full access to Mustarrd again. The disabled status was silently overwritten by the login and the account was re-enabled. After this fix, a disabled user who attempts to sign in with Plex gets a "Your account has been disabled" error and cannot access Mustarrd until an admin re-enables them.
+
+**What changed:** The Plex sign-in endpoint now checks whether the user account is disabled before granting a session. Previously it set every returning Plex user's status to "active" unconditionally, which undid any admin disable action. The credentials (username and password) login path already had this check; the Plex login path now matches it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Mustarrd reads the program title and automatically formats the filename for your
 | Movie | `The Matrix (1999).ts` |
 | Everything else | `ESPN - SportsCenter - 2026-01-28.ts` |
 
-Filename templates are customizable in Settings if you want a different format.
+Filename templates are customizable in Settings if you want a different format. The file extension (.ts, .mkv, .mp4) is set by your Recording Format in Settings, not by the filename template, so you should not add an extension to your template.
 
 ## Where Your Files Go
 
@@ -146,6 +146,7 @@ Most users never need to touch these. Set them in `docker-compose.yml` or a `bac
 | `CATCHUP_DEFAULT_DOWNLOAD_FOLDER` | In-progress download location | `/app/downloads` |
 | `CATCHUP_DEFAULT_COMPLETED_FOLDER` | Finished file location | `/app/completed` |
 | `CATCHUP_MAX_CONCURRENT_DOWNLOADS` | Max simultaneous downloads | `2` |
+| `CATCHUP_EPG_REFRESH_INTERVAL_HOURS` | How often Mustarrd automatically refreshes the program guide, in hours | `8` |
 | `CATCHUP_SESSION_SECRET` | Session signing key, auto-generated and persisted to `./config/session_secret` on first run. Only set this manually to rotate or share across instances | *(auto)* |
 | `CATCHUP_CORS_ORIGINS` | Comma-separated allowed frontend origins; only needed when the UI is accessed from a non-localhost address | `http://localhost:4178,...` |
 | `CATCHUP_SESSION_COOKIE_SECURE_MODE` | When to mark session cookies as HTTPS-only: `auto` (default, detects HTTPS including reverse-proxy setups), `always`, or `never` | `auto` |


### PR DESCRIPTION
## What a user notices

None. Documentation and changelog only.

## What changed

CHANGELOG entries added for four merged PRs:

- **PR #172** (Fixed: Disabling a Plex user now actually blocks them from logging in)
- **PR #255** (Fixed: ComSkip settings panel now appears correctly after the setup wizard runs)
- **PR #256** (Improved: Edit Account button now appears directly on unreachable provider cards)
- **PR #259** (Improved: Settings now shows when your program guide last synced, with a Refresh Now button)

README updated: added `CATCHUP_EPG_REFRESH_INTERVAL_HOURS` to the environment variable config table, and corrected the File Naming description to say the file extension depends on your Recording Format setting.

## How it was tested

Grep confirms no em dashes in any changed text. All entries follow the existing plain-English format for non-technical operators.