### PR TITLE
Failing regression tests: XMLTV short TZ offsets, HTML entity parse error, deflate passthrough

### DIFF
--- a/backend/tests/test_epg_deflate_xmltv.py
+++ b/backend/tests/test_epg_deflate_xmltv.py
@@ -1,0 +1,87 @@
+"""
+Regression tests: deflate-compressed XMLTV passes through _maybe_decompress
+unchanged, causing ET.iterparse to raise ParseError on the binary garbage.
+
+_maybe_decompress checks for gzip magic bytes (\x1f\x8b) only. HTTP deflate
+(Content-Encoding: deflate) uses zlib framing with no fixed magic signature.
+Deflate data is returned as-is. The caller passes it to ET.iterparse, which
+fails immediately.
+
+Impact: provider EPG silently stops updating. Per-channel expired rows are
+deleted in non-force mode; no new rows inserted. Guide empties as old content
+ages past archive_days with no clear user error.
+
+Fix: after failing the gzip check, try zlib.decompress() (handles deflate with
+zlib header) and zlib.decompress(data, -15) (raw deflate, no header).
+"""
+import sys
+import unittest
+import zlib
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+_PLAIN_XMLTV = b'<?xml version="1.0" encoding="UTF-8"?><tv></tv>'
+
+
+class MaybeDecompressDeflateTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager()
+
+    def test_zlib_deflate_with_header_is_decompressed(self):
+        """_maybe_decompress must decompress zlib-framed deflate data."""
+        compressed = zlib.compress(_PLAIN_XMLTV)
+        # Verify it is NOT gzip (no \x1f\x8b magic)
+        self.assertNotEqual(compressed[:2], b"\x1f\x8b")
+        result = self.mgr._maybe_decompress(compressed)
+        self.assertEqual(
+            result,
+            _PLAIN_XMLTV,
+            "_maybe_decompress returned raw compressed bytes for zlib deflate; "
+            "ET.iterparse will raise ParseError on this input.",
+        )
+
+    def test_raw_deflate_no_header_is_decompressed(self):
+        """_maybe_decompress must decompress raw deflate (no zlib header)."""
+        compressed = zlib.compress(_PLAIN_XMLTV)[2:-4]  # strip zlib header+checksum
+        result = self.mgr._maybe_decompress(compressed)
+        self.assertEqual(
+            result,
+            _PLAIN_XMLTV,
+            "_maybe_decompress returned raw compressed bytes for raw deflate; "
+            "ET.iterparse will raise ParseError on this input.",
+        )
+
+    def test_gzip_still_decompresses_after_deflate_support(self):
+        """Existing gzip path must continue to work when deflate support is added."""
+        import gzip
+
+        compressed = gzip.compress(_PLAIN_XMLTV)
+        result = self.mgr._maybe_decompress(compressed)
+        self.assertEqual(result, _PLAIN_XMLTV)
+
+    def test_plain_xml_still_passes_through(self):
+        """Non-compressed data must pass through unchanged."""
+        result = self.mgr._maybe_decompress(_PLAIN_XMLTV)
+        self.assertEqual(result, _PLAIN_XMLTV)
+
+    def test_deflate_bytes_are_not_valid_xml(self):
+        """Sanity check: deflate output fed to ET.iterparse causes ParseError.
+
+        This demonstrates why unhandled deflate is a real bug: the caller
+        would receive a ParseError rather than parsed content.
+        """
+        import xml.etree.ElementTree as ET
+        import io
+
+        compressed = zlib.compress(_PLAIN_XMLTV)
+        with self.assertRaises(ET.ParseError):
+            list(ET.iterparse(io.BytesIO(compressed), events=("end",)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_html_entity_parse_error.py
+++ b/backend/tests/test_epg_html_entity_parse_error.py
@@ -1,0 +1,199 @@
+"""
+Regression tests: HTML entities in XMLTV descriptions abort parse after force-mode row deletion.
+
+ET.iterparse (expat) rejects HTML entities not defined in the XML spec: &nbsp;,
+&eacute;, &mdash;, etc. Providers that generate XMLTV from HTML often include these.
+
+When _iter_programs hits such an entity it raises xml.etree.ElementTree.ParseError.
+No try/except wraps the iteration loop at line 345 of _ingest_account_epg.
+
+With force=True, the sequence is:
+  1. total_programs = xmltv_bytes.count(b"<programme") > 0 (entity is in description,
+     but the <programme> element is real and counted).
+  2. Force-delete commits: all EPGProgram rows for the account wiped.
+  3. ET.iterparse raises ParseError when it encounters &nbsp; in the description.
+  4. Exception propagates out of _refresh_account (no catch for ParseError there).
+  5. Caller (_refresh_all_accounts) catches and logs. No rows inserted.
+  6. EPG is empty.
+
+Expected after fix:
+  - _refresh_account does not raise (ParseError caught and handled internally).
+  - Rows parsed before the bad entity are kept; guide not completely wiped.
+"""
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+import xml.etree.ElementTree as ET
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+# XMLTV with a real <programme> before a programme that contains &nbsp; in desc.
+# The first programme can be counted and parsed; the second causes ParseError.
+_XMLTV_WITH_HTML_ENTITY = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b"<tv>"
+    b'<channel id="ch1"><display-name>Test Channel</display-name></channel>'
+    b'<programme start="20261201200000 +0000" stop="20261201210000 +0000" channel="ch1">'
+    b"<title>Good Show</title>"
+    b"</programme>"
+    b'<programme start="20261201210000 +0000" stop="20261201220000 +0000" channel="ch1">'
+    b"<title>Bad Show</title>"
+    b"<desc>Watch it&nbsp;on Monday</desc>"
+    b"</programme>"
+    b"</tv>"
+)
+
+
+def _make_account(account_id=1):
+    account = MagicMock()
+    account.id = account_id
+    account.name = "Test"
+    account.server_url = "http://provider.example"
+    account.username = "user"
+    return account
+
+
+def _make_session_ctx(delete_tracker):
+    fake_session = AsyncMock()
+
+    async def tracking_execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt)
+        if "DELETE" in stmt_str.upper():
+            delete_tracker.append(stmt_str)
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        result.all.return_value = []
+        return result
+
+    fake_session.execute = tracking_execute
+
+    @asynccontextmanager
+    async def fake_begin():
+        yield
+
+    fake_session.begin = fake_begin
+
+    @asynccontextmanager
+    async def maker():
+        yield fake_session
+
+    return maker
+
+
+class EPGHtmlEntityParseErrorTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_html_entity_in_desc_does_not_propagate_parse_error(self):
+        """_refresh_account must not raise ParseError when XMLTV contains &nbsp;."""
+        manager = EPGIngestManager()
+        account = _make_account()
+        delete_tracker = []
+
+        client = MagicMock()
+        client.get_live_streams = AsyncMock(return_value=[
+            {
+                "stream_id": "ch1",
+                "name": "Test Channel",
+                "tv_archive": 1,
+                "tv_archive_duration": 7,
+                "epg_channel_id": "ch1",
+            }
+        ])
+        client.get_xmltv = AsyncMock(return_value=_XMLTV_WITH_HTML_ENTITY)
+        client.close = AsyncMock()
+
+        with (
+            patch(
+                "services.epg_ingest_manager.async_session_maker",
+                side_effect=_make_session_ctx(delete_tracker),
+            ),
+            patch("services.epg_ingest_manager.resolve_account_password", return_value="pass"),
+            patch("services.epg_ingest_manager.XtreamClient", return_value=client),
+        ):
+            try:
+                await manager._refresh_account(account, force=True)
+            except ET.ParseError as exc:
+                self.fail(
+                    f"ParseError from &nbsp; in XMLTV must not propagate out of "
+                    f"_refresh_account. Got: {exc}"
+                )
+
+    async def test_html_entity_force_mode_does_not_wipe_rows_on_parse_error(self):
+        """Force-mode must not delete rows when the parse subsequently fails.
+
+        Current bug: delete commits before iteration; ParseError then leaves guide empty.
+        After fix: either defer deletion until after successful parse, or catch ParseError
+        and keep partial results (no total wipe).
+        """
+        manager = EPGIngestManager()
+        account = _make_account()
+        delete_tracker = []
+        insert_tracker = []
+
+        fake_session = AsyncMock()
+
+        async def tracking_execute(stmt, *args, **kwargs):
+            stmt_str = str(stmt)
+            if "DELETE" in stmt_str.upper():
+                delete_tracker.append(stmt_str)
+            elif "INSERT" in stmt_str.upper():
+                insert_tracker.append(stmt_str)
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = []
+            result.all.return_value = []
+            return result
+
+        fake_session.execute = tracking_execute
+
+        @asynccontextmanager
+        async def fake_begin():
+            yield
+
+        fake_session.begin = fake_begin
+
+        @asynccontextmanager
+        async def maker():
+            yield fake_session
+
+        client = MagicMock()
+        client.get_live_streams = AsyncMock(return_value=[
+            {
+                "stream_id": "ch1",
+                "name": "Test Channel",
+                "tv_archive": 1,
+                "tv_archive_duration": 7,
+                "epg_channel_id": "ch1",
+            }
+        ])
+        client.get_xmltv = AsyncMock(return_value=_XMLTV_WITH_HTML_ENTITY)
+        client.close = AsyncMock()
+
+        with (
+            patch("services.epg_ingest_manager.async_session_maker", side_effect=maker),
+            patch("services.epg_ingest_manager.resolve_account_password", return_value="pass"),
+            patch("services.epg_ingest_manager.XtreamClient", return_value=client),
+        ):
+            try:
+                await manager._refresh_account(account, force=True)
+            except ET.ParseError:
+                pass  # Bug present: parse error propagated
+
+        # After fix: if delete fired but parse failed, this should be impossible:
+        # either no delete (deferred until post-parse) or partial rows still inserted.
+        if delete_tracker:
+            self.assertGreater(
+                len(insert_tracker),
+                0,
+                "Force-delete fired but ParseError prevented any rows being inserted. "
+                "EPG wiped completely. Delete must be deferred until after a successful parse, "
+                "or partial results must be committed before the failing element.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_xmltv_iso_timestamps.py
+++ b/backend/tests/test_epg_xmltv_iso_timestamps.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for ISO 8601 XMLTV timestamps silently dropping all programs.
+
+Some XMLTV providers emit timestamps in ISO format (with dashes and colons)
+rather than the compact XMLTV-spec format (YYYYMMDDHHmmss):
+
+    start="2024-01-15 20:00:00 +0100"   <-- ISO with space separator
+    start="2024-01-15T20:00:00+01:00"   <-- ISO 8601 with T separator
+
+_parse_xmltv_time splits on the first space. For "2024-01-15 20:00:00 +0100"
+the date_part becomes "2024-01-15" (10 chars). The function checks for 14 or
+12 digit parts only, so len == 10 falls through to `return None`. Every
+programme for the account is silently skipped. No warning is emitted. The
+entire guide goes empty with no user-visible error.
+"""
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class ParseXmltvTimeISOFormatTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager.__new__(EPGIngestManager)
+
+    def test_iso_date_time_space_separator_no_tz_returns_utc(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00")
+        self.assertIsNotNone(result, "ISO timestamp with space separator returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, 0, tzinfo=timezone.utc))
+
+    def test_iso_date_time_space_separator_with_utc_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 +0100")
+        self.assertIsNotNone(result, "ISO timestamp with +0100 offset returned None")
+        self.assertEqual(result.hour, 20)
+        self.assertEqual(result.utcoffset().total_seconds(), 3600)
+
+    def test_iso_date_time_space_separator_with_negative_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 -0500")
+        self.assertIsNotNone(result, "ISO timestamp with -0500 offset returned None")
+        self.assertEqual(result.utcoffset().total_seconds(), -18000)
+
+    def test_iso_date_only_time_no_seconds(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00")
+        self.assertIsNotNone(result, "ISO timestamp without seconds returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, tzinfo=timezone.utc))
+
+    def test_iso_t_separator_no_tz(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00")
+        self.assertIsNotNone(result, "ISO 8601 T-separator timestamp returned None")
+        self.assertEqual(result, datetime(2024, 1, 15, 20, 0, 0, tzinfo=timezone.utc))
+
+    def test_iso_t_separator_with_colon_offset(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00+01:00")
+        self.assertIsNotNone(result, "ISO 8601 T-separator with colon offset returned None")
+        self.assertEqual(result.hour, 20)
+        self.assertEqual(result.utcoffset().total_seconds(), 3600)
+
+    def test_iso_t_separator_with_z_suffix(self):
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00Z")
+        self.assertIsNotNone(result, "ISO 8601 Z-suffix timestamp returned None")
+        self.assertEqual(result.tzinfo, timezone.utc)
+
+    def test_compact_format_still_works_alongside_iso(self):
+        """Existing compact format must not regress when ISO support is added."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +0100")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.hour, 20)
+
+    def test_empty_string_still_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time(""))
+
+    def test_garbage_still_returns_none(self):
+        self.assertIsNone(self.mgr._parse_xmltv_time("notadate"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_xmltv_short_tz_offsets.py
+++ b/backend/tests/test_epg_xmltv_short_tz_offsets.py
@@ -1,0 +1,91 @@
+"""
+Regression tests: short numeric TZ offsets (+5:30, +530) silently stored as UTC.
+
+_parse_xmltv_time colon-strips only when len(tz_part) == 6 and tz_part[3] == ':',
+which handles "+05:30" -> "+0530" but misses single-digit-hour forms:
+
+  "+5:30"  (len=5)  - strptime("%z") rejects single-digit hour -> ValueError -> UTC
+  "+530"   (len=4)  - strptime("%z") rejects 3-digit value   -> ValueError -> UTC
+  "-3:30"  (len=5)  - same issue
+
+Affected time zones: India (+5:30), Iran (+3:30), Myanmar (+6:30),
+Sri Lanka (+5:30), Afghanistan (+4:30), Newfoundland (-3:30).
+
+Provider emits timestamps with non-padded hour; all programmes stored 3.5-6.5 h
+off. Downloads fire at the wrong time; Browse EPG shows wrong slots.
+"""
+import sys
+import unittest
+from datetime import timedelta, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+IST = timezone(timedelta(hours=5, minutes=30))
+IRAN = timezone(timedelta(hours=3, minutes=30))
+NFD = timezone(timedelta(hours=-3, minutes=-30))
+
+
+class ShortTzOffsetTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager.__new__(EPGIngestManager)
+
+    def test_plus_5_colon_30_returns_ist_offset(self):
+        """'+5:30' (len=5) must be interpreted as UTC+5:30, not UTC."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +5:30")
+        self.assertIsNotNone(result, "'+5:30' offset returned None")
+        self.assertEqual(
+            result.utcoffset(),
+            timedelta(hours=5, minutes=30),
+            f"'+5:30' parsed as {result.utcoffset()}, expected +05:30 (UTC+5:30)",
+        )
+
+    def test_plus_530_no_colon_returns_ist_offset(self):
+        """'+530' (len=4, no colon) must be interpreted as UTC+5:30, not UTC."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +530")
+        self.assertIsNotNone(result, "'+530' offset returned None")
+        self.assertEqual(
+            result.utcoffset(),
+            timedelta(hours=5, minutes=30),
+            f"'+530' parsed as {result.utcoffset()}, expected +05:30 (UTC+5:30)",
+        )
+
+    def test_minus_3_colon_30_returns_nfd_offset(self):
+        """'-3:30' (Newfoundland, len=5) must be interpreted as UTC-3:30, not UTC."""
+        result = self.mgr._parse_xmltv_time("20240115200000 -3:30")
+        self.assertIsNotNone(result, "'-3:30' offset returned None")
+        self.assertEqual(
+            result.utcoffset(),
+            timedelta(hours=-3, minutes=-30),
+            f"'-3:30' parsed as {result.utcoffset()}, expected -03:30",
+        )
+
+    def test_plus_3_colon_30_returns_iran_offset(self):
+        """'+3:30' (Iran, len=5) must be interpreted as UTC+3:30, not UTC."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +3:30")
+        self.assertIsNotNone(result, "'+3:30' offset returned None")
+        self.assertEqual(
+            result.utcoffset(),
+            timedelta(hours=3, minutes=30),
+            f"'+3:30' parsed as {result.utcoffset()}, expected +03:30",
+        )
+
+    def test_standard_padded_offset_still_works(self):
+        """+05:30 (standard 6-char form) must continue to parse correctly."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +05:30")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.utcoffset(), timedelta(hours=5, minutes=30))
+
+    def test_standard_compact_offset_still_works(self):
+        """+0530 (standard 5-char no-colon form) must continue to parse correctly."""
+        result = self.mgr._parse_xmltv_time("20240115200000 +0530")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.utcoffset(), timedelta(hours=5, minutes=30))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR contains

Three test files that deliberately FAIL to demonstrate bugs filed in #tasks today. Each test file includes a docstring explaining the bug and links to the relevant code location.

**This PR contains no fixes.** These are Gremlin's regression tests. Clementine or another agent should fix the underlying code and update the tasks when the tests pass.

## Bugs demonstrated

### 1. Short numeric TZ offsets silently stored as UTC

File: `test_epg_xmltv_short_tz_offsets.py` (4 failing tests)

`_parse_xmltv_time` colon-strips only when `len(tz_part) == 6`. Single-digit-hour forms like `+5:30` (len=5) and `+530` (len=4) fall through to `strptime("%z")`, which raises `ValueError` (Python requires two-digit hours). The `except ValueError` path returns `dt.replace(tzinfo=timezone.utc)`. Programs from India (+5:30), Iran (+3:30), Myanmar (+6:30), Newfoundland (-3:30), and similar half-hour zones are stored 3.5 to 6.5 hours wrong.

Code: `backend/services/epg_ingest_manager.py:634-639`

### 2. HTML entities in XMLTV descriptions wipe EPG after force-mode row deletion

File: `test_epg_html_entity_parse_error.py` (2 failing tests)

`ET.iterparse` (expat) rejects HTML entities not defined in XML: `&nbsp;`, `&eacute;`, `&mdash;`, etc. These appear in descriptions from providers that generate XMLTV from HTML. No try/except wraps the iteration at line 345. With `force=True`: rows deleted (committed) at lines 280-284, then `ParseError` propagates out of `_refresh_account`, no rows inserted. EPG empty.

Code: `backend/services/epg_ingest_manager.py:280-284, 345, 488-577`

### 3. Deflate-compressed XMLTV passes through _maybe_decompress unchanged

File: `test_epg_deflate_xmltv.py` (2 failing tests, 3 passing)

`_maybe_decompress` checks only for gzip magic bytes `\x1f\x8b`. HTTP `Content-Encoding: deflate` uses zlib framing with no fixed magic signature. Deflate bytes are returned as-is. `ET.iterparse` gets binary garbage and raises `ParseError`. Guide stops updating, stales silently.

`zlib` is already imported in the file. Fix: try `zlib.decompress(data)` after the gzip check.

Code: `backend/services/epg_ingest_manager.py:579-585`

## Test results before fix

```
Ran 13 tests
FAILED (failures=8)
```

8 failing tests demonstrate the bugs. 5 passing tests verify existing correct behavior does not regress.

## How to test

```bash
cd backend
python3 -m unittest tests.test_epg_xmltv_short_tz_offsets tests.test_epg_html_entity_parse_error tests.test_epg_deflate_xmltv
```

All 13 tests should pass after the fixes are applied.