### PR TITLE
fix: zero-pad short TZ offsets in timeshift URL builder

### DIFF
--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -89,6 +89,10 @@ def _normalize_provider_start_token(provider_start: str, pre_padding_minutes: in
         # Strip trailing timezone offset (e.g. " +0200", " -0500", " +0000") before
         # trying compact formats.  The datetime part without the offset is the
         # provider's local wall-clock time, which is what the timeshift URL expects.
+        # Zero-pad single-digit hour offsets (+5:30, +530, -3:30) so the strip
+        # regex below can match them.
+        token = re.sub(r"([+-])(\d)(:\d{2})$", r"\g<1>0\2\3", token)
+        token = re.sub(r"([+-])(\d)(\d{2})$", r"\g<1>0\2\3", token)
         bare = re.sub(r"\s*([+-]\d{2}:?\d{2}|Z)$", "", token).strip()
         for fmt, candidate in (
             ("%Y-%m-%d %H:%M:%S", bare),

--- a/backend/tests/test_download_builder_short_tz_offsets.py
+++ b/backend/tests/test_download_builder_short_tz_offsets.py
@@ -1,0 +1,72 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_builder import _normalize_provider_start_token
+
+
+class NormalizeProviderStartTokenShortTZTests(unittest.TestCase):
+    """_normalize_provider_start_token zero-pads single-digit-hour TZ offsets.
+
+    Providers serving India (+5:30), Newfoundland (-3:30), or Iran (+3:30)
+    emit offsets with a 1-digit hour.  Before this fix the strip regex required
+    two hour digits; the offset stayed in 'bare', all strptime attempts failed,
+    and the function returned None.  build_timeshift_url fell back to UTC,
+    putting IST users 5.5 hours off from the intended content.
+    """
+
+    def test_plus_colon_form_ist(self):
+        """'+5:30' (India IST) is stripped; wall-clock time returned."""
+        result = _normalize_provider_start_token("20240115203000 +5:30", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_compact_form_ist(self):
+        """'+530' compact form (India IST) is stripped; wall-clock time returned."""
+        result = _normalize_provider_start_token("20240115203000 +530", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_negative_colon_form_nst(self):
+        """-3:30' (Newfoundland NST) is stripped; wall-clock time returned."""
+        result = _normalize_provider_start_token("20240115203000 -3:30", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_plus_colon_form_irst(self):
+        """'+3:30' (Iran IRST) is stripped; wall-clock time returned."""
+        result = _normalize_provider_start_token("20240115120000 +3:30", 0)
+        self.assertEqual(result, "2024-01-15:12-00")
+
+    def test_standard_two_digit_offset_unchanged(self):
+        """+0530' (already zero-padded) continues to work."""
+        result = _normalize_provider_start_token("20240115203000 +0530", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_standard_colon_offset_unchanged(self):
+        """'+05:30' (padded colon form) continues to work."""
+        result = _normalize_provider_start_token("20240115203000 +05:30", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_utc_offset_unchanged(self):
+        """+0000' (UTC) continues to work."""
+        result = _normalize_provider_start_token("20240115120000 +0000", 0)
+        self.assertEqual(result, "2024-01-15:12-00")
+
+    def test_pre_padding_applied_with_short_tz(self):
+        """Pre-padding is subtracted after the wall-clock time is extracted."""
+        result = _normalize_provider_start_token("20240115203000 +5:30", 30)
+        self.assertEqual(result, "2024-01-15:20-00")
+
+    def test_empty_token_returns_none(self):
+        """Empty token returns None regardless."""
+        self.assertIsNone(_normalize_provider_start_token("", 0))
+
+    def test_none_token_returns_none(self):
+        """None token returns None without raising."""
+        self.assertIsNone(_normalize_provider_start_token(None, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What the user would notice

If your IPTV provider uses a time zone with a single-digit hour offset, such as India Standard Time (+5:30), Newfoundland Standard Time (-3:30), or Iran Standard Time (+3:30), scheduled downloads were fetching content roughly 3.5 to 5.5 hours earlier than the program you scheduled. The guide showed the correct time, the download started at the right time, but the recorded content was wrong.

## Root cause

`_normalize_provider_start_token` in `download_builder.py` strips the trailing TZ offset from the provider's start timestamp before building the timeshift URL. The strip regex required two hour digits (`\d{2}`), so `+5:30`, `+530`, and `-3:30` did not match. The offset stayed in the datetime string, all `strptime` attempts failed, and the function returned `None`. `build_timeshift_url` then fell back to UTC wall-clock time.

This was masked until PR #269: the EPG parse path had the same bug, so schedules never dispatched correctly anyway. After #269, EPG times are correct but the timeshift URL is still built from UTC.

## Fix

Two lines zero-pad single-digit hour offsets to their standard two-digit forms before the existing strip regex, exactly the same approach PR #269 used for the EPG parse path.

```
Before: '20240115203000 +5:30'  -> None  (falls back to UTC, 5.5 h off)
After:  '20240115203000 +5:30'  -> '2024-01-15:20-30'  (correct)

Before: '20240115203000 +530'   -> None
After:  '20240115203000 +530'   -> '2024-01-15:20-30'

Before: '20240115203000 -3:30'  -> None
After:  '20240115203000 -3:30'  -> '2024-01-15:20-30'
```

Standard two-digit forms (`+0530`, `+05:30`, `+0000`) are unchanged.

## How it was tested

10 regression tests in `backend/tests/test_download_builder_short_tz_offsets.py`. All 675 backend tests pass.

```
Ran 675 tests in 3.020s
OK
```