### PR TITLE
design: fix misleading right panel message on Browse EPG when provider unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1045,9 +1045,18 @@ export default function Browse() {
                     </Stack>
                   ) : channelsIsError ? (
                     <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
-                      <IconVideo size={48} opacity={0.3} />
+                      <IconAlertCircle size={48} color="var(--mantine-color-red-5)" opacity={0.6} />
                       <Text c="dimmed" ta="center">
-                        Channel guide will appear here once your provider is connected.
+                        {authStatus?.is_admin ? (
+                          <>
+                            Could not reach your provider.{' '}
+                            <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+                              Check Settings → Accounts.
+                            </Link>
+                          </>
+                        ) : (
+                          'Could not reach the provider. Contact your administrator.'
+                        )}
                       </Text>
                     </Stack>
                   ) : (


### PR DESCRIPTION
## What a user would notice

When your IPTV provider is unreachable, the Browse EPG page shows an error in the left (Channels) panel. The right panel used to show a generic video icon and the message **"Channel guide will appear here once your provider is connected."** A user who already has a provider configured but whose provider is temporarily down would read this and think they hadn't set up a provider yet, which is wrong and confusing.

After this change, the right panel shows a red alert icon and **"Could not reach your provider. Check Settings → Accounts."** Both panels now give the same consistent signal: something is wrong with the provider connection, and here is where to fix it.

## What changed

One file: `frontend/src/pages/Browse.jsx`.

- Changed the icon from `IconVideo` (neutral) to `IconAlertCircle` (red) in the right panel error state.
- Changed the text from the misleading "once your provider is connected" to "Could not reach your provider." with an orange link to Settings → Accounts for admins, or "Contact your administrator." for non-admin users.

No backend changes. No logic changes.

## Before and after evidence

Screenshots posted in #design.

**Before:** Right panel shows video icon and "Channel guide will appear here once your provider is connected." Implies provider is not configured, contradicts the left panel error.

**After:** Right panel shows red alert icon and "Could not reach your provider. Check Settings → Accounts." Consistent with the left panel, actionable.

## How it was tested

- Ran the frontend dev server with a test account pointing to an unreachable host.
- Confirmed both panels show consistent error messaging on desktop (1280px).
- Confirmed mobile (390px) is unaffected: on mobile the right panel never appears when channels fail to load, since the two-column layout only applies on desktop.