### PR TITLE
[Design] Browse EPG shows error immediately when provider is unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -406,6 +406,7 @@ export default function Browse() {
     queryKey: ['channels', selectedAccountId],
     queryFn: () => channelsApi.getChannels(selectedAccountId, null, true),
     enabled: !!selectedAccountId,
+    retry: false,
   })
 
   // Fetch EPG for selected channel


### PR DESCRIPTION
## What a user would notice

Before this change, opening Browse EPG when a provider is unreachable showed a spinning orange loading circle that never stopped. There was no message explaining what was wrong. A non-technical user would wait indefinitely, not knowing why the page was empty.

After this change, the error appears within a second: a red alert icon, "Could not reach your provider," and a clickable link directly to Settings, Accounts so the user can fix the issue.

## What changed

One line added to `Browse.jsx`: `retry: false` on the channels query. By default TanStack Query retries a failed request three times with exponential backoff, which delays the error state by several minutes. The VOD, series, and global EPG search queries already use `retry: false`; the channels query was the only one that did not.

The error message and the right-panel fallback text ("Channel guide will appear here once your provider is connected.") were already coded and waiting, hidden behind the loading state.

No logic changes. Frontend only.

## Before

Channels panel shows an infinite orange loading spinner. No error. No explanation.

## After

Channels panel immediately shows a red alert icon with "Could not reach your provider." and a clickable Settings, Accounts link. Right panel shows "Channel guide will appear here once your provider is connected."

## How it was tested

- Started the app locally with both provider accounts set to unreachable URLs
- Opened Browse EPG before and after the change
- Before: spinner ran indefinitely through networkidle
- After: error state rendered immediately on page load, both desktop (1280x900) and mobile (390x844)