### PR TITLE
[Design] fix "Airs" label shown on failed/cancelled history cards

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -104,9 +104,9 @@ function ScheduleCard({
   const isActive = activeStatuses.includes(schedule.status)
   const isTerminal = terminalStatuses.includes(schedule.status)
   const canDelete = !isActive
-  const startHasPassed = schedule.start_timestamp
-    ? schedule.start_timestamp < Date.now() / 1000
-    : isTerminal
+  const startHasPassed = isTerminal
+    ? true
+    : (schedule.start_timestamp ? schedule.start_timestamp < Date.now() / 1000 : false)
 
   const startTime = formatAirDateTime(schedule, 'start', guideOffsetHours)
   const endTime = formatChannelDateTime(schedule, 'end', guideOffsetHours, 'h:mm A')

--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -100,11 +100,13 @@ function ScheduleCard({
 }) {
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const activeStatuses = ['scheduled', 'queued', 'downloading', 'processing', 'paused_low_space']
+  const terminalStatuses = ['completed', 'failed', 'cancelled']
   const isActive = activeStatuses.includes(schedule.status)
+  const isTerminal = terminalStatuses.includes(schedule.status)
   const canDelete = !isActive
   const startHasPassed = schedule.start_timestamp
     ? schedule.start_timestamp < Date.now() / 1000
-    : false
+    : isTerminal
 
   const startTime = formatAirDateTime(schedule, 'start', guideOffsetHours)
   const endTime = formatChannelDateTime(schedule, 'end', guideOffsetHours, 'h:mm A')


### PR DESCRIPTION
## What a user would notice

In Scheduled Recordings > History, failed recordings showed **"Airs: Yesterday at 7:30 PM"** (present tense) while cancelled recordings correctly showed **"Aired:"** (past tense). A non-technical user reading "Airs" on a history card would be confused about whether the show is upcoming or already past.

## What changed

Three-line change in `ScheduleCard` in `Scheduled.jsx`. Terminal-status recordings (completed/failed/cancelled) always aired in the past, so `startHasPassed` is now forced to `true` for all terminal statuses, regardless of the stored `start_timestamp` value.

The previous fallback (`startHasPassed = false` when `start_timestamp` was absent) has been replaced: active cards still check the clock, terminal cards always show "Aired:".

### Which status + timestamp combinations show which label

| Status | `start_timestamp` | Label shown |
|---|---|---|
| Active (scheduled/queued/downloading/processing/paused) | Any future value | **Airs:** |
| Active | Any past value | **Aired:** |
| Active | Absent (0 / null) | **Airs:** |
| Terminal (completed/failed/cancelled) | Any value, including future | **Aired:** (always) |
| Terminal | Absent (0 / null) | **Aired:** (always) |

Frontend only. No logic change. No API change.

## Before

EastEnders (FAILED) shows "Airs: Yesterday at 7:30 PM" while Doctor Who (CANCELLED) shows "Aired:":

![Before](https://cdn.discordapp.com/attachments/1513731390955589793/1513731474545156158/desktop_scheduled_history.png)

## After

All history cards consistently show "Aired:":

![After desktop](https://cdn.discordapp.com/attachments/1513731390955589793/1513731503644082196/after_scheduled_history_desktop.png)

![After mobile](https://cdn.discordapp.com/attachments/1513731390955589793/1513731516903886970/after_scheduled_history_mobile.png)

## How it was tested

- Started the app locally (backend + frontend dev server)
- Verified before screenshot shows "Airs:" on the FAILED EastEnders card
- Applied fix, hot-reloaded, verified after screenshot shows "Aired:" on all three history cards
- Confirmed Upcoming tab cards still correctly show "Airs:" for future scheduled recordings