### PR TITLE
fix: preserve source recording when move to completed folder fails with ENOSPC

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import aiohttp
 import aiofiles
+import errno
 import glob as glob_module
 import logging
 import os
@@ -702,7 +703,37 @@ class DownloadManager:
 
                 completed_folder = self._resolve_completed_folder(settings)
                 download_folder = self._resolve_download_folder(settings)
-                completed_path = self._move_to_completed(download.output_path, completed_folder, download_folder)
+                try:
+                    completed_path = self._move_to_completed(download.output_path, completed_folder, download_folder)
+                except OSError as move_err:
+                    # Move failed (e.g. ENOSPC on the completed folder mount). The
+                    # downloaded file is still intact in the download folder. Mark as
+                    # FAILED without deleting the source.
+                    if move_err.errno == errno.ENOSPC:
+                        msg = (
+                            "Not enough space in the completed recordings folder. "
+                            "Your recording is safe in the downloads folder. "
+                            "Free up space on that drive."
+                        )
+                    else:
+                        msg = _friendly_error(move_err)
+                    download.status = DownloadStatus.FAILED.value
+                    if not download.completed_at:
+                        download.completed_at = datetime.utcnow()
+                    download.error_message = msg
+                    await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
+                    try:
+                        await session.commit()
+                    except Exception:
+                        pass
+                    await self._broadcast_progress(
+                        download_id,
+                        download.progress,
+                        DownloadStatus.FAILED.value,
+                        error=msg,
+                    )
+                    await self._broadcast_log(download_id, f"Download failed: {msg}", level="error")
+                    return
                 download.output_path = completed_path
 
                 download.status = DownloadStatus.COMPLETED.value
@@ -1049,7 +1080,15 @@ class DownloadManager:
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         if os.path.abspath(path) == os.path.abspath(dest):
             return path
-        shutil.move(path, dest)
+        try:
+            shutil.move(path, dest)
+        except OSError:
+            try:
+                if os.path.exists(dest):
+                    os.unlink(dest)
+            except OSError:
+                pass
+            raise
         return dest
 
     def _cleanup_working_files(self, original_path: str, completed_path: str, keep_logs: bool, delete_original: bool = True) -> None:

--- a/backend/tests/test_download_manager_enospc_move.py
+++ b/backend/tests/test_download_manager_enospc_move.py
@@ -1,0 +1,112 @@
+import asyncio
+import errno
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+from models import DownloadStatus
+
+
+def _make_session(download):
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = download
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=mock_result)
+    session.commit = AsyncMock()
+    return session
+
+
+class ENOSPCMoveTests(unittest.TestCase):
+    def setUp(self):
+        self.manager = DownloadManager()
+
+    def test_enospc_on_move_preserves_source_file(self):
+        """Source .ts must NOT be deleted when shutil.move raises ENOSPC."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_file = os.path.join(tmpdir, "show.ts")
+
+            mock_download = MagicMock()
+            mock_download.id = 1
+            mock_download.status = DownloadStatus.PENDING.value
+            mock_download.output_path = source_file
+            mock_download.source_url = "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts"
+            mock_download.progress = 0.0
+            mock_download.completed_at = None
+            mock_download.error_message = None
+            mock_download.total_size = None
+
+            session = _make_session(mock_download)
+
+            @asynccontextmanager
+            async def mock_session_maker():
+                yield session
+
+            async def fake_download_file(url, path, download_id, sess, offset=0):
+                with open(path, "wb") as f:
+                    f.write(b"\x00" * 1024)
+                return 1024
+
+            def raise_enospc(path, completed_folder, download_folder=None):
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            with patch("services.download_manager.async_session_maker", mock_session_maker):
+                with patch.object(self.manager, "_download_file", fake_download_file):
+                    with patch.object(self.manager, "_move_to_completed", raise_enospc):
+                        with patch.object(self.manager, "_broadcast_progress", AsyncMock()):
+                            with patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                                with patch.object(self.manager, "_sync_schedule_status", AsyncMock()):
+                                    with patch.object(self.manager, "_needs_post_processing", return_value=False):
+                                        asyncio.run(self.manager._execute_download(1))
+
+            self.assertTrue(
+                os.path.exists(source_file),
+                "Completed source file must NOT be deleted when move to completed folder fails with ENOSPC",
+            )
+            self.assertEqual(mock_download.status, DownloadStatus.FAILED.value)
+
+    def test_move_to_completed_cleans_partial_dest_on_enospc(self):
+        """Partial file at dest must be removed when shutil.move raises ENOSPC."""
+        with tempfile.TemporaryDirectory() as src_dir:
+            with tempfile.TemporaryDirectory() as dst_dir:
+                source_file = os.path.join(src_dir, "show.ts")
+                dest_file = os.path.join(dst_dir, "show.ts")
+
+                with open(source_file, "wb") as f:
+                    f.write(b"\x00" * 1024)
+
+                # Simulate a partial copy at dest before ENOSPC
+                with open(dest_file, "wb") as f:
+                    f.write(b"\x00" * 512)
+
+                original_move = shutil.move
+
+                def fake_move(src, dst):
+                    # Partial copy already exists at dst; now raise ENOSPC
+                    raise OSError(errno.ENOSPC, "No space left on device")
+
+                with patch("shutil.move", fake_move):
+                    with self.assertRaises(OSError):
+                        self.manager._move_to_completed(source_file, dst_dir)
+
+                self.assertFalse(
+                    os.path.exists(dest_file),
+                    "Partial file at dest must be cleaned up after ENOSPC in _move_to_completed",
+                )
+                self.assertTrue(
+                    os.path.exists(source_file),
+                    "Source file must still exist after failed move",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What happened

On Unraid (and any setup with separate shares for downloads and completed recordings), `shutil.move` works as copy-then-unlink. If the completed folder's mount ran out of space mid-copy, the copy raised `ENOSPC`. The exception handler in `_execute_download` then deleted `download.output_path`, which still pointed to the original source file because the path update never ran. The fully downloaded recording was permanently lost.

**Before (broken path):**
1. Download completes into download folder.
2. `_move_to_completed` starts copy to full completed mount.
3. `shutil.move` raises `OSError: ENOSPC`.
4. Exception handler fires, reads `download.output_path` (still the source), calls `os.unlink` on it.
5. Source file deleted. Recording gone. No recovery possible.

**After (fixed path):**
1. Download completes into download folder.
2. `_move_to_completed` starts copy; `shutil.move` raises `OSError: ENOSPC`; any partial file at the destination is cleaned up immediately.
3. `_execute_download` catches the `OSError` before updating `output_path`, marks the download FAILED with the message: "Not enough space in the completed recordings folder. Your recording is safe in the downloads folder. Free up space on that drive."
4. Source file untouched. User frees space and can re-download if needed.

## Changes

- `backend/services/download_manager.py`
  - `_move_to_completed`: wrap `shutil.move` with `try/except OSError`; remove any partial dest file before re-raising.
  - `_execute_download`: catch `OSError` from `_move_to_completed` before `output_path` is updated; mark FAILED with user-readable message; return without deleting the source.
  - `errno` moved to module-level import (was inline-only inside `_friendly_error`).
- `backend/tests/test_download_manager_enospc_move.py`: two regression tests.
  - `test_enospc_on_move_preserves_source_file`: source `.ts` must survive an ENOSPC from the move, status FAILED. Fails before fix, passes after.
  - `test_move_to_completed_cleans_partial_dest_on_enospc`: partial file at dest must be removed when `shutil.move` raises. Fails before fix, passes after.

## How to test

1. Put `CATCHUP_DEFAULT_DOWNLOAD_FOLDER` and `CATCHUP_DEFAULT_COMPLETED_FOLDER` on separate mounts.
2. Fill the completed folder's mount to near-capacity.
3. Queue a download that will exhaust the remaining space.
4. Download should complete in the downloads folder, then show FAILED with "Not enough space in the completed recordings folder..." The source `.ts` remains in the downloads folder.

Full suite: 705 pass.