### PR TITLE
design: add confirm password field to Security settings

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -141,6 +141,7 @@ export default function Settings() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [newUserName, setNewUserName] = useState('')
   const [newUserDisplayName, setNewUserDisplayName] = useState('')
   const [newUserPassword, setNewUserPassword] = useState('')
@@ -312,6 +313,7 @@ export default function Settings() {
     onSuccess: async () => {
       setCurrentPassword('')
       setNewPassword('')
+      setConfirmPassword('')
       queryClient.setQueryData(['auth', 'status'], (previous) => {
         if (!previous) return previous
         return {
@@ -533,6 +535,14 @@ export default function Settings() {
       notifications.show({
         title: 'Password too short',
         message: 'New password must be at least 8 characters.',
+        color: 'yellow',
+      })
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      notifications.show({
+        title: 'Passwords do not match',
+        message: 'New password and confirmation must be the same.',
         color: 'yellow',
       })
       return
@@ -1095,7 +1105,7 @@ export default function Settings() {
         <Text fw={600} size="lg">Security</Text>
         <Text size="sm" c="dimmed">
           {isAdmin
-            ? 'Change the admin password used to access Settings'
+            ? 'Change your admin account password'
             : 'Change your local download user password'}
         </Text>
       </Stack>
@@ -1122,6 +1132,13 @@ export default function Settings() {
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}
             autoComplete="new-password"
+          />
+          <PasswordInput
+            label={isAdmin ? 'Confirm New Admin Password' : 'Confirm New Password'}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            autoComplete="new-password"
+            error={confirmPassword && confirmPassword !== newPassword ? 'Passwords do not match' : null}
           />
           <Group justify="flex-end">
             <Button


### PR DESCRIPTION
## What a user would notice

Settings > Security had two password fields: Current Admin Password and New Admin Password. There was no confirmation field. If a user mistyped their new password on a phone or while distracted, they would set an unknown password and lock themselves out of Mustarrd with no warning.

Now there is a third field: Confirm New Admin Password. The field shows a red "Passwords do not match" error inline while the user is typing, so they know before hitting Change Password. The submit handler also validates the match and shows a notification if they somehow reach it with mismatched values.

The description was also updated from "Change the admin password used to access Settings" to "Change your admin account password" since the password controls the whole app, not just Settings.

## What changed

\`frontend/src/pages/Settings.jsx\` only. No backend changes.

- Added \`confirmPassword\` state (cleared on success alongside the other fields).
- Added inline \`error\` prop on the new PasswordInput: shows "Passwords do not match" when confirm is non-empty and differs from new password.
- Added mismatch check in \`handleChangePassword\` before calling the API.
- Corrected the Security section description for admin users.

## How it was tested

Playwright: opened Security, typed different values in New and Confirm fields, confirmed the red inline error appeared. Typed matching values, confirmed no error. Before/after screenshots in #design.

## Before / After

Before: two fields, no typo protection, description says "...used to access Settings".
After: three fields, inline mismatch error, description says "Change your admin account password".

Screenshots in the Pixel iteration 40 thread in #design.