### PR TITLE
docs: changelog entries for PR #283 and #284; fix README Retry label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Improved: Cancelled downloads now show "Download Again" instead of "Retry"
+
+**What you would notice:** In the Downloads history, a recording you intentionally cancelled used to show a button labelled **Retry**, the same as a recording that failed due to an error. This made it hard to tell at a glance whether something went wrong. Cancelled downloads now show **Download Again** to make it clear the recording stopped because you stopped it, not because something broke. Failed recordings still show **Retry** as before.
+
+**What changed:** A small label change was made to the Downloads history card. No download logic was changed.
+
+---
+
+### Improved: Settings now tells you how to save recordings when ffmpeg is not installed
+
+**What you would notice:** If you are running Mustarrd outside Docker and do not have ffmpeg installed, the warning in Settings > Post-Processing used to say to install ffmpeg manually but did not tell you what to do if you could not. It now adds: "To save recordings without converting, switch the format above to **Keep original (.ts)**." This gives you a working path forward without needing to install anything.
+
+**What changed:** One sentence was added to the ffmpeg unavailable warning in Settings > Post-Processing. No settings values or recording logic were changed.
+
+---
+
 ### Improved: ComSkip configuration fields now appear in Settings whenever ComSkip is installed
 
 **What you would notice:** On a fresh Docker install with ComSkip available, the binary path and INI path fields in Settings > Post-Processing were invisible unless you had already switched to a ComSkip recording format. This was a catch-22: you could not see or adjust the ComSkip paths without first picking a format that required them. After this fix, those fields appear whenever Mustarrd detects the ComSkip binary, regardless of which format you have selected.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then open **http://localhost:4177** in your browser.
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - When any scheduled recording is paused for low disk space, or when free space drops below the configured minimum, an orange banner appears at the top of every page, not just Downloads, so you are alerted no matter where you are in the app
 - The **History** tab shows past downloads. Use the status filter dropdown at the top to show only Completed, Failed, or Cancelled entries
-- Failed and cancelled downloads show a **Retry** button directly on the card
+- Failed downloads show a **Retry** button directly on the card; cancelled downloads show a **Download Again** button
 - Use the **Clear finished** button to remove all completed and failed entries from history at once (a confirmation prompt prevents accidents; cancelled entries are not cleared so you can still retry them)
 
 | Desktop | Mobile |


### PR DESCRIPTION
## What a user would notice

The changelog now covers the two most recent merged improvements. The README also has a small correction.

## Changes

**CHANGELOG:** Added plain-English entries for:
- PR #284: Cancelled downloads now show "Download Again" instead of "Retry"
- PR #283: Settings now suggests switching to Keep original (.ts) when ffmpeg is unavailable

**README:** Updated the Downloads section. It previously said "Failed and cancelled downloads show a Retry button" which was no longer accurate after PR #284. Now reads: "Failed downloads show a Retry button; cancelled downloads show a Download Again button."

## How it was tested

Diffed the two PRs against the changelog and README. No code changes.