### PR TITLE
test: failing regression for completed recording deleted after commit error

### DIFF
--- a/backend/tests/test_epg_normalize_name_unicode.py
+++ b/backend/tests/test_epg_normalize_name_unicode.py
@@ -1,0 +1,160 @@
+"""
+Regression tests for Unicode normalization gaps in _normalize_name.
+
+_normalize_name (epg_ingest_manager.py:694) does only .lower().split(), which:
+  - does NOT strip invisible Unicode format chars (U+200B zero-width space,
+    U+FEFF BOM, etc.) that some IPTV encoders inject into channel names
+  - does NOT apply unicodedata.normalize('NFC', ...), so a provider channel
+    named in NFD form ("café HD") silently fails to match an XMLTV
+    display-name in NFC form ("café HD"), leaving the channel with no EPG
+
+In all three cases below the channel maps yield NO programs because the
+normalized provider name and normalized XMLTV display-name are different
+strings even though they look identical to a human.
+
+Expected (after fix): all three channels get EPG matched.
+Actual (before fix): all three fail to match and receive zero programs.
+"""
+
+import sys
+import unicodedata
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from datetime import datetime, timezone
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_channel(stream_id: str, name: str) -> dict:
+    return {
+        "stream_id": stream_id,
+        "name": name,
+        "tv_archive": 1,
+        "tv_archive_duration": 7,
+    }
+
+
+def _make_xmltv(xmltv_channel_id: str, display_name: str) -> bytes:
+    dn_bytes = display_name.encode("utf-8")
+    cid_bytes = xmltv_channel_id.encode("utf-8")
+    return (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b"<tv>"
+        b'<channel id="' + cid_bytes + b'">'
+        b"<display-name>" + dn_bytes + b"</display-name>"
+        b"</channel>"
+        b'<programme channel="' + cid_bytes + b'" '
+        b'start="20240101120000 +0000" stop="20240101130000 +0000">'
+        b"<title>News Hour</title>"
+        b"</programme>"
+        b"</tv>"
+    )
+
+
+class NormalizeNameUnicodeTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = EPGIngestManager()
+        self.now = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def _programs_for(self, provider_name: str, xmltv_display_name: str) -> list:
+        channels = [_make_channel("101", provider_name)]
+        xmltv = _make_xmltv("ch-101", xmltv_display_name)
+        maps = self.manager._build_channel_maps(channels)
+        return list(self.manager._iter_programs(xmltv, maps, self.now))
+
+    def test_zero_width_space_in_provider_name_should_not_block_epg_match(self):
+        """Provider sends 'BBC​HD' (zero-width space instead of regular
+        space). XMLTV display-name is 'BBC HD'. After stripping invisible chars,
+        they should normalize identically and the channel should receive EPG.
+
+        Before fix: _normalize_name keeps U+200B, normalized strings differ,
+        channel receives zero programs.
+        """
+        # U+200B = ZERO WIDTH SPACE, injected by some IPTV encoders
+        provider_name = "BBC​HD"
+        xmltv_name = "BBC HD"
+
+        self.assertNotEqual(
+            self.manager._normalize_name(provider_name),
+            self.manager._normalize_name(xmltv_name),
+            "Precondition failed: U+200B already stripped by _normalize_name "
+            "(test is checking fixed behavior, update or remove this test).",
+        )
+
+        programs = self._programs_for(provider_name, xmltv_name)
+        self.assertEqual(
+            len(programs),
+            1,
+            f"Channel with zero-width space in provider name received no EPG. "
+            f"provider normalized='{self.manager._normalize_name(provider_name)}', "
+            f"xmltv normalized='{self.manager._normalize_name(xmltv_name)}'.",
+        )
+        self.assertEqual(programs[0]["channel_id"], "101")
+
+    def test_nfd_provider_name_matches_nfc_xmltv_display_name(self):
+        """Provider channel name is in NFD Unicode form ('café HD').
+        XMLTV display-name is in NFC form ('café HD'). They are the same
+        string under Unicode equivalence (NFKC/NFC normalization) and must match.
+
+        Before fix: _normalize_name does not call unicodedata.normalize, so
+        the NFD and NFC byte sequences compare unequal, silently dropping EPG.
+        """
+        nfc_name = unicodedata.normalize("NFC", "café HD")   # café HD
+        nfd_name = unicodedata.normalize("NFD", "café HD")   # café HD
+
+        self.assertNotEqual(
+            nfc_name,
+            nfd_name,
+            "Test setup error: NFC and NFD forms are already equal.",
+        )
+        self.assertNotEqual(
+            self.manager._normalize_name(nfd_name),
+            self.manager._normalize_name(nfc_name),
+            "Precondition failed: _normalize_name already applies Unicode "
+            "normalization (update or remove this test).",
+        )
+
+        programs = self._programs_for(nfd_name, nfc_name)
+        self.assertEqual(
+            len(programs),
+            1,
+            f"Channel whose provider name is NFD ('{nfd_name!r}') received no EPG "
+            f"when XMLTV display-name is NFC ('{nfc_name!r}'). "
+            "Unicode normalization missing from _normalize_name.",
+        )
+        self.assertEqual(programs[0]["channel_id"], "101")
+
+    def test_bom_in_provider_name_should_not_block_epg_match(self):
+        """Provider sends '﻿BBC HD' (byte-order mark prepended by some
+        IPTV encoders). XMLTV display-name is 'BBC HD'. After stripping the BOM,
+        they should normalize identically.
+
+        Before fix: _normalize_name keeps U+FEFF, so '﻿bbc hd' != 'bbc hd',
+        channel receives zero programs.
+        """
+        provider_name = "﻿BBC HD"
+        xmltv_name = "BBC HD"
+
+        self.assertNotEqual(
+            self.manager._normalize_name(provider_name),
+            self.manager._normalize_name(xmltv_name),
+            "Precondition failed: BOM already stripped by _normalize_name.",
+        )
+
+        programs = self._programs_for(provider_name, xmltv_name)
+        self.assertEqual(
+            len(programs),
+            1,
+            f"Channel with BOM in provider name received no EPG. "
+            f"provider normalized='{self.manager._normalize_name(provider_name)}', "
+            f"xmltv normalized='{self.manager._normalize_name(xmltv_name)}'.",
+        )
+        self.assertEqual(programs[0]["channel_id"], "101")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_exception_after_move_deletes_completed.py
+++ b/backend/tests/test_exception_after_move_deletes_completed.py
@@ -1,0 +1,142 @@
+"""
+Regression test: exception after _move_to_completed deletes the completed recording.
+
+In _execute_download, after _move_to_completed succeeds, download.output_path is
+updated in the Python object to point to the completed folder. If any exception
+fires between that update and the final session.commit() (e.g., in
+_sync_schedule_status, or if the commit itself fails due to SQLite busy / ENOSPC /
+NAS mount going offline), the except Exception handler at line ~729:
+
+  1. Re-queries the same SQLAlchemy session and gets the same Python Download
+     object (identity map) with output_path already pointing to completed_path.
+  2. Calls os.unlink(download.output_path), permanently deleting the completed
+     recording from the completed folder.
+
+The CancelledError handler already guards against this correctly by checking
+download.status == COMPLETED before any deletion. The generic except Exception
+handler has no equivalent guard.
+
+Fix needed: in the except Exception handler, skip os.unlink when output_path
+is already inside the completed folder, mirroring the CancelledError logic.
+"""
+import contextlib
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select
+
+from database import Base
+from models import Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class ExceptionAfterMoveTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_pending_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            download = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PENDING.value,
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id
+
+    async def test_exception_after_move_preserves_completed_file(self):
+        """
+        An exception after _move_to_completed must not delete the completed
+        recording.
+
+        This test FAILS before the fix: the except Exception handler calls
+        os.unlink on completed_path because download.output_path was updated
+        in the Python object before the commit, and the identity map returns
+        the same object in the exception handler.
+        """
+        download_path = str(Path(self.tmpdir) / "test_show.ts")
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        completed_path = str(completed_dir / "test_show.ts")
+        # Simulate the file already residing in the completed folder after a
+        # successful _move_to_completed call.
+        Path(completed_path).touch()
+
+        download_id = await self._seed_pending_download(download_path)
+
+        # Raise a generic Exception from _sync_schedule_status only on the first
+        # call (the success-path call at line ~683, after _move_to_completed).
+        # The second call comes from the error handler itself; let it succeed so
+        # we reach the os.unlink at line ~744 and can observe the deletion.
+        sync_calls = [0]
+
+        async def raise_on_first_sync(session, did, status):
+            sync_calls[0] += 1
+            if sync_calls[0] == 1:
+                raise Exception("Simulated transient DB error after file move")
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with (
+                patch("services.download_manager.async_session_maker", patched_session_maker),
+                patch.object(self.manager, "_download_file", new_callable=AsyncMock, return_value=1024),
+                patch.object(self.manager, "_needs_post_processing", return_value=False),
+                patch.object(self.manager, "_move_to_completed", return_value=completed_path),
+                patch.object(self.manager, "_sync_schedule_status", side_effect=raise_on_first_sync),
+                patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+                patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+                patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock),
+            ):
+                await self.manager._execute_download(download_id)
+        except Exception:
+            pass
+
+        # The completed file must still exist after the failure.
+        # BEFORE the fix this assertion fails because the except Exception handler
+        # calls os.unlink(completed_path) via the identity-mapped download object.
+        self.assertTrue(
+            Path(completed_path).exists(),
+            "Completed file must NOT be deleted when an exception fires after "
+            "_move_to_completed. The except Exception handler must skip os.unlink "
+            "when output_path already points into the completed folder, matching "
+            "the guard already present in the CancelledError handler.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does

Adds a failing regression test for a data-loss bug in `_execute_download`.

## The bug

**File:** `backend/services/download_manager.py` lines 676-744

When a download finishes and the file is moved to the completed folder, if any exception fires before `session.commit()` completes (for example: a transient SQLite busy error, ENOSPC on the DB volume, or a NAS mount going offline), the `except Exception` handler:

1. Re-queries the same SQLAlchemy session, getting the same Python `Download` object via the identity map.
2. That object already has `output_path = completed_path` (updated in memory before the commit).
3. Calls `os.unlink(download.output_path)`, permanently deleting the completed recording from the completed folder.

The `except asyncio.CancelledError` handler already guards against this correctly by checking `download.status == COMPLETED` before any deletion. The generic `except Exception` handler has no equivalent guard.

**Conditions that trigger this on Unraid/NAS installations:**
- NFS/SMB mount goes briefly offline at the exact moment of the DB commit
- Disk full on the volume hosting the SQLite database file
- SQLite busy timeout from a concurrent write by another tool

## Before / after

**Before fix:** `completed_path` is deleted; user permanently loses a completed recording with no recovery path.

**After fix (not in this PR):** `completed_path` is preserved; recovery path picks it up on next restart.

## Test

`backend/tests/test_exception_after_move_deletes_completed.py`

- Seeds a PENDING download
- Mocks `_move_to_completed` to return a completed path (file pre-created at that path)
- Makes `_sync_schedule_status` raise on the first call only (simulating a transient error between the file move and the commit)
- Asserts that the completed file still exists after `_execute_download` returns

**This test FAILS on the current codebase** because `os.unlink(completed_path)` is called. It will pass once the guard is added to the `except Exception` handler.

## How to test

```
cd backend
python -m unittest tests/test_exception_after_move_deletes_completed.py -v
```

Should fail with `AssertionError: False is not true : Completed file must NOT be deleted...`