### PR TITLE
design: remove redundant duration from Download starts line

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -728,7 +728,7 @@ export default function Downloads() {
                         Airs: {airStart || 'Unknown'} - {airEnd || 'Unknown'} ({formatDuration(rec.duration_minutes || 0)})
                       </Text>
                       <Text size="xs" c="dimmed">
-                        Download starts: {downloadAt || 'Unknown'} ({formatDuration(totalDuration)})
+                        Download starts: {downloadAt || 'Unknown'}{totalDuration !== (rec.duration_minutes || 0) ? ` (${formatDuration(totalDuration)} with padding)` : ''}
                       </Text>
                     </Stack>
                   </Card>

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -166,7 +166,7 @@ function ScheduleCard({
 
         {(isActive || schedule.status === 'completed') && (
           <Text size="xs" c="dimmed">
-            Download starts: {availableAt || 'Unknown'} ({formatDuration(totalDuration)})
+            Download starts: {availableAt || 'Unknown'}{totalDuration !== (schedule.duration_minutes || 0) ? ` (${formatDuration(totalDuration)} with padding)` : ''}
           </Text>
         )}
 


### PR DESCRIPTION
## What changed

On the Downloads > Upcoming and Scheduled Recordings > Upcoming pages, scheduled recording cards showed a parenthetical duration after the download start time:

> Download starts: Today at 9:00 PM **(1h)**

When no padding is configured (the common case), this duration is identical to the one already shown on the line above:

> Airs: Today at 8:00 PM - 9:00 PM **(1h)**

A non-technical user could read "(1h)" after "Download starts" as "the download takes 1 hour," not "the recording is 1 hour long." It is also noise when the same number appears twice on two consecutive lines.

**Fix:** Hide the duration from the Download starts line when no padding has been added. When the user has configured pre or post padding, show the total padded duration with a clear "(Xh Ym with padding)" label so they know the recording is longer than the show itself.

## Before

> Airs: Today at 8:00 PM - 9:00 PM (1h)
> Download starts: Today at 9:00 PM **(1h)** — same number, potentially confusing

## After

> Airs: Today at 8:00 PM - 9:00 PM (1h)
> Download starts: Today at 9:00 PM — clean, no duplication

With padding (5 min pre + 3 min post on a 1h show):
> Download starts: Today at 8:55 PM **(1h 8m with padding)** — clearly labeled

## Files changed

- `frontend/src/pages/Downloads.jsx` — Upcoming tab cards
- `frontend/src/pages/Scheduled.jsx` — ScheduleCard component

## Test plan

- Open Downloads > Upcoming with scheduled recordings that have no padding: duration is gone from "Download starts" line
- Configure pre or post padding on a scheduled recording: "(Xh Ym with padding)" appears on "Download starts" line
- Scheduled Recordings > Upcoming cards behave identically