### PR TITLE
docs: changelog entries for PRs #260, #262, #263, #266, and #267

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: IPTV providers with HTML entities in guide data no longer wipe the program guide
+
+**What you would notice:** Some IPTV providers build their program guide data from web pages and include HTML shortcuts like `&nbsp;` (a special space) or `&eacute;` (the letter e with an accent) in show descriptions. These are valid in HTML but not in the XML format Mustarrd uses to read guide data. When Mustarrd tried to import a guide containing these characters, the XML parser would crash mid-import. If you had "Force Refresh" selected, the old guide was deleted first, and then the crash left you with a completely empty Browse page and no error message. Every automatic guide refresh after that repeated the wipe. After this fix, those HTML characters are converted to a safe form before parsing. The guide loads correctly, descriptions are preserved, and no data is lost.
+
+**What changed:** The part of Mustarrd that reads incoming guide data now automatically escapes HTML-style character codes to safe XML equivalents before the XML parser sees them. Standard XML characters (`&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`) and numeric codes are left unchanged.
+
+---
+
+### Improved: Downloads > Upcoming tab now tells you how to cancel a scheduled recording
+
+**What you would notice:** The Downloads page has an Upcoming tab that shows your scheduled recordings before they run. The cards there were read-only: no buttons, no links, and no explanation of what to do if you wanted to cancel or change one. Users were often confused about where to go. A small line of text now appears at the top of the Upcoming list that reads "To cancel or edit a recording, go to Scheduled Recordings." and includes a clickable link that takes you straight there.
+
+**What changed:** A single hint line with a navigation link was added to the top of the Upcoming recordings list. No download or scheduling logic was changed.
+
+---
+
 ### Improved: Scheduled Recordings history now has a status filter
 
 **What you would notice:** The Scheduled Recordings history tab showed all recordings mixed together with no way to narrow the list. The Downloads history tab already had a status filter, but Scheduled did not. A filter dropdown now appears at the top of the Scheduled history tab. You can select All, Completed, Failed, or Cancelled to see only the recordings you care about. If no recordings match the selected filter, a plain message explains why the list is empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+## 2026-06-09
+
+### Improved: Scheduled Recordings history now has a status filter
+
+**What you would notice:** The Scheduled Recordings history tab showed all recordings mixed together with no way to narrow the list. The Downloads history tab already had a status filter, but Scheduled did not. A filter dropdown now appears at the top of the Scheduled history tab. You can select All, Completed, Failed, or Cancelled to see only the recordings you care about. If no recordings match the selected filter, a plain message explains why the list is empty.
+
+**What changed:** A status filter dropdown was added to the Scheduled Recordings history tab. No scheduling or backend logic was changed.
+
+---
+
+### Fixed: Scheduled recordings on Movies or Sports channels now get the correct filename
+
+**What you would notice:** When you scheduled a recording on a channel categorized as Movies or Sports and left the filename field blank, the downloaded file got the wrong name. A movie called "The Dark Knight" on a Movies channel would be named like `The Dark Knight - 2024-01-15.mkv` instead of `The Dark Knight (2008).mkv`, because Mustarrd lost track of the channel's category between when you scheduled the recording and when it actually ran. This fix ensures the channel category is saved when you create the schedule and used when the recording fires.
+
+**What changed:** The scheduled recording now saves the channel category (such as "Movies" or "Sports") when the schedule is created. When the scheduler runs the recording, it passes that saved category to the filename generator so the file is named correctly. No user-visible setting or config was changed. A regression test was added.
+
+---
+
+### Fixed: Program guide no longer goes empty for providers that use date-style timestamps
+
+**What you would notice:** If your IPTV provider sends program guide data using date-formatted timestamps like `2024-01-15 20:00:00 +0100` instead of the compact numeric format like `20240115200000 +0100`, your entire Browse page would be silently empty after every guide refresh. No error appeared in the logs or the UI. After this fix, both timestamp formats are handled correctly and the program guide populates as expected.
+
+**What changed:** The part of Mustarrd that reads incoming guide data now recognizes ISO-style date timestamps (with dashes, a space separator, or a `T` separator) and converts them to the format Mustarrd uses internally. The existing compact-format path is unchanged.
+
+---
+
 ## 2026-06-08
 
 ### Improved: Settings now shows when your program guide last synced, with a Refresh Now button


### PR DESCRIPTION
## What changed

Five changelog entries added for PRs merged on 2026-06-08 and 2026-06-09:

- **PR #263** (design): Scheduled Recordings history now has a status filter dropdown, matching the one already on Downloads history.
- **PR #260** (fix): Scheduled recordings on Movies or Sports channels now get the correct filename when no custom filename is set.
- **PR #262** (fix): Program guide no longer goes silently empty for IPTV providers that use ISO-style date timestamps (e.g. `2024-01-15 20:00:00 +0100`).
- **PR #266** (fix): IPTV providers that include HTML entities like `&nbsp;` in their guide data no longer wipe the entire program guide on every refresh.
- **PR #267** (design): The Downloads > Upcoming tab now shows a plain-English hint with a link to Scheduled Recordings so users know where to go to cancel or edit a scheduled recording.

## How it was tested

Read each merged PR description and wrote plain-English entries for a non-technical Unraid user. No code changes. No em dashes used.