### PR TITLE
design: dim error detail text under unavailable tool badges in Post-Processing settings

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -802,10 +802,10 @@ export default function Settings() {
               </Badge>
             </Group>
             {toolsStatus.ffmpeg?.error && (
-              <Text size="xs" c="red">ffmpeg error: {toolsStatus.ffmpeg.error}</Text>
+              <Text size="xs" c="dimmed">ffmpeg error: {toolsStatus.ffmpeg.error}</Text>
             )}
             {toolsStatus.comskip?.error && (
-              <Text size="xs" c="red">Comskip error: {toolsStatus.comskip.error}</Text>
+              <Text size="xs" c="dimmed">Comskip error: {toolsStatus.comskip.error}</Text>
             )}
             {toolsStatus.vaapi?.enabled && (
               <Text size="xs" c="dimmed">


### PR DESCRIPTION
## What a user would notice

Before: Settings > Post-Processing showed two red pill badges (FFMPEG UNAVAILABLE, COMSKIP UNAVAILABLE) immediately followed by two MORE lines of red text ("ffmpeg error: not executable or not found" / "Comskip error: not executable or not found"). For a non-technical Unraid user, the page looked like it had four separate problems blazing in red. The actual guidance (yellow box: "switch the format to Keep original") is further down the page.

After: The badge is still red and still the headline signal. The error detail text is now dimmed gray, matching the VA-API driver line directly below it. It reads as supplementary diagnostic detail rather than a second alarm.

## What changed

`Settings.jsx`: two lines, `c="red"` -> `c="dimmed"` on the ffmpeg and Comskip error text nodes. Frontend only, no backend changes.

## How it was tested

Started the app locally (backend + frontend dev server). Opened Settings > Post-Processing with ffmpeg and comskip both unavailable. Compared before and after at 1280x800 desktop and 390x844 mobile. Before and after screenshots in #design.

BEFORE (desktop): two red badges + two red text lines = four simultaneous alarms
AFTER (desktop): two red badges + two dimmed detail lines = clear headline with calm diagnostic detail