### PR TITLE
design: Guide sync status and refresh in Settings

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -44,9 +44,11 @@ import {
   IconTrash,
   IconKey,
   IconDeviceTv,
+  IconCalendar,
+  IconRefresh,
 } from '@tabler/icons-react'
 
-import { adminPlexApi, adminUsersApi, authApi, settingsApi } from '../api'
+import { adminPlexApi, adminUsersApi, authApi, epgApi, settingsApi } from '../api'
 import AccountsSection from '../components/settings/AccountsSection'
 import LogsSection from '../components/settings/LogsSection'
 
@@ -118,6 +120,7 @@ const ADMIN_SECTIONS = [
   { id: 'recording', label: 'Recording', icon: IconDownload },
   { id: 'processing', label: 'Post-Processing', icon: IconWand },
   { id: 'naming', label: 'File Naming', icon: IconFile },
+  { id: 'guide', label: 'Guide', icon: IconCalendar },
   { id: 'appearance', label: 'Appearance', icon: IconMoon },
   { id: 'security', label: 'Security', icon: IconLock },
   { id: 'logs', label: 'Logs', icon: IconListDetails },
@@ -228,6 +231,22 @@ export default function Settings() {
     enabled: isAdmin,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
+  })
+  const { data: epgStatus } = useQuery({
+    queryKey: ['epg', 'status'],
+    queryFn: epgApi.status,
+    enabled: isAdmin,
+    refetchInterval: 5000,
+  })
+  const epgRefreshMutation = useMutation({
+    mutationFn: () => epgApi.refresh(false),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['epg', 'status'] })
+      notifications.show({ title: 'Guide refresh started', message: 'The guide will update in the background.', color: 'green' })
+    },
+    onError: (err) => {
+      notifications.show({ title: 'Refresh failed', message: err?.message || 'Could not start guide refresh.', color: 'red' })
+    },
   })
   const { data: managedUsers = [] } = useQuery({
     queryKey: ['admin', 'users'],
@@ -989,6 +1008,50 @@ export default function Settings() {
     </Stack>
   )
 
+  const renderGuide = () => {
+    const lastSync = epgStatus?.last_completed_at
+    let lastSyncLabel = 'Guide not yet synced'
+    if (lastSync) {
+      const d = new Date(lastSync)
+      const now = new Date()
+      const isToday = d.toDateString() === now.toDateString()
+      const timeStr = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+      lastSyncLabel = isToday
+        ? `Today at ${timeStr}`
+        : `${d.toLocaleDateString([], { month: 'long', day: 'numeric' })} at ${timeStr}`
+    }
+    const isRunning = epgStatus?.running || epgRefreshMutation.isPending
+    return (
+      <Stack gap="lg">
+        <Stack gap={2}>
+          <Text fw={600} size="lg">Guide</Text>
+          <Text size="sm" c="dimmed">Program guide sync status and manual refresh</Text>
+        </Stack>
+        <SettingRow
+          label="Last synced"
+          description="When Mustarrd last updated the program guide from your provider"
+        >
+          <Text size="sm" c={lastSync ? undefined : 'dimmed'}>{lastSyncLabel}</Text>
+        </SettingRow>
+        <SettingRow
+          label="Refresh guide now"
+          description="Fetch the latest program guide data from your provider in the background"
+        >
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={<IconRefresh size={14} />}
+            loading={isRunning}
+            disabled={isRunning}
+            onClick={() => epgRefreshMutation.mutate()}
+          >
+            {isRunning ? 'Refreshing...' : 'Refresh Now'}
+          </Button>
+        </SettingRow>
+      </Stack>
+    )
+  }
+
   const renderAppearance = () => (
     <Stack gap="lg">
       <Stack gap={2}>
@@ -1265,6 +1328,7 @@ export default function Settings() {
     recording: renderRecording,
     processing: renderProcessing,
     naming: renderNaming,
+    guide: renderGuide,
     appearance: renderAppearance,
     security: renderSecurity,
     users: renderUsers,


### PR DESCRIPTION
## What changed

Added a **Guide** section to Settings (between File Naming and Appearance). It shows when the program guide was last synced and lets the user trigger a refresh without navigating away.

**Before:** No way to see guide sync status from Settings. Users had no way to know if their guide data was stale without going to Accounts and using "Force EPG Refresh."

**After:** Settings > Guide shows "Last synced: Today at 10:30 PM" and a "Refresh Now" button. The button shows a spinner while running and disables to prevent double-clicks. If the guide has never synced, shows "Guide not yet synced."

## How it was tested

- Started the app locally, navigated to Settings > Guide. "Last synced" shows the correct time.
- Guide section appears in the sidebar between File Naming and Appearance at desktop width.
- Mobile layout renders cleanly with the dropdown section selector.
- Build passes (vite build --mode development).

## Notes

- Frontend-only. Uses existing GET /api/epg/status and POST /api/epg/refresh.
- Reuses the ['epg', 'status'] query key shared with AccountsSection.
- Not included in configSections so the unsaved-changes guard does not apply.