### PR TITLE
[Design] Label cancelled downloads "Download Again" not "Retry"

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -143,6 +143,7 @@ function DownloadCard({
   const [showLogDetails, setShowLogDetails] = useState(false)
   const isActive = ['pending', 'downloading', 'processing'].includes(download.status)
   const canRetry = ['failed', 'cancelled'].includes(download.status)
+  const retryLabel = download.status === 'cancelled' ? 'Download Again' : 'Retry'
   const downloadProgress = typeof download.download_progress === 'number'
     ? download.download_progress
     : (download.status === 'processing' ? 100 : (download.progress ?? 0))
@@ -194,7 +195,7 @@ function DownloadCard({
                     leftSection={<IconRefresh size={14} />}
                     onClick={() => onRetry(download)}
                   >
-                    Retry
+                    {retryLabel}
                   </Menu.Item>
                 )}
                 {!isActive && (
@@ -390,7 +391,7 @@ function DownloadCard({
               leftSection={<IconRefresh size={14} />}
               onClick={() => onRetry(download)}
             >
-              Retry
+              {retryLabel}
             </Button>
           </Group>
         )}


### PR DESCRIPTION
## What a user would notice

Cancelled downloads in the Downloads History tab used to show a button labelled **Retry**, the same as failed downloads. A non-technical user who deliberately cancelled a download would see "Retry" and wonder if something went wrong.

Now:
- **FAILED** downloads: button still says **Retry**
- **CANCELLED** downloads: button now says **Download Again**

This makes the intent clear without changing any logic.

## What changed

One derived variable added in `DownloadCard` in `Downloads.jsx`:

```js
const retryLabel = download.status === 'cancelled' ? 'Download Again' : 'Retry'
```

Both the standalone button and the three-dot menu item use `{retryLabel}` instead of the hardcoded string. Frontend only, no backend changes, no logic changes.

## Before and after

**Before** (Soccer AM cancelled, button says "Retry"):

CANCELLED card showed "Retry" next to FAILED cards that also said "Retry". A user who intentionally cancelled a download had no way to tell from the button label that nothing went wrong.

**After** (Soccer AM cancelled, button says "Download Again"):

FAILED cards: "Retry". CANCELLED cards: "Download Again". The label matches what actually happened.

Tested at 1440px desktop and 390px mobile. Both the standalone button and the three-dot menu item update correctly.