### PR TITLE
design: file naming variable chips click to insert

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useContext } from 'react'
+import { useState, useEffect, useCallback, useContext, useRef } from 'react'
 import { UNSAFE_NavigationContext, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import {
   Title,
@@ -57,17 +57,44 @@ function isPlexNotConnectedError(message) {
 }
 
 function TemplateSection({ label, template, variables, example, renderedExample, onChange }) {
+  const inputRef = useRef(null)
+
+  function insertVariable(varName) {
+    const insertion = `{${varName}}`
+    const input = inputRef.current
+    if (input) {
+      const start = input.selectionStart ?? template.length
+      const end = input.selectionEnd ?? template.length
+      const newVal = template.slice(0, start) + insertion + template.slice(end)
+      onChange(newVal)
+      requestAnimationFrame(() => {
+        input.focus()
+        const pos = start + insertion.length
+        input.setSelectionRange(pos, pos)
+      })
+    } else {
+      onChange(template + insertion)
+    }
+  }
+
   return (
     <Stack gap="xs">
       <TextInput
+        ref={inputRef}
         label={label}
         value={template}
         onChange={(e) => onChange(e.target.value)}
         placeholder={example}
       />
-      <Group gap="xs" wrap="wrap">
+      <Group gap="xs" wrap="wrap" align="center">
+        <Text size="xs" c="dimmed">Variables:</Text>
         {variables.map((v) => (
-          <Code key={v.name} style={{ cursor: 'help' }} title={v.description}>
+          <Code
+            key={v.name}
+            style={{ cursor: 'pointer' }}
+            title={v.description}
+            onClick={() => insertVariable(v.name)}
+          >
             {`{${v.name}}`}
           </Code>
         ))}


### PR DESCRIPTION
## What a user would notice

On Settings > File Naming, the variable chips (`{show}`, `{season}`, etc.) below each template input were display-only. Hovering showed a tooltip, but clicking did nothing. The cursor style was `help`, which on desktop suggests a tooltip but implies you cannot interact further. On touch devices there is no hover at all, so the chips appeared purely decorative.

Now clicking any variable chip inserts it into the template field at the current cursor position. Focus and cursor are restored after insertion, so you can keep editing without extra clicks. A "Variables:" label was added before the chips so their purpose is clear at a glance.

## What changed

`frontend/src/pages/Settings.jsx` only. No backend changes.

- `TemplateSection`: added `useRef` ref on the TextInput, `insertVariable(varName)` function that reads `selectionStart`/`selectionEnd` and splices the variable into the template value, restores focus and cursor via `requestAnimationFrame`.
- Variable chips: `cursor: 'help'` changed to `cursor: 'pointer'`, added `onClick` handler.
- Added `Variables:` label (dimmed text) before the chip list.

## How it was tested

Playwright: opened File Naming, clicked `{date}` chip on the TV Shows template, confirmed the value changed from `{show} - S{season:02d}E{episode:02d} - {title}` to `{show} - S{season:02d}E{episode:02d} - {title}{date}`. PASS.

Before/after screenshots are in the Pixel iteration 39 thread in #design.