### PR TITLE
design: use relative dates in Downloads history cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -213,7 +213,7 @@ function DownloadCard({
 
         <Group gap="xs" wrap="nowrap">
           <Text size="xs" c="dimmed">
-            {formatChannelDateTime(download, 'start', guideOffsetHours, 'MMM D, YYYY h:mm A') || 'Unknown'}
+            {formatAirDateTime(download, 'start', guideOffsetHours) || 'Unknown'}
           </Text>
           <Text size="xs" c="dimmed">
             ({formatDuration(download.duration_minutes)})


### PR DESCRIPTION
## What changed

Downloads > History cards showed program air dates as absolute dates like "Jun 8, 2026 7:30 PM". Scheduled Recordings > History already showed relative dates like "Yesterday at 7:30 PM". The two pages used the same underlying utility but `DownloadCard` was calling `formatChannelDateTime` with a fixed absolute format string instead of `formatAirDateTime`.

One-line fix: swap to `formatAirDateTime` in the date line of `DownloadCard`.

**Before:**
> EastEnders - BBC One
> Jun 8, 2026 7:30 PM  (30m)
>
> Soccer AM - Sky One
> Nov 14, 2023 10:13 PM  (1h 30m)

**After:**
> EastEnders - BBC One
> Yesterday at 7:30 PM  (30m)
>
> Soccer AM - Sky One
> Tue, Nov 14, 2023 at 10:13 PM  (1h 30m)

The change applies to Active, Upcoming, and History tabs equally (all use `DownloadCard`). Active cards now show "Today at..." for in-progress downloads. Upcoming cards already used `formatAirDateTime` in their `ScheduledRecordingCard` component; this makes `DownloadCard` consistent.

## How it was tested

Dev server with seed data. Verified at 1280px desktop and 390px mobile. "Yesterday at 7:30 PM" rendered correctly for the Jun 8 EastEnders entry. Old 2023 entries rendered as "Tue, Nov 14, 2023 at 10:13 PM". No layout breakage on either viewport.