### PR TITLE
fix: show ComSkip settings panel when binary is installed or format is active

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -853,7 +853,7 @@ export default function Settings() {
               value: f.value,
               label: f.label,
               disabled:
-                ['remux_mkv', 'remux_mp4', 'remux_mkv_comskip', 'transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && !ffmpegReady
+                ['remux_mkv', 'remux_mp4', 'remux_mkv_comskip', 'transcode_mkv', 'transcode_mp4', 'transcode_comskip', 'transcode_mp4_comskip'].includes(f.value) && ffmpegReady === false
                   ? true
                   : false,
             }))}
@@ -861,7 +861,7 @@ export default function Settings() {
             onChange={handleFormatChange}
           />
 
-          {!ffmpegReady && currentFormat !== 'keep_original' && (
+          {ffmpegReady === false && currentFormat !== 'keep_original' && (
             <Alert color="yellow" variant="light">
               <Text size="sm">
                 ffmpeg is unavailable. The Docker image includes ffmpeg; install or fix it manually if running locally.
@@ -869,7 +869,7 @@ export default function Settings() {
             </Alert>
           )}
 
-          {!comskipReady && isComskipFormat && (
+          {comskipReady === false && isComskipFormat && (
             <Alert color="yellow" variant="light">
               <Text size="sm">
                 Comskip binary not found in the default PATH. Enter the path to your comskip binary below, or see{' '}
@@ -914,11 +914,13 @@ export default function Settings() {
             </SettingRow>
           )}
 
-          {isComskipFormat && (
+          {(isComskipFormat || comskipReady) && (
             <Stack gap="xs">
-              <Text size="xs" c="dimmed">
-                Commercials are detected and removed, then the result is saved as {currentFormat === 'transcode_mp4_comskip' ? 'MP4' : 'MKV'}.
-              </Text>
+              {isComskipFormat && (
+                <Text size="xs" c="dimmed">
+                  Commercials are detected and removed, then the result is saved as {currentFormat === 'transcode_mp4_comskip' ? 'MP4' : 'MKV'}.
+                </Text>
+              )}
               <TextInput
                 label="Comskip Binary Path (optional)"
                 description="Custom path to the comskip binary"


### PR DESCRIPTION
## What a user would notice

In Settings > Post-Processing, the ComSkip binary path and INI path fields were invisible even when ComSkip was installed and working. Tyler confirmed the panel never appeared in Docker even with all dependencies present.

## What changed

Two bugs in `Settings.jsx`:

**Bug 1: Format dropdown locked while tool status loads**

The Recording Format dropdown disables non-keep_original options when ffmpeg is not available. The check used `!ffmpegReady`, but `ffmpegReady` is `undefined` (not `false`) while the `/api/settings/tools` query is still loading. `!undefined` is truthy, so ALL recording formats were disabled until the tools status arrived, even in Docker where ffmpeg is always present. If the probe was slow or the endpoint failed, the dropdown stayed locked permanently.

Changed to `ffmpegReady === false` so formats are only disabled when the probe has confirmed ffmpeg is absent. Same change applied to the ffmpeg-unavailable alert and the ComSkip-not-found alert.

**Bug 2: ComSkip config hidden until a ComSkip format is already selected**

The binary path and INI path fields were gated on `isComskipFormat` (a ComSkip recording format already active). If the user's current format was "Keep original" or "MKV container (fast)", the ComSkip fields were invisible and there was no way to configure them before switching formats.

Changed to `isComskipFormat || comskipReady` so the ComSkip binary path and INI path inputs are always visible when the ComSkip binary is detected as available, regardless of which format is currently selected. The "Commercials are detected and removed..." description line is still gated on `isComskipFormat` only.

## Which scenarios now show the ComSkip config fields

| Situation | Before | After |
|---|---|---|
| ComSkip format selected, binary available | Shown | Shown |
| ComSkip format selected, binary unavailable | Shown | Shown |
| Non-ComSkip format, binary available (installed Docker) | Hidden | **Shown** |
| Non-ComSkip format, binary unavailable | Hidden | Hidden |
| toolsStatus still loading, ComSkip format selected | Shown | Shown |
| toolsStatus still loading, non-ComSkip format | Hidden | Hidden |

## How it was tested

Started app locally (backend + frontend dev server). Confirmed:

- With a "MKV container (fast)" format active and ComSkip installed: ComSkip binary path and INI path fields now appear below the format selector.
- With "Keep original" active and ComSkip not detected: fields remain hidden.
- With a ComSkip format selected: fields appear as before, plus the description line "Commercials are detected and removed..." is shown.
- Recording Format dropdown options are not disabled while toolsStatus is loading (verified by temporarily slowing the tools endpoint response).

Frontend only. No API change. No backend change.