### PR TITLE
[Design] add status filter to Scheduled Recordings history tab

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -12,6 +12,7 @@ import {
   Loader,
   Alert,
   Button,
+  Select,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 import { useNavigate, Link } from 'react-router-dom'
@@ -29,6 +30,7 @@ import {
   IconSettings,
   IconPlayerPlay,
   IconFolderOpen,
+  IconFilter,
 } from '@tabler/icons-react'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
@@ -254,6 +256,7 @@ export default function Scheduled() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [localItems, setLocalItems] = useState([])
+  const [historyFilter, setHistoryFilter] = useState('all')
   const desktopApi = typeof window !== 'undefined' ? window.mustarrdDesktop : null
   const isDesktop = Boolean(desktopApi?.openFileLocation && desktopApi?.playFile)
 
@@ -366,6 +369,9 @@ export default function Scheduled() {
   const historySchedules = localItems?.filter((s) =>
     ['completed', 'failed', 'cancelled'].includes(s.status)
   ) || []
+  const filteredHistorySchedules = historyFilter === 'all'
+    ? historySchedules
+    : historySchedules.filter((s) => s.status === historyFilter)
   const accountGuideOffsets = Object.fromEntries(
     (accounts || []).map((account) => [Number(account.id), getGuideOffsetHours(account.guide_offset_hours)])
   )
@@ -451,7 +457,25 @@ export default function Scheduled() {
             </Card>
           ) : (
             <Stack gap="md">
-              {historySchedules.map((schedule) => (
+              <Select
+                size="xs"
+                w={160}
+                value={historyFilter}
+                onChange={(v) => setHistoryFilter(v || 'all')}
+                leftSection={<IconFilter size={14} />}
+                allowDeselect={false}
+                data={[
+                  { value: 'all', label: 'All statuses' },
+                  { value: 'completed', label: 'Completed' },
+                  { value: 'failed', label: 'Failed' },
+                  { value: 'cancelled', label: 'Cancelled' },
+                ]}
+              />
+              {filteredHistorySchedules.length === 0 ? (
+                <Text c="dimmed" ta="center" py="lg" size="sm">
+                  No {historyFilter} scheduled recordings.
+                </Text>
+              ) : filteredHistorySchedules.map((schedule) => (
                 <ScheduleCard
                   key={schedule.id}
                   schedule={schedule}


### PR DESCRIPTION
## What a user would notice

The Scheduled Recordings History tab now has a status filter dropdown, matching the one already on the Downloads History tab. Users can narrow the list to show only Completed, Failed, or Cancelled scheduled recordings instead of scrolling a mixed list.

## What changed

Added an "All statuses" filter Select to the History panel in `Scheduled.jsx`. Selecting a status shows only matching cards; selecting "All statuses" restores the full list. If the filter returns no results, a plain-English message appears ("No failed scheduled recordings."). Frontend-only, one file.

## How it was tested

Loaded the Scheduled > History tab in the local dev environment, opened the filter dropdown, and confirmed each option correctly filters the card list. Verified the empty-state message appears when a filter matches zero items.

## Before

History tab showed all statuses mixed together with no way to filter.

## After

History tab has a filter dropdown at the top. Selecting "Failed" shows only failed recordings; selecting "Cancelled" shows only cancelled ones.