### PR TITLE
design: link to Scheduled Recordings from Downloads Upcoming tab

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -704,6 +704,10 @@ export default function Downloads() {
             </Card>
           ) : (
             <Stack gap="sm">
+              <Text size="xs" c="dimmed">
+                To cancel or edit a recording, go to{' '}
+                <Link to="/scheduled" style={{ color: 'var(--mantine-color-orange-5)' }}>Scheduled Recordings</Link>.
+              </Text>
               {upcomingRecordings.map((rec) => {
                 const guideOffset = accountGuideOffsets[Number(rec.account_id)] || 0
                 const airStart = formatAirDateTime(rec, 'start', guideOffset)


### PR DESCRIPTION
## What a user would notice

The Downloads > Upcoming tab now shows a one-line hint: "To cancel or edit a recording, go to Scheduled Recordings." with a clickable link. Previously, users who wanted to cancel an upcoming scheduled recording had no idea they could only do that from the Scheduled page. The cards were completely read-only with no actions and no guidance.

## What changed

Added four lines to `frontend/src/pages/Downloads.jsx`. A small muted hint line appears at the top of the upcoming recordings list, above the cards. The link uses the same orange color and `Link` component already used throughout the app. No logic change, frontend only.

## How it was tested

Screenshots taken at desktop (1280px) and mobile (390px). Before/after posted in #design.

**Before:** Read-only cards, no context, no path to cancel.
**After:** Subtle hint with direct link to Scheduled Recordings visible above the list.