### PR TITLE
Failing tests: EPG missing TZ abbreviations + stale titles on provider update

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -22,6 +22,11 @@ from services.log_stream import backend_log_stream
 
 logger = logging.getLogger(__name__)
 
+
+def _program_insert_stmt():
+    return insert(EPGProgram).prefix_with("OR IGNORE")
+
+
 # Named entities valid in XML (no DTD required). Any other &name; in XMLTV
 # descriptions comes from HTML-origin feeds and will cause ET.iterparse to
 # raise ParseError. Replace them with &amp;name; before parsing.
@@ -263,7 +268,7 @@ class EPGIngestManager:
         inserted = 0
         password = resolve_account_password(account)
         client = XtreamClient(account.server_url, account.username, password)
-        insert_stmt = insert(EPGProgram).prefix_with("OR IGNORE")
+        insert_stmt = _program_insert_stmt()
         try:
             channels = await client.get_live_streams()
             catchup_channels = [

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -10,7 +10,8 @@ from typing import Dict, Iterable, Optional
 from xml.etree.ElementTree import Element
 
 from defusedxml import ElementTree as ET
-from sqlalchemy import delete, insert, select, func
+from sqlalchemy import delete, select, func
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from config import settings as app_settings
 from database import async_session_maker
@@ -24,7 +25,15 @@ logger = logging.getLogger(__name__)
 
 
 def _program_insert_stmt():
-    return insert(EPGProgram).prefix_with("OR IGNORE")
+    stmt = sqlite_insert(EPGProgram)
+    return stmt.on_conflict_do_update(
+        index_elements=["account_id", "epg_id"],
+        set_={
+            "title": stmt.excluded.title,
+            "description": stmt.excluded.description,
+            "category": stmt.excluded.category,
+        },
+    )
 
 
 # Named entities valid in XML (no DTD required). Any other &name; in XMLTV
@@ -56,14 +65,20 @@ def _sanitize_html_entities(data: bytes) -> bytes:
 _NAMED_TZ_OFFSETS: Dict[str, int] = {
     "UTC": 0, "GMT": 0,
     "EST": -300, "EDT": -240,
+    "AST": -240, "ADT": -180,
+    "NST": -210, "NDT": -150,
     "CST": -360, "CDT": -300,
     "MST": -420, "MDT": -360,
     "PST": -480, "PDT": -420,
     "WET": 0, "WEST": 60, "BST": 60,
     "CET": 60, "CEST": 120,
     "EET": 120, "EEST": 180,
+    "MSK": 180,
     "IST": 330,
-    "HKT": 480, "JST": 540, "AEST": 600, "AEDT": 660,
+    "SGT": 480, "HKT": 480,
+    "JST": 540, "KST": 540,
+    "ACST": 570, "ACDT": 630,
+    "AEST": 600, "AEDT": 660,
     "NZST": 720, "NZDT": 780,
 }
 

--- a/backend/tests/test_epg_stale_title_on_provider_update.py
+++ b/backend/tests/test_epg_stale_title_on_provider_update.py
@@ -17,15 +17,15 @@ or a typo corrected by the provider after initial ingest). Re-downloading or
 re-scheduling based on the stale guide entry records the wrong content with
 the wrong filename.
 
-Root cause: epg_ingest_manager.py line 244
-    insert_stmt = insert(EPGProgram).prefix_with("OR IGNORE")
+Root cause: epg_ingest_manager._program_insert_stmt()
+    returns insert(EPGProgram).prefix_with("OR IGNORE")
 
 There is no UPDATE or ON CONFLICT DO UPDATE path. Once a row is in the DB,
 its title and description are frozen until the row expires.
 
-Fix required: change the insert to use ON CONFLICT DO UPDATE SET title=...,
-description=..., category=... (leaving start_time, end_time, channel_id
-unchanged since those form the identity key).
+Fix required: change _program_insert_stmt() to use ON CONFLICT DO UPDATE SET
+title=..., description=..., category=... (leaving start_time, end_time,
+channel_id unchanged since those form the identity key).
 """
 import sys
 import unittest
@@ -37,12 +37,12 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from sqlalchemy import select
-from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 import models  # import all models so Base.metadata includes every table
 from database import Base
 from models import EPGProgram
+from services.epg_ingest_manager import _program_insert_stmt
 
 
 def _program_row(epg_id, title, description="", account_id=1):
@@ -70,16 +70,6 @@ def _program_row(epg_id, title, description="", account_id=1):
     }
 
 
-def _insert_stmt():
-    """Build the same statement as epg_ingest_manager.py line 244.
-
-    NOTE: when that line is changed (e.g. to ON CONFLICT DO UPDATE SET
-    title=...), update this helper to match so the tests reflect the
-    production semantics.
-    """
-    return insert(EPGProgram).prefix_with("OR IGNORE")
-
-
 class StaleTitleOnProviderUpdateTests(unittest.IsolatedAsyncioTestCase):
     """INSERT OR IGNORE silently discards provider-corrected titles and descriptions."""
 
@@ -97,7 +87,7 @@ class StaleTitleOnProviderUpdateTests(unittest.IsolatedAsyncioTestCase):
     async def _insert(self, rows):
         async with self.session_maker() as session:
             async with session.begin():
-                await session.execute(_insert_stmt(), rows)
+                await session.execute(_program_insert_stmt(), rows)
 
     async def _fetch(self, account_id, epg_id):
         async with self.session_maker() as session:
@@ -135,7 +125,7 @@ class StaleTitleOnProviderUpdateTests(unittest.IsolatedAsyncioTestCase):
             f"Expected updated title 'Live: World Cup Final', got '{prog.title}'. "
             "INSERT OR IGNORE silently discards provider-corrected titles. "
             "Once a row is inserted, its title is frozen until the row expires. "
-            "Fix: change epg_ingest_manager.py line 244 to ON CONFLICT DO UPDATE "
+            "Fix: change _program_insert_stmt() in epg_ingest_manager.py to ON CONFLICT DO UPDATE "
             "SET title=excluded.title, description=excluded.description.",
         )
 

--- a/backend/tests/test_epg_stale_title_on_provider_update.py
+++ b/backend/tests/test_epg_stale_title_on_provider_update.py
@@ -1,9 +1,8 @@
 """
-Regression test for EPG title/description silently staying stale after a
-provider corrects its guide data.
+Regression test: EPG titles and descriptions frozen forever when provider corrects metadata.
 
-Bug (MEDIUM): EPGProgram rows are inserted with INSERT OR IGNORE against a
-unique index on (account_id, epg_id), where
+Bug (MEDIUM): EPGProgram rows are inserted with INSERT OR IGNORE against a unique
+index on (account_id, epg_id), where
     epg_id = f"{stream_id}:{start_timestamp}:{stop_timestamp}"
 
 When a provider corrects a program title or description (same channel, same
@@ -24,68 +23,93 @@ Root cause: epg_ingest_manager.py line 244
 There is no UPDATE or ON CONFLICT DO UPDATE path. Once a row is in the DB,
 its title and description are frozen until the row expires.
 
-Fix required: change the insert to ON CONFLICT DO UPDATE SET title=...,
+Fix required: change the insert to use ON CONFLICT DO UPDATE SET title=...,
 description=..., category=... (leaving start_time, end_time, channel_id
 unchanged since those form the identity key).
 """
-import sqlite3
 import sys
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
+from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-def _make_db():
-    """Return an in-memory SQLite connection with the minimal EPGProgram schema."""
-    conn = sqlite3.connect(":memory:")
-    conn.execute("""
-        CREATE TABLE epg_programs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            account_id INTEGER NOT NULL,
-            epg_id TEXT NOT NULL,
-            channel_id TEXT NOT NULL,
-            title TEXT,
-            description TEXT,
-            start_time REAL,
-            end_time REAL,
-            UNIQUE(account_id, epg_id)
+import models  # import all models so Base.metadata includes every table
+from database import Base
+from models import EPGProgram
+
+
+def _program_row(epg_id, title, description="", account_id=1):
+    """Return a minimal EPGProgram dict for bulk insert, mirroring the
+    batch dicts built in epg_ingest_manager.refresh_epg_for_account()."""
+    start = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 1, 13, 0, 0, tzinfo=timezone.utc)
+    return {
+        "account_id": account_id,
+        "epg_id": epg_id,
+        "channel_id": "101",
+        "channel_name": "Test Channel",
+        "title": title,
+        "description": description,
+        "category": None,
+        "start_time": start,
+        "end_time": end,
+        "start_timestamp": int(start.timestamp()),
+        "stop_timestamp": int(end.timestamp()),
+        "duration_minutes": 60,
+        "has_archive": True,
+        "provider_start": None,
+        "provider_stop": None,
+        "xmltv_id": None,
+    }
+
+
+def _insert_stmt():
+    """Build the same statement as epg_ingest_manager.py line 244.
+
+    NOTE: when that line is changed (e.g. to ON CONFLICT DO UPDATE SET
+    title=...), update this helper to match so the tests reflect the
+    production semantics.
+    """
+    return insert(EPGProgram).prefix_with("OR IGNORE")
+
+
+class StaleTitleOnProviderUpdateTests(unittest.IsolatedAsyncioTestCase):
+    """INSERT OR IGNORE silently discards provider-corrected titles and descriptions."""
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_maker = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
         )
-    """)
-    conn.commit()
-    return conn
 
+    async def asyncTearDown(self):
+        await self.engine.dispose()
 
-def _insert_or_ignore(conn, account_id, epg_id, title, description=""):
-    conn.execute(
-        "INSERT OR IGNORE INTO epg_programs "
-        "(account_id, epg_id, channel_id, title, description, start_time, end_time) "
-        "VALUES (?, ?, 'ch1', ?, ?, 0.0, 3600.0)",
-        (account_id, epg_id, title, description),
-    )
-    conn.commit()
+    async def _insert(self, rows):
+        async with self.session_maker() as session:
+            async with session.begin():
+                await session.execute(_insert_stmt(), rows)
 
+    async def _fetch(self, account_id, epg_id):
+        async with self.session_maker() as session:
+            result = await session.execute(
+                select(EPGProgram).where(
+                    EPGProgram.account_id == account_id,
+                    EPGProgram.epg_id == epg_id,
+                )
+            )
+            return result.scalar_one_or_none()
 
-def _fetch_title(conn, account_id, epg_id):
-    row = conn.execute(
-        "SELECT title FROM epg_programs WHERE account_id=? AND epg_id=?",
-        (account_id, epg_id),
-    ).fetchone()
-    return row[0] if row else None
-
-
-class StaleTitleOnProviderUpdateTests(unittest.TestCase):
-    """INSERT OR IGNORE silently discards provider-corrected titles."""
-
-    def setUp(self):
-        self.conn = _make_db()
-
-    def tearDown(self):
-        self.conn.close()
-
-    def test_corrected_title_visible_after_provider_update(self):
+    async def test_corrected_title_visible_after_provider_update(self):
         """After a provider corrects a program title, the next EPG refresh must
         store the updated title in the guide.
 
@@ -96,61 +120,63 @@ class StaleTitleOnProviderUpdateTests(unittest.TestCase):
 
         Expected behavior: second ingest with the corrected title overwrites the
         stale value; the guide reflects what the provider currently says.
+
+        This test FAILS while the bug is present and passes after the fix.
         """
         epg_id = "101:1717228800:1717232400"
-        _insert_or_ignore(self.conn, 1, epg_id, "Placeholder Title")
-        _insert_or_ignore(self.conn, 1, epg_id, "Live: World Cup Final")
+        await self._insert([_program_row(epg_id, "Placeholder Title")])
+        await self._insert([_program_row(epg_id, "Live: World Cup Final")])
 
-        title = _fetch_title(self.conn, 1, epg_id)
+        prog = await self._fetch(1, epg_id)
+        self.assertIsNotNone(prog, "Row must exist after first insert.")
         self.assertEqual(
-            title,
+            prog.title,
             "Live: World Cup Final",
-            f"Expected updated title 'Live: World Cup Final', got '{title}'. "
+            f"Expected updated title 'Live: World Cup Final', got '{prog.title}'. "
             "INSERT OR IGNORE silently discards provider-corrected titles. "
             "Once a row is inserted, its title is frozen until the row expires. "
-            "Fix: use ON CONFLICT DO UPDATE SET title=excluded.title, "
-            "description=excluded.description.",
+            "Fix: change epg_ingest_manager.py line 244 to ON CONFLICT DO UPDATE "
+            "SET title=excluded.title, description=excluded.description.",
         )
 
-    def test_corrected_description_visible_after_provider_update(self):
+    async def test_corrected_description_visible_after_provider_update(self):
         """After a provider corrects a program description, it must be stored.
 
         Bug: same INSERT OR IGNORE path silently discards description updates.
         """
         epg_id = "101:1717228800:1717232400"
-        _insert_or_ignore(self.conn, 1, epg_id, "Movie Night", "TBA")
-        _insert_or_ignore(self.conn, 1, epg_id, "Movie Night", "A classic thriller from 1978.")
+        await self._insert([_program_row(epg_id, "Movie Night", "TBA")])
+        await self._insert([_program_row(epg_id, "Movie Night", "A classic thriller from 1978.")])
 
-        row = self.conn.execute(
-            "SELECT description FROM epg_programs WHERE account_id=1 AND epg_id=?",
-            (epg_id,),
-        ).fetchone()
-        description = row[0] if row else None
+        prog = await self._fetch(1, epg_id)
         self.assertEqual(
-            description,
+            prog.description,
             "A classic thriller from 1978.",
-            f"Expected updated description, got '{description}'. "
+            f"Expected updated description, got '{prog.description}'. "
             "INSERT OR IGNORE silently discards provider description updates.",
         )
 
-    def test_first_insert_still_creates_row(self):
+    async def test_first_insert_still_creates_row(self):
         """Sanity: a new epg_id must still be inserted (regression guard)."""
         epg_id = "101:1717315200:1717318800"
-        _insert_or_ignore(self.conn, 1, epg_id, "News at Ten")
-        title = _fetch_title(self.conn, 1, epg_id)
-        self.assertEqual(title, "News at Ten", "New row was not inserted.")
+        await self._insert([_program_row(epg_id, "News at Ten")])
+        prog = await self._fetch(1, epg_id)
+        self.assertIsNotNone(prog, "New row must exist after first insert.")
+        self.assertEqual(prog.title, "News at Ten")
 
-    def test_different_account_can_have_same_epg_id(self):
+    async def test_different_account_can_have_same_epg_id(self):
         """Two accounts can have rows with the same epg_id (regression guard).
-        Unique constraint is (account_id, epg_id), not just epg_id.
+        The unique constraint is (account_id, epg_id), not just epg_id.
         """
         epg_id = "101:1717228800:1717232400"
-        _insert_or_ignore(self.conn, 1, epg_id, "Account 1 Title")
-        _insert_or_ignore(self.conn, 2, epg_id, "Account 2 Title")
-        title_1 = _fetch_title(self.conn, 1, epg_id)
-        title_2 = _fetch_title(self.conn, 2, epg_id)
-        self.assertEqual(title_1, "Account 1 Title")
-        self.assertEqual(title_2, "Account 2 Title")
+        await self._insert([_program_row(epg_id, "Account 1 Title", account_id=1)])
+        await self._insert([_program_row(epg_id, "Account 2 Title", account_id=2)])
+        prog1 = await self._fetch(1, epg_id)
+        prog2 = await self._fetch(2, epg_id)
+        self.assertIsNotNone(prog1)
+        self.assertIsNotNone(prog2)
+        self.assertEqual(prog1.title, "Account 1 Title")
+        self.assertEqual(prog2.title, "Account 2 Title")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_epg_stale_title_on_provider_update.py
+++ b/backend/tests/test_epg_stale_title_on_provider_update.py
@@ -1,0 +1,157 @@
+"""
+Regression test for EPG title/description silently staying stale after a
+provider corrects its guide data.
+
+Bug (MEDIUM): EPGProgram rows are inserted with INSERT OR IGNORE against a
+unique index on (account_id, epg_id), where
+    epg_id = f"{stream_id}:{start_timestamp}:{stop_timestamp}"
+
+When a provider corrects a program title or description (same channel, same
+air time, different metadata), the OR IGNORE clause silently discards the
+update. The stale title persists until the row's end_time falls below the
+archive cutoff and is cleaned up in the next refresh cycle, which can be
+days away for channels with long archive windows.
+
+User impact: a user sees the wrong program title in the guide (e.g. a news
+special mislabeled by the provider, a live event with a placeholder title,
+or a typo corrected by the provider after initial ingest). Re-downloading or
+re-scheduling based on the stale guide entry records the wrong content with
+the wrong filename.
+
+Root cause: epg_ingest_manager.py line 244
+    insert_stmt = insert(EPGProgram).prefix_with("OR IGNORE")
+
+There is no UPDATE or ON CONFLICT DO UPDATE path. Once a row is in the DB,
+its title and description are frozen until the row expires.
+
+Fix required: change the insert to ON CONFLICT DO UPDATE SET title=...,
+description=..., category=... (leaving start_time, end_time, channel_id
+unchanged since those form the identity key).
+"""
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def _make_db():
+    """Return an in-memory SQLite connection with the minimal EPGProgram schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE epg_programs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id INTEGER NOT NULL,
+            epg_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            start_time REAL,
+            end_time REAL,
+            UNIQUE(account_id, epg_id)
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert_or_ignore(conn, account_id, epg_id, title, description=""):
+    conn.execute(
+        "INSERT OR IGNORE INTO epg_programs "
+        "(account_id, epg_id, channel_id, title, description, start_time, end_time) "
+        "VALUES (?, ?, 'ch1', ?, ?, 0.0, 3600.0)",
+        (account_id, epg_id, title, description),
+    )
+    conn.commit()
+
+
+def _fetch_title(conn, account_id, epg_id):
+    row = conn.execute(
+        "SELECT title FROM epg_programs WHERE account_id=? AND epg_id=?",
+        (account_id, epg_id),
+    ).fetchone()
+    return row[0] if row else None
+
+
+class StaleTitleOnProviderUpdateTests(unittest.TestCase):
+    """INSERT OR IGNORE silently discards provider-corrected titles."""
+
+    def setUp(self):
+        self.conn = _make_db()
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_corrected_title_visible_after_provider_update(self):
+        """After a provider corrects a program title, the next EPG refresh must
+        store the updated title in the guide.
+
+        Bug: INSERT OR IGNORE keeps the first-inserted title forever. A program
+        initially stored as 'Placeholder Title' cannot have its title corrected
+        to 'Live: World Cup Final' even after the provider fixes its guide data.
+        The user sees 'Placeholder Title' until the row expires (could be days).
+
+        Expected behavior: second ingest with the corrected title overwrites the
+        stale value; the guide reflects what the provider currently says.
+        """
+        epg_id = "101:1717228800:1717232400"
+        _insert_or_ignore(self.conn, 1, epg_id, "Placeholder Title")
+        _insert_or_ignore(self.conn, 1, epg_id, "Live: World Cup Final")
+
+        title = _fetch_title(self.conn, 1, epg_id)
+        self.assertEqual(
+            title,
+            "Live: World Cup Final",
+            f"Expected updated title 'Live: World Cup Final', got '{title}'. "
+            "INSERT OR IGNORE silently discards provider-corrected titles. "
+            "Once a row is inserted, its title is frozen until the row expires. "
+            "Fix: use ON CONFLICT DO UPDATE SET title=excluded.title, "
+            "description=excluded.description.",
+        )
+
+    def test_corrected_description_visible_after_provider_update(self):
+        """After a provider corrects a program description, it must be stored.
+
+        Bug: same INSERT OR IGNORE path silently discards description updates.
+        """
+        epg_id = "101:1717228800:1717232400"
+        _insert_or_ignore(self.conn, 1, epg_id, "Movie Night", "TBA")
+        _insert_or_ignore(self.conn, 1, epg_id, "Movie Night", "A classic thriller from 1978.")
+
+        row = self.conn.execute(
+            "SELECT description FROM epg_programs WHERE account_id=1 AND epg_id=?",
+            (epg_id,),
+        ).fetchone()
+        description = row[0] if row else None
+        self.assertEqual(
+            description,
+            "A classic thriller from 1978.",
+            f"Expected updated description, got '{description}'. "
+            "INSERT OR IGNORE silently discards provider description updates.",
+        )
+
+    def test_first_insert_still_creates_row(self):
+        """Sanity: a new epg_id must still be inserted (regression guard)."""
+        epg_id = "101:1717315200:1717318800"
+        _insert_or_ignore(self.conn, 1, epg_id, "News at Ten")
+        title = _fetch_title(self.conn, 1, epg_id)
+        self.assertEqual(title, "News at Ten", "New row was not inserted.")
+
+    def test_different_account_can_have_same_epg_id(self):
+        """Two accounts can have rows with the same epg_id (regression guard).
+        Unique constraint is (account_id, epg_id), not just epg_id.
+        """
+        epg_id = "101:1717228800:1717232400"
+        _insert_or_ignore(self.conn, 1, epg_id, "Account 1 Title")
+        _insert_or_ignore(self.conn, 2, epg_id, "Account 2 Title")
+        title_1 = _fetch_title(self.conn, 1, epg_id)
+        title_2 = _fetch_title(self.conn, 2, epg_id)
+        self.assertEqual(title_1, "Account 1 Title")
+        self.assertEqual(title_2, "Account 2 Title")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_xmltv_missing_tz_abbreviations.py
+++ b/backend/tests/test_epg_xmltv_missing_tz_abbreviations.py
@@ -1,0 +1,239 @@
+"""
+Regression tests for missing timezone abbreviations in _NAMED_TZ_OFFSETS.
+
+Bug (MEDIUM-HIGH): _NAMED_TZ_OFFSETS only covers 21 Western-centric timezone
+abbreviations. Common abbreviations used by Australian (ACST/ACDT), Newfoundland
+(NST/NDT), Russian (MSK), Singaporean (SGT), Korean (KST), and Atlantic Canadian
+(AST/ADT) providers are absent. When _parse_xmltv_time encounters an unknown named
+timezone, the datetime.strptime(tz_part, "%z") call raises ValueError, and the
+except clause at line 677 silently returns dt.replace(tzinfo=timezone.utc),
+storing the program offset by hours.
+
+A provider serving "20260601120000 ACST" stores the program as 12:00 UTC instead
+of 02:30 UTC, a 9.5-hour error. Every scheduled recording for that channel fires
+against the wrong content segment.
+
+Note: the previous named-timezone fix (PR that addressed EST/PST/CET/BST etc.)
+only added abbreviations already known to the developer. The half-hour offset zones
+(ACST +9:30, NST -3:30, NDT -2:30, ACDT +10:30) and several full-hour zones
+(MSK, SGT, KST, AST, ADT) were not included.
+
+Root cause: epg_ingest_manager.py line 677
+  except ValueError:
+      return dt.replace(tzinfo=timezone.utc)
+
+Fix required: add ACST, ACDT, NST, NDT, MSK, SGT, KST, AST, ADT (and others)
+to _NAMED_TZ_OFFSETS.
+"""
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class MissingTimezoneAbbreviationTests(unittest.TestCase):
+    """Each test asserts the correct UTC equivalent; all fail before the fix
+    because the unknown abbreviation silently becomes UTC."""
+
+    def setUp(self):
+        self.manager = EPGIngestManager.__new__(EPGIngestManager)
+
+    # ------------------------------------------------------------------
+    # Australia Central (half-hour offsets)
+    # ------------------------------------------------------------------
+
+    def test_acst_returns_utc_minus_9h30m(self):
+        """'20260601120000 ACST' (UTC+9:30) must be stored as 02:30 UTC.
+
+        Bug: ACST not in _NAMED_TZ_OFFSETS. strptime raises ValueError.
+        Fallback stores 12:00 UTC instead of 02:30 UTC: 9.5-hour error.
+        Australian Central providers (SA, NT) have every program shifted.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 ACST")
+        self.assertIsNotNone(result, "ACST timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 2, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"ACST noon should be 02:30 UTC, got {result_utc.isoformat()}. "
+            "ACST (UTC+9:30) is missing from _NAMED_TZ_OFFSETS and silently "
+            "coerced to UTC, producing a 9.5-hour shift.",
+        )
+
+    def test_acdt_returns_utc_minus_10h30m(self):
+        """'20260101120000 ACDT' (UTC+10:30) must be stored as 01:30 UTC.
+
+        Bug: ACDT not in _NAMED_TZ_OFFSETS. South Australia and NT summer time
+        shifts all programs 10.5 hours from where they should be.
+        """
+        result = self.manager._parse_xmltv_time("20260101120000 ACDT")
+        self.assertIsNotNone(result, "ACDT timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"ACDT noon should be 01:30 UTC, got {result_utc.isoformat()}. "
+            "ACDT (UTC+10:30) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    # ------------------------------------------------------------------
+    # Newfoundland (half-hour offsets)
+    # ------------------------------------------------------------------
+
+    def test_nst_returns_utc_plus_3h30m(self):
+        """'20260601120000 NST' (UTC-3:30) must be stored as 15:30 UTC.
+
+        Bug: NST not in _NAMED_TZ_OFFSETS. Prior fixes (PRs #269, #274)
+        corrected Newfoundland's numeric offset (+5:30 style) but did not
+        add 'NST' as a named abbreviation. Providers using 'NST' in XMLTV
+        still silently get UTC: 3.5-hour error, wrong content recorded.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 NST")
+        self.assertIsNotNone(result, "NST timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 15, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"NST noon should be 15:30 UTC, got {result_utc.isoformat()}. "
+            "NST (UTC-3:30) is missing from _NAMED_TZ_OFFSETS. "
+            "PRs #269/#274 fixed numeric +5:30 style but not the named form.",
+        )
+
+    def test_ndt_returns_utc_plus_2h30m(self):
+        """'20260601120000 NDT' (UTC-2:30) must be stored as 14:30 UTC.
+
+        Bug: NDT not in _NAMED_TZ_OFFSETS. Newfoundland Daylight Time.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 NDT")
+        self.assertIsNotNone(result, "NDT timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 14, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"NDT noon should be 14:30 UTC, got {result_utc.isoformat()}. "
+            "NDT (UTC-2:30) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    # ------------------------------------------------------------------
+    # Full-hour offsets
+    # ------------------------------------------------------------------
+
+    def test_msk_returns_utc_minus_3h(self):
+        """'20260601120000 MSK' (UTC+3) must be stored as 09:00 UTC.
+
+        Bug: MSK not in _NAMED_TZ_OFFSETS. Russian providers using MSK in
+        XMLTV have all programs shifted 3 hours.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 MSK")
+        self.assertIsNotNone(result, "MSK timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"MSK noon should be 09:00 UTC, got {result_utc.isoformat()}. "
+            "MSK (UTC+3) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    def test_sgt_returns_utc_minus_8h(self):
+        """'20260601120000 SGT' (UTC+8) must be stored as 04:00 UTC.
+
+        Bug: SGT not in _NAMED_TZ_OFFSETS. Singapore providers have all
+        programs shifted 8 hours.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 SGT")
+        self.assertIsNotNone(result, "SGT timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 4, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"SGT noon should be 04:00 UTC, got {result_utc.isoformat()}. "
+            "SGT (UTC+8) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    def test_kst_returns_utc_minus_9h(self):
+        """'20260601120000 KST' (UTC+9) must be stored as 03:00 UTC.
+
+        Bug: KST not in _NAMED_TZ_OFFSETS. Korean providers have all
+        programs shifted 9 hours.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 KST")
+        self.assertIsNotNone(result, "KST timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 3, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"KST noon should be 03:00 UTC, got {result_utc.isoformat()}. "
+            "KST (UTC+9) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    def test_ast_returns_utc_plus_4h(self):
+        """'20260601120000 AST' (UTC-4) must be stored as 16:00 UTC.
+
+        Bug: AST not in _NAMED_TZ_OFFSETS. Atlantic Standard Time is used by
+        Atlantic Canadian providers (New Brunswick, Nova Scotia, PEI).
+        Programs shift 4 hours from intended time.
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 AST")
+        self.assertIsNotNone(result, "AST timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 16, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"AST noon should be 16:00 UTC, got {result_utc.isoformat()}. "
+            "AST (UTC-4) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    def test_adt_returns_utc_plus_3h(self):
+        """'20260601120000 ADT' (UTC-3) must be stored as 15:00 UTC.
+
+        Bug: ADT not in _NAMED_TZ_OFFSETS. Atlantic Daylight Time (Atlantic
+        Canada summer).
+        """
+        result = self.manager._parse_xmltv_time("20260601120000 ADT")
+        self.assertIsNotNone(result, "ADT timestamp returned None.")
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 15, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected_utc,
+            f"ADT noon should be 15:00 UTC, got {result_utc.isoformat()}. "
+            "ADT (UTC-3) is missing from _NAMED_TZ_OFFSETS.",
+        )
+
+    # ------------------------------------------------------------------
+    # Regression guard: existing abbreviations must still work
+    # ------------------------------------------------------------------
+
+    def test_ist_still_correct(self):
+        """IST (UTC+5:30) must still return the correct value after the fix."""
+        result = self.manager._parse_xmltv_time("20260601120000 IST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 6, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected_utc)
+
+    def test_jst_still_correct(self):
+        """JST (UTC+9) must still return the correct value."""
+        result = self.manager._parse_xmltv_time("20260601120000 JST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected_utc = datetime(2026, 6, 1, 3, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected_utc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes two bugs in EPG data handling.

**Bug 1: Missing timezone abbreviations cause multi-hour program shifts**
ACST, ACDT, NST, NDT, MSK, SGT, KST, AST, and ADT were not in `_NAMED_TZ_OFFSETS`. When a provider uses one of these in XMLTV, the parser hit a `ValueError` and silently stored the program as UTC instead of the correct local time. Australian Central (ACST UTC+9:30) programs were shifted 9.5 hours. Newfoundland (NST UTC-3:30) programs shifted 3.5 hours. Every scheduled recording for those channels would grab the wrong content.

**Bug 2: Provider-corrected titles and descriptions are silently discarded**
EPG programs were inserted with `INSERT OR IGNORE`. If a provider corrected a title or description after initial ingest (e.g. a placeholder becoming "Live: World Cup Final"), the update was silently dropped. The stale title persisted until the row expired, which can be days for channels with long archive windows. Now uses `ON CONFLICT DO UPDATE SET title, description, category` so the guide always reflects what the provider currently says.

## Changes

- `backend/services/epg_ingest_manager.py`: Added ACST (+9:30), ACDT (+10:30), NST (-3:30), NDT (-2:30), MSK (+3), SGT (+8), KST (+9), AST (-4), ADT (-3) to `_NAMED_TZ_OFFSETS`.
- `backend/services/epg_ingest_manager.py`: Changed `_program_insert_stmt()` from `INSERT OR IGNORE` to `ON CONFLICT(account_id, epg_id) DO UPDATE SET title, description, category`.

## Before / After

**Before (TZ bug):**
```
# Provider sends: 20260601120000 ACST
# _parse_xmltv_time stores: 2026-06-01T12:00:00+00:00  (wrong, 9.5h off)
# test_acst_returns_utc_minus_9h30m: FAIL
# AssertionError: 2026-06-01T12:00:00+00:00 != 2026-06-01T02:30:00+00:00
```

**After (TZ bug):**
```
# Provider sends: 20260601120000 ACST
# _parse_xmltv_time stores: 2026-06-01T02:30:00+00:00  (correct)
# test_acst_returns_utc_minus_9h30m: PASS
```

**Before (stale title bug):**
```
# First ingest:  title = "Placeholder Title"   -> stored
# Second ingest: title = "Live: World Cup Final" -> silently discarded (OR IGNORE)
# test_corrected_title_visible_after_provider_update: FAIL
# AssertionError: 'Placeholder Title' != 'Live: World Cup Final'
```

**After (stale title bug):**
```
# First ingest:  title = "Placeholder Title"   -> stored
# Second ingest: title = "Live: World Cup Final" -> stored (ON CONFLICT DO UPDATE)
# test_corrected_title_visible_after_provider_update: PASS
```

## Test results

```
Ran 692 tests in 3.177s
OK
```
All 11 previously failing tests now pass. No regressions.

## How to test

1. Check out this branch and run `python -m unittest discover -s tests` from `backend/`. All 692 tests pass.
2. To verify the TZ fix manually: set up an account with an ACST or NST XMLTV feed and confirm programs appear at the correct local times.
3. To verify the stale-title fix: force an EPG refresh after a provider corrects a program title. The guide should reflect the corrected title within one refresh cycle (default 6 hours or via Settings > EPG > Refresh Now).