### PR TITLE
fix: parse ISO 8601 XMLTV timestamps (YYYY-MM-DD format)

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -601,6 +601,38 @@ class EPGIngestManager:
         if not value:
             return None
         value = value.strip()
+
+        # ISO format detection: date part contains dashes (YYYY-MM-DD) or T separator.
+        # Some providers emit "2024-01-15 20:00:00 +0100" or "2024-01-15T20:00:00+01:00"
+        # instead of the compact XMLTV-spec format "20240115200000 +0100".
+        first_chunk = value.split(" ", 1)[0] if " " in value else value
+        if "-" in first_chunk[:10] or "T" in first_chunk:
+            try:
+                parts = value.split()
+                if len(parts) == 3:
+                    # "2024-01-15 20:00:00 +0100" -> "2024-01-15T20:00:00+0100"
+                    iso_str = parts[0] + "T" + parts[1] + parts[2]
+                elif len(parts) == 2 and parts[1][:1] in "+-":
+                    # "2024-01-15T20:00:00 +0100" (space before offset)
+                    iso_str = parts[0] + parts[1]
+                elif len(parts) == 2:
+                    # "2024-01-15 20:00:00" (no tz)
+                    iso_str = parts[0] + "T" + parts[1]
+                else:
+                    iso_str = value
+                if iso_str.endswith("Z"):
+                    iso_str = iso_str[:-1] + "+00:00"
+                # ±HHMM -> ±HH:MM (fromisoformat needs colon in offset on Python < 3.11)
+                if len(iso_str) >= 5 and iso_str[-5] in "+-" and iso_str[-4:].isdigit():
+                    iso_str = iso_str[:-2] + ":" + iso_str[-2:]
+                dt = datetime.fromisoformat(iso_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt
+            except (ValueError, TypeError):
+                return None
+
+        # Compact XMLTV format: YYYYMMDDHHmmss [±HHMM]
         # Split on first space to separate date digits from optional timezone.
         # Providers may omit seconds (12-digit YYYYMMDDHHmm) per the XMLTV spec.
         if " " in value:

--- a/backend/tests/test_epg_xmltv_iso_timestamps.py
+++ b/backend/tests/test_epg_xmltv_iso_timestamps.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for ISO 8601 XMLTV timestamps silently dropping all programs.
+
+Some XMLTV providers emit timestamps in ISO format (with dashes and colons)
+rather than the compact XMLTV-spec format (YYYYMMDDHHmmss):
+
+    start="2024-01-15 20:00:00 +0100"   <-- ISO with space separator
+    start="2024-01-15T20:00:00+01:00"   <-- ISO 8601 with T separator
+
+_parse_xmltv_time splits on the first space. For "2024-01-15 20:00:00 +0100"
+the date_part becomes "2024-01-15" (10 chars). The function checks for 14 or
+12 digit parts only, so len == 10 falls through to `return None`. Every
+programme for the account is silently skipped. No warning is emitted. The
+entire guide goes empty with no user-visible error.
+"""
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class ParseXmltvTimeISOFormatTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager.__new__(EPGIngestManager)
+
+    def test_iso_date_time_space_separator_no_tz_returns_utc(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00")
+        self.assertIsNotNone(result, "ISO timestamp with space separator returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, 0, tzinfo=timezone.utc))
+
+    def test_iso_date_time_space_separator_with_utc_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 +0100")
+        self.assertIsNotNone(result, "ISO timestamp with +0100 offset returned None")
+        self.assertEqual(result.hour, 20)
+        self.assertEqual(result.utcoffset().total_seconds(), 3600)
+
+    def test_iso_date_time_space_separator_with_negative_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 -0500")
+        self.assertIsNotNone(result, "ISO timestamp with -0500 offset returned None")
+        self.assertEqual(result.utcoffset().total_seconds(), -18000)
+
+    def test_iso_date_only_time_no_seconds(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00")
+        self.assertIsNotNone(result, "ISO timestamp without seconds returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, tzinfo=timezone.utc))
+
+    def test_iso_t_separator_no_tz(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00")
+        self.assertIsNotNone(result, "ISO 8601 T-separator timestamp returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, 0, tzinfo=timezone.utc))
+
+    def test_iso_t_separator_with_colon_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00+01:00")
+        self.assertIsNotNone(result, "ISO 8601 T-separator with colon offset returned None")
+        self.assertEqual(result.hour, 20)
+        self.assertEqual(result.utcoffset().total_seconds(), 3600)
+
+    def test_iso_t_separator_with_z_suffix(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00Z")
+        self.assertIsNotNone(result, "ISO 8601 Z-suffix timestamp returned None")
+        self.assertEqual(result.tzinfo, timezone.utc)
+
+    def test_compact_format_still_works_alongside_iso(self):
+        """Existing compact format must not regress when ISO support is added."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +0100")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.hour, 20)
+
+    def test_empty_string_still_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time(""))
+
+    def test_garbage_still_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time("notadate"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If your IPTV provider sends program guide data using ISO-format dates like `2024-01-15 20:00:00 +0100` instead of the compact `20240115200000 +0100`, your entire Browse EPG was silently empty after every refresh. No error appeared in the logs or UI.

## What changed

`_parse_xmltv_time` in `epg_ingest_manager.py` now detects ISO-style timestamps (date part contains dashes or a `T` separator) and routes them through a separate normalization path before calling `datetime.fromisoformat`. The compact XMLTV format path is unchanged.

Supported ISO variants now parsed correctly:
- `2024-01-15 20:00:00` (space separator, no tz)
- `2024-01-15 20:00:00 +0100` (space separator, ±HHMM offset)
- `2024-01-15 20:00` (no seconds)
- `2024-01-15T20:00:00` (T separator)
- `2024-01-15T20:00:00+01:00` (T separator, colon offset)
- `2024-01-15T20:00:00Z` (Z suffix)

## How it was tested

Regression tests from Gremlin's PR #261 (7 failing tests) were cherry-picked onto this branch. All 7 now pass alongside the 3 existing compact-format tests. Full suite: 631 tests, all pass.

**Before fix:**
```
Ran 10 tests in 0.002s
FAILED (failures=7)
```

**After fix:**
```
Ran 10 tests in 0.001s
OK

Ran 631 tests in 2.777s
OK
```

Supersedes PR #261 (test-only). Tests are included in this PR so Gremlin's branch can be closed.