### PR TITLE
fix: commit COMPLETED after post-process cancel-after-move; delete orphaned .ts on queued cancel

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -390,6 +390,7 @@ class DownloadManager:
 
                 if download_id in self._cancelled:
                     self._cancelled.discard(download_id)
+                    await self._delete_cancelled_post_file(download_id)
                     continue
 
                 self._cleanup_completed_post_tasks()
@@ -891,7 +892,15 @@ class DownloadManager:
                     select(Download).where(Download.id == download_id)
                 )
                 download = result.scalar_one_or_none()
-                if download and download.status in [
+                if download and download.status == DownloadStatus.COMPLETED.value:
+                    # File was already moved to the completed folder before the cancel
+                    # arrived. The in-memory COMPLETED state was never committed because
+                    # the session shares the same identity map. Commit it now so the
+                    # recording is not left as PROCESSING with an orphaned file.
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
+                    await session.commit()
+                    await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
+                elif download and download.status in [
                     DownloadStatus.PENDING.value,
                     DownloadStatus.DOWNLOADING.value,
                     DownloadStatus.PROCESSING.value,
@@ -924,6 +933,21 @@ class DownloadManager:
                     error=str(e)
                 )
                 await self._broadcast_log(download_id, f"Post-processing failed: {e}", level="error")
+
+    async def _delete_cancelled_post_file(self, download_id: int) -> None:
+        """Delete the source file for a post-processing job cancelled before it started."""
+        try:
+            async with async_session_maker() as session:
+                result = await session.execute(
+                    select(Download).where(Download.id == download_id)
+                )
+                dl = result.scalar_one_or_none()
+                if dl and dl.output_path:
+                    path = Path(dl.output_path)
+                    if path.is_file():
+                        path.unlink()
+        except Exception:
+            pass
 
     async def _resolve_download_owner(self, download_id: int) -> int | None:
         if download_id in self._download_owners:

--- a/backend/tests/test_post_process_cancel_after_move.py
+++ b/backend/tests/test_post_process_cancel_after_move.py
@@ -1,0 +1,147 @@
+"""
+Regression test: CancelledError after _move_to_completed in _execute_post_process must
+commit COMPLETED so the row does not stay stuck as PROCESSING.
+
+In _execute_post_process, after _post_process() returns successfully, the flow is:
+  1. _select_final_path()       (sync)
+  2. _move_to_completed()       (sync, file is now in completed folder)
+  3. _cleanup_working_files()   (sync)
+  4. download.status = COMPLETED (sync, only in memory, not yet committed)
+  5. await _sync_schedule_status(...)   <-- FIRST await after the move
+  6. await session.commit()
+
+If task.cancel() fires at step 5 or 6, CancelledError is raised. The handler
+re-selects the download using the same session: SQLAlchemy's identity map returns
+the in-memory object where status is already COMPLETED, so the handler skips the
+CANCELLED branch and does not commit. When the session context exits, the uncommitted
+COMPLETED is rolled back and the row stays PROCESSING. The file is in the completed
+folder but the DB says PROCESSING: the recording is effectively orphaned.
+
+This mirrors the download-phase bug covered by test_cancel_after_move_deletes_completed.py
+(TODO 1512804545061982270), but for the post-processing phase which has no equivalent guard.
+
+Expected fix: the CancelledError handler should detect the file is already in the
+completed folder (or output_path was updated) and commit COMPLETED instead.
+"""
+
+import asyncio
+import contextlib
+import sys
+import tempfile
+import shutil
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class PostProcessCancelAfterMoveTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_processing_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            dl = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=50.0,
+            )
+            session.add(dl)
+            await session.commit()
+            await session.refresh(dl)
+            return dl.id
+
+    async def test_cancel_after_post_process_move_preserves_completed_status(self):
+        """CancelledError after _move_to_completed must commit COMPLETED, not leave row as PROCESSING."""
+        source_path = str(Path(self.tmpdir) / "show.ts")
+        Path(source_path).touch()
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        completed_path = str(completed_dir / "show.mkv")
+        Path(completed_path).touch()
+
+        download_id = await self._seed_processing_download(source_path)
+
+        sync_calls = [0]
+
+        async def hooked_sync_schedule_status(session, did, status):
+            sync_calls[0] += 1
+            if sync_calls[0] == 1:
+                raise asyncio.CancelledError()
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with patch("services.download_manager.async_session_maker", patched_session_maker), \
+                 patch.object(self.manager, "_needs_post_processing", return_value=True), \
+                 patch.object(self.manager, "_post_process", new_callable=AsyncMock,
+                              return_value=(completed_path, [])), \
+                 patch.object(self.manager, "_select_final_path", return_value=completed_path), \
+                 patch.object(self.manager, "_move_to_completed", return_value=completed_path), \
+                 patch.object(self.manager, "_cleanup_working_files"), \
+                 patch.object(self.manager, "_sync_schedule_status",
+                              side_effect=hooked_sync_schedule_status), \
+                 patch.object(self.manager, "_resolve_completed_folder",
+                              return_value=str(completed_dir)), \
+                 patch.object(self.manager, "_resolve_download_folder",
+                              return_value=self.tmpdir), \
+                 patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+                 patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock), \
+                 patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock):
+                await self.manager._execute_post_process(download_id)
+        except asyncio.CancelledError:
+            pass
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+
+        # This assertion FAILS on the current codebase.
+        # The handler re-selects via the same session (identity map returns COMPLETED
+        # in memory), skips the CANCELLED branch, and does not commit. The session
+        # exits with a rollback, leaving the row stuck as PROCESSING.
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.COMPLETED.value,
+            "Post-processing download must be COMPLETED after CancelledError fires "
+            "after _move_to_completed. Currently the uncommitted COMPLETED is rolled "
+            "back on session exit, leaving the row stuck as PROCESSING.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_post_process_cancel_queued_cleanup.py
+++ b/backend/tests/test_post_process_cancel_queued_cleanup.py
@@ -1,0 +1,133 @@
+"""
+Regression test: cancelling a PROCESSING download that is queued but not yet started
+in post-processing must delete the source file from the download folder.
+
+When a download completes the download phase, _execute_download sets status=PROCESSING
+and puts the download_id in _post_queue, then returns. If cancel_download() is called
+before process_post_queue picks up the job, the id is not in _active_post so no
+task.cancel() fires. cancel_download writes CANCELLED to the DB and returns True.
+
+Later, process_post_queue picks up the id, finds it in _cancelled, discards it, and
+continues; _execute_post_process is never started. No file cleanup occurs.
+
+Contrast: _execute_download's CancelledError handler explicitly calls
+os.unlink(download.output_path) when a download is cancelled mid-flight.
+The post-processing cancel path has no equivalent.
+
+Result: the source .ts sits in the download folder indefinitely, invisible to the app
+(status=CANCELLED), silently consuming disk space. On Unraid installs with limited
+storage this can fill the drive without any user-visible indication.
+
+Expected fix: cancel_download or the process_post_queue skip path should delete
+download.output_path when cancelling a queued-not-started post-processing job.
+"""
+
+import asyncio
+import contextlib
+import sys
+import tempfile
+import shutil
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class PostProcessQueuedCancelCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_processing_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            dl = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=100.0,
+            )
+            session.add(dl)
+            await session.commit()
+            await session.refresh(dl)
+            return dl.id
+
+    async def test_cancel_queued_post_process_deletes_source_file(self):
+        """
+        Cancelling a PROCESSING download not yet in _active_post must clean up the source file.
+
+        This test FAILS on the current codebase: cancel_download returns True and the
+        post_queue skip path discards the job without deleting the .ts file.
+        """
+        source_ts = Path(self.tmpdir) / "show.ts"
+        source_ts.write_bytes(b"fake ts content")
+
+        download_id = await self._seed_processing_download(str(source_ts))
+
+        # Put the id in _post_queue as if _execute_download just completed.
+        await self.manager._post_queue.put(download_id)
+
+        # The download is NOT in _active_post (post-processing has not started).
+        assert download_id not in self.manager._active_post
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        with patch("services.download_manager.async_session_maker", patched_session_maker), \
+             patch.object(self.manager, "_sync_schedule_status", new_callable=AsyncMock), \
+             patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+             patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock):
+            result = await self.manager.cancel_download(download_id)
+
+            self.assertTrue(result, "cancel_download must return True for a PROCESSING download.")
+
+            # Run the real process_post_queue inside the patch context so
+            # _delete_cancelled_post_file reaches the test's in-memory DB.
+            task = asyncio.create_task(self.manager.process_post_queue())
+            await asyncio.sleep(0.1)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # This assertion FAILS on the current codebase.
+        # The source .ts remains on disk because no cleanup runs when the
+        # queued post-processing job is skipped due to cancellation.
+        self.assertFalse(
+            source_ts.exists(),
+            "Source .ts file must be deleted when a queued-not-started post-processing "
+            "job is cancelled. Currently the file is left on disk indefinitely.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

**Bug 1 (HIGH):** Enable transcode, start a download, let it finish transcoding, then cancel right as it finishes. The transcoded file lands in your completed folder, but the Downloads page shows the recording as CANCELLED (or it disappears). The file is permanently orphaned. There is no way to find it through the app.

**Bug 2 (MEDIUM):** Enable transcode, start a download, and cancel it as soon as the status switches to PROCESSING (before the transcode starts). The app correctly shows CANCELLED, but the original .ts file is silently left in your download folder consuming disk space. On Unraid with limited storage this can quietly fill the drive.

## What changed

**Bug 1:** In `_execute_post_process`, the `asyncio.CancelledError` handler re-selects the download from the same SQLAlchemy session. Because the session's identity map already holds the in-memory `COMPLETED` object (set just before the cancel arrived), the re-select returns that COMPLETED object. The old guard only handled `PENDING/DOWNLOADING/PROCESSING`, so it skipped the CANCELLED branch entirely and did nothing. The session then exited with a rollback, leaving the row stuck as PROCESSING while the file sat in the completed folder.

Fix: added a `COMPLETED` branch in the handler that commits the already-set completed state, exactly as the equivalent guard in `_execute_download` does.

**Bug 2:** When `cancel_download()` is called for a download that has finished downloading (status=PROCESSING) but whose post-processing task has not started yet (id is in `_post_queue` but not `_active_post`), no `task.cancel()` fires. `cancel_download` writes CANCELLED to the DB and returns. Later, `process_post_queue` picks up the id, finds it in `_cancelled`, and discards it with no file cleanup.

Fix: added `_delete_cancelled_post_file()` and called it from the `process_post_queue` cancel-skip path. It reads `output_path` from the DB and deletes the file if it exists, mirroring the `os.unlink()` that `_execute_download`'s cancel handler already does.

## How it was tested

Two new regression tests, both verified to fail before this commit and pass after:

**Before (Bug 1):** `AssertionError: 'processing' != 'completed'` (the row was left PROCESSING after rollback)

**Before (Bug 2):** `AssertionError: True is not false` (the .ts file still existed after cancel)

**After:**
```
test_cancel_after_post_process_move_preserves_completed_status ... ok
test_cancel_queued_post_process_deletes_source_file ... ok

Ran 2 tests in 0.199s
OK
```

Full suite: 667 tests, all pass.

This PR supersedes PR #276 (which added the same tests as `@unittest.expectedFailure` without the fix). That PR can be closed.

Closes TODO threads: 1513727017349021727 (HIGH) and 1513727054909014057 (MEDIUM)