### PR TITLE
design: add Retry button to failed scheduled recordings

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -31,11 +31,12 @@ import {
   IconPlayerPlay,
   IconFolderOpen,
   IconFilter,
+  IconRefresh,
 } from '@tabler/icons-react'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 
-import { accountsApi, schedulesApi } from '../api'
+import { accountsApi, downloadsApi, schedulesApi } from '../api'
 import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
 
 dayjs.extend(duration)
@@ -97,6 +98,7 @@ function ScheduleCard({
   onDelete,
   onOpenFileLocation,
   onPlayFile,
+  onRetryDownload,
 }) {
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const activeStatuses = ['scheduled', 'queued', 'downloading', 'processing', 'paused_low_space']
@@ -182,6 +184,18 @@ function ScheduleCard({
           <Alert color="red" variant="light" p="xs">
             <Text size="xs">{renderErrorMessage(schedule.download_error_message)}</Text>
           </Alert>
+        )}
+        {schedule.download_status === 'failed' && schedule.download_id && (
+          <Group>
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<IconRefresh size={14} />}
+              onClick={() => onRetryDownload(schedule)}
+            >
+              Retry
+            </Button>
+          </Group>
         )}
 
         {schedule.download_status === 'completed' && schedule.download_id && (
@@ -306,6 +320,26 @@ export default function Scheduled() {
         title: 'Schedule Deleted',
         message: 'The schedule has been removed',
         color: 'green',
+      })
+    },
+  })
+
+  const retryDownloadMutation = useMutation({
+    mutationFn: (schedule) => downloadsApi.retry(schedule.download_id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      queryClient.invalidateQueries({ queryKey: ['downloads'] })
+      notifications.show({
+        title: 'Download Queued',
+        message: 'The download has been re-queued.',
+        color: 'green',
+      })
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Retry Failed',
+        message: error.message,
+        color: 'red',
       })
     },
   })
@@ -438,6 +472,7 @@ export default function Scheduled() {
                   onDelete={(s) => deleteMutation.mutate(s)}
                   onOpenFileLocation={handleOpenFileLocation}
                   onPlayFile={handlePlayFile}
+                  onRetryDownload={(s) => retryDownloadMutation.mutate(s)}
                 />
               ))}
             </Stack>
@@ -487,6 +522,7 @@ export default function Scheduled() {
                   onDelete={(s) => deleteMutation.mutate(s)}
                   onOpenFileLocation={handleOpenFileLocation}
                   onPlayFile={handlePlayFile}
+                  onRetryDownload={(s) => retryDownloadMutation.mutate(s)}
                 />
               ))}
             </Stack>


### PR DESCRIPTION
## What changed

The Scheduled Recordings > History tab showed an error message for FAILED recordings but had no inline action. Users had to navigate away to Downloads > History to find the Retry button there.

A **Retry** button now appears directly on FAILED scheduled history cards, matching how Downloads > History already works.

## What a user would notice

**Before:** Seeing "EastEnders - FAILED" in Scheduled History, the only visible options were the error message and a three-dot Delete menu. To retry, the user had to leave the page and go to Downloads > History to find the failed download entry.

**After:** A Retry button appears right below the error message. One click re-queues the download without leaving the Scheduled page.

## Change

One file only: `frontend/src/pages/Scheduled.jsx`
- Added `downloadsApi` import and `IconRefresh` icon
- Added `onRetryDownload` prop to `ScheduleCard`
- Added Retry button when `schedule.download_status === 'failed'` and `schedule.download_id` is set
- Added `retryDownloadMutation` in the parent component using `downloadsApi.retry(download_id)`
- No backend changes, no logic changes

## Screenshots

**BEFORE (desktop):** FAILED card shows error, no action button
![before-desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513787644503654470/guide_after_mobile.png)

(See #design for full before/after screenshots)

## How it was tested

Ran the app locally at localhost:4178 with test data containing a FAILED scheduled recording (EastEnders). Confirmed the Retry button appears only on FAILED cards, not CANCELLED or COMPLETED cards. Confirmed clicking Retry calls `POST /downloads/{id}/retry` and shows a toast notification.