### PR TITLE
[Design] suggest Keep original (.ts) when ffmpeg is unavailable

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -865,6 +865,8 @@ export default function Settings() {
             <Alert color="yellow" variant="light">
               <Text size="sm">
                 ffmpeg is unavailable. The Docker image includes ffmpeg; install or fix it manually if running locally.
+                {' '}To save recordings without converting, switch the format above to{' '}
+                <Text component="span" fw={500}>Keep original (.ts)</Text>.
               </Text>
             </Alert>
           )}


### PR DESCRIPTION
## What changed

When ffmpeg is not installed and the recording format requires it, the yellow warning in Settings > Post-Processing now tells users they can switch to **Keep original (.ts)** to save recordings without converting.

## Why

A non-technical user who sets up Mustarrd locally (outside Docker) may not have ffmpeg installed. The existing warning said "install or fix it manually if running locally" but gave no alternative. A user who cannot install ffmpeg had no idea what to do next.

## Before

"ffmpeg is unavailable. The Docker image includes ffmpeg; install or fix it manually if running locally."

## After

"ffmpeg is unavailable. The Docker image includes ffmpeg; install or fix it manually if running locally. To save recordings without converting, switch the format above to **Keep original (.ts)**."

## Screenshots

Screenshots posted to #design.

## How it was tested

- Ran the app locally without ffmpeg installed
- Navigated to Settings > Post-Processing with format set to MP4
- Confirmed the updated warning text appears and "Keep original (.ts)" is bold
- Confirmed the warning does NOT appear when format is already Keep original (.ts)
- No behavior change, text only

## Scope

Frontend only. One file changed (Settings.jsx), 2 lines added. No logic change.