### PR TITLE
fix: handle bare-list response in get_epg and get_short_epg

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -76,6 +76,8 @@ class XtreamClient:
             if response.status != 200:
                 raise Exception(f"Failed to get EPG: HTTP {response.status}")
             data = await response.json(content_type=None)
+            if isinstance(data, list):
+                return data
             return data.get("epg_listings") or []
 
     async def get_short_epg(self, stream_id: str, limit: int = 10) -> list:
@@ -86,6 +88,8 @@ class XtreamClient:
             if response.status != 200:
                 raise Exception(f"Failed to get short EPG: HTTP {response.status}")
             data = await response.json(content_type=None)
+            if isinstance(data, list):
+                return data
             return data.get("epg_listings") or []
 
     async def get_xmltv(self) -> bytes:

--- a/backend/tests/test_xtream_client_epg_list_response.py
+++ b/backend/tests/test_xtream_client_epg_list_response.py
@@ -1,0 +1,88 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.xtream_client import XtreamClient
+
+
+def _mock_session(json_data, status=200):
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=cm)
+    return AsyncMock(return_value=session)
+
+
+def _client():
+    return XtreamClient("http://provider.test:8080", "user", "pass")
+
+
+class GetEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_bare_list_response_returns_list(self):
+        """Provider returns [] instead of {"epg_listings": []}; must not AttributeError."""
+        client = _client()
+        client._get_session = _mock_session([])
+        result = await client.get_epg("123")
+        self.assertEqual(result, [])
+
+    async def test_bare_list_with_entries_returned(self):
+        entries = [{"id": "1", "title": "News"}, {"id": "2", "title": "Sport"}]
+        client = _client()
+        client._get_session = _mock_session(entries)
+        result = await client.get_epg("123")
+        self.assertEqual(result, entries)
+
+    async def test_dict_response_extracts_epg_listings(self):
+        entries = [{"id": "1", "title": "News"}]
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_epg("123")
+        self.assertEqual(result, entries)
+
+    async def test_dict_response_null_epg_listings_returns_empty(self):
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": None})
+        result = await client.get_epg("123")
+        self.assertEqual(result, [])
+
+
+class GetShortEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_bare_list_response_returns_list(self):
+        """Provider returns [] instead of {"epg_listings": []}; must not AttributeError."""
+        client = _client()
+        client._get_session = _mock_session([])
+        result = await client.get_short_epg("123")
+        self.assertEqual(result, [])
+
+    async def test_bare_list_with_entries_returned(self):
+        entries = [{"id": "1", "title": "Movie"}]
+        client = _client()
+        client._get_session = _mock_session(entries)
+        result = await client.get_short_epg("123")
+        self.assertEqual(result, entries)
+
+    async def test_dict_response_extracts_epg_listings(self):
+        entries = [{"id": "1", "title": "Movie"}]
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_short_epg("123")
+        self.assertEqual(result, entries)
+
+    async def test_dict_response_null_epg_listings_returns_empty(self):
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": None})
+        result = await client.get_short_epg("123")
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If your IPTV provider returns EPG data in a slightly different format (a plain list instead of the standard `{"epg_listings": [...]}` wrapper), the catchup guide for affected channels would be silently empty. On the Browse EPG page it would show no programs to download. No error message, just nothing.

## What changed

`get_epg()` and `get_short_epg()` in `xtream_client.py` now handle both response shapes:
- `{"epg_listings": [...]}` (standard): extracts the list as before
- `[...]` (bare list): returns it directly

This is the same fix applied to VOD/series methods in a prior patch. `get_epg()` and `get_short_epg()` were missed.

## Before

```
data = []  # provider returned a bare list
data.get("epg_listings")  # AttributeError: 'list' object has no attribute 'get'
```

During EPG backfill: `AttributeError` caught per-channel, logged as warning, channel gets no EPG rows, catchup page empty with no explanation.

On Browse EPG live-EPG fallback path: `AttributeError` propagates as HTTP 500.

## After

```python
if isinstance(data, list):
    return data
return data.get("epg_listings") or []
```

Bare-list response returns the list directly. No error, channel EPG populated normally.

## How it was tested

8 new unit tests in `test_xtream_client_epg_list_response.py` cover both methods across four cases each: bare empty list, bare non-empty list, standard dict response, and null `epg_listings`. Bare-list tests fail before the fix (AttributeError), pass after. Full suite: 715 tests, OK.