### PR TITLE
fix: preserve completed recording when DB commit fails after move

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -761,6 +761,21 @@ class DownloadManager:
                     select(Download).where(Download.id == download_id)
                 )
                 download = result.scalar_one_or_none()
+                if download and download.status == DownloadStatus.COMPLETED.value:
+                    # Exception fired after _move_to_completed updated output_path in
+                    # memory but before (or during) session.commit(). The file is
+                    # already in the completed folder; commit the completed state and
+                    # leave it untouched, mirroring the CancelledError guard above.
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
+                    await session.commit()
+                    await self._broadcast_progress(
+                        download_id, 100, DownloadStatus.COMPLETED.value
+                    )
+                    await self._broadcast_log(
+                        download_id,
+                        f"Download completed: {os.path.basename(download.output_path)}"
+                    )
+                    return
                 if download:
                     download.status = DownloadStatus.FAILED.value
                     if not download.completed_at:

--- a/backend/tests/test_exception_after_move_deletes_completed.py
+++ b/backend/tests/test_exception_after_move_deletes_completed.py
@@ -1,0 +1,142 @@
+"""
+Regression test: exception after _move_to_completed deletes the completed recording.
+
+In _execute_download, after _move_to_completed succeeds, download.output_path is
+updated in the Python object to point to the completed folder. If any exception
+fires between that update and the final session.commit() (e.g., in
+_sync_schedule_status, or if the commit itself fails due to SQLite busy / ENOSPC /
+NAS mount going offline), the except Exception handler at line ~729:
+
+  1. Re-queries the same SQLAlchemy session and gets the same Python Download
+     object (identity map) with output_path already pointing to completed_path.
+  2. Calls os.unlink(download.output_path), permanently deleting the completed
+     recording from the completed folder.
+
+The CancelledError handler already guards against this correctly by checking
+download.status == COMPLETED before any deletion. The generic except Exception
+handler has no equivalent guard.
+
+Fix needed: in the except Exception handler, skip os.unlink when output_path
+is already inside the completed folder, mirroring the CancelledError logic.
+"""
+import contextlib
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select
+
+from database import Base
+from models import Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class ExceptionAfterMoveTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_pending_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            download = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PENDING.value,
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id
+
+    async def test_exception_after_move_preserves_completed_file(self):
+        """
+        An exception after _move_to_completed must not delete the completed
+        recording.
+
+        This test FAILS before the fix: the except Exception handler calls
+        os.unlink on completed_path because download.output_path was updated
+        in the Python object before the commit, and the identity map returns
+        the same object in the exception handler.
+        """
+        download_path = str(Path(self.tmpdir) / "test_show.ts")
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        completed_path = str(completed_dir / "test_show.ts")
+        # Simulate the file already residing in the completed folder after a
+        # successful _move_to_completed call.
+        Path(completed_path).touch()
+
+        download_id = await self._seed_pending_download(download_path)
+
+        # Raise a generic Exception from _sync_schedule_status only on the first
+        # call (the success-path call at line ~683, after _move_to_completed).
+        # The second call comes from the error handler itself; let it succeed so
+        # we reach the os.unlink at line ~744 and can observe the deletion.
+        sync_calls = [0]
+
+        async def raise_on_first_sync(session, did, status):
+            sync_calls[0] += 1
+            if sync_calls[0] == 1:
+                raise Exception("Simulated transient DB error after file move")
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with (
+                patch("services.download_manager.async_session_maker", patched_session_maker),
+                patch.object(self.manager, "_download_file", new_callable=AsyncMock, return_value=1024),
+                patch.object(self.manager, "_needs_post_processing", return_value=False),
+                patch.object(self.manager, "_move_to_completed", return_value=completed_path),
+                patch.object(self.manager, "_sync_schedule_status", side_effect=raise_on_first_sync),
+                patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+                patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+                patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock),
+            ):
+                await self.manager._execute_download(download_id)
+        except Exception:
+            pass
+
+        # The completed file must still exist after the failure.
+        # BEFORE the fix this assertion fails because the except Exception handler
+        # calls os.unlink(completed_path) via the identity-mapped download object.
+        self.assertTrue(
+            Path(completed_path).exists(),
+            "Completed file must NOT be deleted when an exception fires after "
+            "_move_to_completed. The except Exception handler must skip os.unlink "
+            "when output_path already points into the completed folder, matching "
+            "the guard already present in the CancelledError handler.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

On Unraid or NAS setups where the database lives on a network share, a recording could vanish from the completed folder at the exact moment the share went briefly offline or the disk filled up. The download would finish and the file would move, but a split-second glitch during the database save caused the app to delete its own completed recording. Affected users would see the download marked as Failed with no file to show for it.

## What changed

In `_execute_download`, after a recording finishes downloading it is moved to the completed folder, then the database is updated. If anything went wrong between the move and the database save (SQLite busy timeout, NAS mount blip, disk full on the database volume), the error handler was calling `os.unlink` on the file path, which at that point already pointed to the completed folder.

The cancel handler already had a guard for this exact situation: "if the download status is already COMPLETED in memory, the file moved successfully, so leave it alone." The generic error handler had no equivalent guard.

This PR adds the same guard to the error handler: if the in-memory download status is COMPLETED when the error fires, commit the completed state and return without touching the file.

## Before / after

**Before fix:** transient DB error after move deletes the completed recording; download marked Failed; file gone.

**After fix:** transient DB error after move leaves the file in place; download marked Completed; operator recovers normally on next app start.

## Test

`backend/tests/test_exception_after_move_deletes_completed.py`

Seeds a PENDING download, mocks `_move_to_completed` to return a completed path (file pre-created at that path), makes `_sync_schedule_status` raise on the first call only (simulating a transient error between move and commit), and asserts the completed file still exists after `_execute_download` returns.

```
cd backend
source venv/bin/activate
python -m unittest tests.test_exception_after_move_deletes_completed -v
```

Full suite (704 tests) green.

Supersedes PR #297 (closed when the branch was rebase-cleaned to drop a scope-contaminating commit from an earlier PR).