### PR TITLE
design: show guidance when Plex account is not connected

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1257,7 +1257,7 @@ export default function Settings() {
   const renderPlex = () => (
     <Stack gap="md">
       <Text fw={600}>Plex Integration</Text>
-      <Group justify="space-between" align="center">
+      <Group align="center">
         <Button
           variant="light"
           onClick={() => {
@@ -1268,107 +1268,119 @@ export default function Settings() {
         >
           Connect Plex Account
         </Button>
-        <Button
-          variant="subtle"
-          onClick={() => listPlexResourcesMutation.mutate()}
-          loading={listPlexResourcesMutation.isPending}
-        >
-          Refresh Servers
-        </Button>
-        <Button
-          variant="subtle"
-          color="red"
-          onClick={() => disconnectPlexMutation.mutate()}
-          loading={disconnectPlexMutation.isPending}
-        >
-          Disconnect
-        </Button>
+        {plexConfig?.token_configured && (
+          <>
+            <Button
+              variant="subtle"
+              onClick={() => listPlexResourcesMutation.mutate()}
+              loading={listPlexResourcesMutation.isPending}
+            >
+              Refresh Servers
+            </Button>
+            <Button
+              variant="subtle"
+              color="red"
+              onClick={() => disconnectPlexMutation.mutate()}
+              loading={disconnectPlexMutation.isPending}
+            >
+              Disconnect
+            </Button>
+          </>
+        )}
       </Group>
 
-      <Select
-        label="Plex Server"
-        placeholder="Select an owned server"
-        data={plexResources.map((r) => ({
-          value: r.resource_id,
-          label: `${r.name}${r.platform ? ` (${r.platform})` : ''}`,
-        }))}
-        value={plexForm.resource_id || null}
-        onChange={(value) => {
-          if (!value) return
-          const selected = plexResources.find((r) => r.resource_id === value)
-          updatePlexForm((prev) => ({
-            ...prev,
-            resource_id: value,
-            resource_name: selected?.name || '',
-            machine_identifier: selected?.machine_identifier || null,
-            connection_uri: selected?.base_url || '',
-            base_url: selected?.base_url || '',
-          }))
-          setPlexLibraries([])
-          listPlexLibrariesMutation.mutate({ resourceId: value, connectionUri: selected?.base_url || '' })
-        }}
-      />
+      {!plexConfig?.token_configured ? (
+        <Alert color="blue" variant="light" icon={<IconAlertCircle size={16} />}>
+          No Plex account connected. Click Connect Plex Account to sign in with Plex. Your servers and libraries will appear here once connected.
+        </Alert>
+      ) : (
+        <>
+          <Select
+            label="Plex Server"
+            placeholder="Select an owned server"
+            data={plexResources.map((r) => ({
+              value: r.resource_id,
+              label: `${r.name}${r.platform ? ` (${r.platform})` : ''}`,
+            }))}
+            value={plexForm.resource_id || null}
+            onChange={(value) => {
+              if (!value) return
+              const selected = plexResources.find((r) => r.resource_id === value)
+              updatePlexForm((prev) => ({
+                ...prev,
+                resource_id: value,
+                resource_name: selected?.name || '',
+                machine_identifier: selected?.machine_identifier || null,
+                connection_uri: selected?.base_url || '',
+                base_url: selected?.base_url || '',
+              }))
+              setPlexLibraries([])
+              listPlexLibrariesMutation.mutate({ resourceId: value, connectionUri: selected?.base_url || '' })
+            }}
+          />
 
-      <Select
-        label="Connection URI"
-        placeholder="Select which Plex endpoint to use"
-        data={(plexResources.find((r) => r.resource_id === plexForm.resource_id)?.connections || []).map((conn) => ({
-          value: conn.uri,
-          label: `${conn.uri}${conn.local ? ' (Local)' : ''}${conn.relay ? ' (Relay)' : ''}`,
-        }))}
-        value={plexForm.connection_uri || null}
-        onChange={(value) => {
-          if (!value || !plexForm.resource_id) return
-          updatePlexForm((prev) => ({ ...prev, connection_uri: value, base_url: value }))
-          setPlexLibraries([])
-          listPlexLibrariesMutation.mutate({ resourceId: plexForm.resource_id, connectionUri: value })
-        }}
-      />
+          <Select
+            label="Connection URI"
+            placeholder="Select which Plex endpoint to use"
+            data={(plexResources.find((r) => r.resource_id === plexForm.resource_id)?.connections || []).map((conn) => ({
+              value: conn.uri,
+              label: `${conn.uri}${conn.local ? ' (Local)' : ''}${conn.relay ? ' (Relay)' : ''}`,
+            }))}
+            value={plexForm.connection_uri || null}
+            onChange={(value) => {
+              if (!value || !plexForm.resource_id) return
+              updatePlexForm((prev) => ({ ...prev, connection_uri: value, base_url: value }))
+              setPlexLibraries([])
+              listPlexLibrariesMutation.mutate({ resourceId: plexForm.resource_id, connectionUri: value })
+            }}
+          />
 
-      <MultiSelect
-        label="Libraries to Refresh"
-        placeholder="Choose one or more libraries"
-        data={plexLibraries.map((lib) => ({
-          value: String(lib.id),
-          label: `${lib.title}${lib.type ? ` (${lib.type})` : ''}`,
-        }))}
-        value={(plexForm.library_section_ids || []).map((v) => String(v))}
-        onChange={(values) => updatePlexForm((prev) => ({ ...prev, library_section_ids: values }))}
-        searchable
-      />
+          <MultiSelect
+            label="Libraries to Refresh"
+            placeholder="Choose one or more libraries"
+            data={plexLibraries.map((lib) => ({
+              value: String(lib.id),
+              label: `${lib.title}${lib.type ? ` (${lib.type})` : ''}`,
+            }))}
+            value={(plexForm.library_section_ids || []).map((v) => String(v))}
+            onChange={(values) => updatePlexForm((prev) => ({ ...prev, library_section_ids: values }))}
+            searchable
+          />
 
-      <Switch
-        label="Allow Plex server users to sign in to Mustarrd"
-        checked={plexForm.auto_allow_all_server_users}
-        onChange={(e) =>
-          updatePlexForm((prev) => ({ ...prev, auto_allow_all_server_users: e.currentTarget.checked }))
-        }
-      />
-      <Switch
-        label="Auto-refresh selected Plex libraries after downloads"
-        checked={plexForm.enabled}
-        onChange={(e) => updatePlexForm((prev) => ({ ...prev, enabled: e.currentTarget.checked }))}
-      />
-      <Group justify="flex-end">
-        <Button
-          onClick={() =>
-            savePlexMutation.mutate({
-              resource_id: plexForm.resource_id,
-              resource_name: plexForm.resource_name || null,
-              connection_uri: plexForm.connection_uri || plexForm.base_url,
-              base_url: plexForm.base_url,
-              machine_identifier: plexForm.machine_identifier || null,
-              library_section_ids: (plexForm.library_section_ids || []).map((s) => String(s)),
-              auto_allow_all_server_users: plexForm.auto_allow_all_server_users,
-              enabled: plexForm.enabled,
-            })
-          }
-          disabled={!plexForm.resource_id || !plexForm.base_url}
-          loading={savePlexMutation.isPending}
-        >
-          Save Plex Integration
-        </Button>
-      </Group>
+          <Switch
+            label="Allow Plex server users to sign in to Mustarrd"
+            checked={plexForm.auto_allow_all_server_users}
+            onChange={(e) =>
+              updatePlexForm((prev) => ({ ...prev, auto_allow_all_server_users: e.currentTarget.checked }))
+            }
+          />
+          <Switch
+            label="Auto-refresh selected Plex libraries after downloads"
+            checked={plexForm.enabled}
+            onChange={(e) => updatePlexForm((prev) => ({ ...prev, enabled: e.currentTarget.checked }))}
+          />
+          <Group justify="flex-end">
+            <Button
+              onClick={() =>
+                savePlexMutation.mutate({
+                  resource_id: plexForm.resource_id,
+                  resource_name: plexForm.resource_name || null,
+                  connection_uri: plexForm.connection_uri || plexForm.base_url,
+                  base_url: plexForm.base_url,
+                  machine_identifier: plexForm.machine_identifier || null,
+                  library_section_ids: (plexForm.library_section_ids || []).map((s) => String(s)),
+                  auto_allow_all_server_users: plexForm.auto_allow_all_server_users,
+                  enabled: plexForm.enabled,
+                })
+              }
+              disabled={!plexForm.resource_id || !plexForm.base_url}
+              loading={savePlexMutation.isPending}
+            >
+              Save Plex Integration
+            </Button>
+          </Group>
+        </>
+      )}
     </Stack>
   )
 


### PR DESCRIPTION
## What a user would notice

Before this change, Settings > Plex Integration showed three empty dropdowns (Plex Server, Connection URI, Libraries to Refresh), a Disconnect button, and two switches even when no Plex account had been linked. A non-technical user would see what appeared to be a broken form with no indication of what to do first.

After this change, when no Plex account is connected the form is hidden and replaced with a single clear message: "No Plex account connected. Click Connect Plex Account to sign in with Plex. Your servers and libraries will appear here once connected." The Disconnect and Refresh Servers buttons are also hidden until an account is linked. The full form reappears once connected.

## What changed

One file, frontend only (`frontend/src/pages/Settings.jsx`). The `renderPlex` function now conditionally renders based on `plexConfig?.token_configured`. No backend changes.

## How it was tested

Playwright screenshots taken at 1280x800 (desktop) and 390x844 (mobile) with the app running locally. Before/after screenshots posted to #design. Both widths confirmed clean.

**Before:** Empty dropdowns, Disconnect/Refresh buttons visible, no explanation.
**After:** Single "Connect Plex Account" button and a clear guidance alert.