### PR TITLE
fix: CDATA with literal <programme text triggers spurious force-delete

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -299,7 +299,8 @@ class EPGIngestManager:
 
             raw_xmltv = await client.get_xmltv()
             xmltv_bytes = self._maybe_decompress(raw_xmltv) if raw_xmltv else b""
-            total_programs = xmltv_bytes.count(b"<programme") if xmltv_bytes else 0
+            _xmltv_no_cdata = re.sub(rb"<!\[CDATA\[.*?\]\]>", b"", xmltv_bytes, flags=re.DOTALL) if xmltv_bytes else b""
+            total_programs = _xmltv_no_cdata.count(b"<programme")
             self._status["total_programs"] = total_programs if total_programs > 0 else None
             if xmltv_bytes:
                 await self._log(

--- a/backend/tests/test_epg_force_wipe_empty_xmltv.py
+++ b/backend/tests/test_epg_force_wipe_empty_xmltv.py
@@ -123,6 +123,45 @@ class EPGForceWipeEmptyXmltvTests(unittest.IsolatedAsyncioTestCase):
             f"Got DELETE statements: {delete_tracker}",
         )
 
+    async def test_force_refresh_cdata_only_programme_text_does_not_delete_rows(self):
+        """No DELETE issued when <programme text appears only inside a CDATA section.
+
+        CDATA sections are opaque text to the XML parser. ET.iterparse correctly treats
+        their content as character data, not elements, so no programme events are yielded.
+        But the old code counted <programme via raw byte scan, which hit the CDATA
+        text, set total_programs > 0, and triggered force-delete. The guide was then wiped
+        and nothing was inserted.
+
+        After the fix, CDATA sections are stripped from the byte buffer before counting,
+        so total_programs stays 0 and existing rows are preserved.
+        """
+        manager = EPGIngestManager()
+        account = _make_account()
+        delete_tracker = []
+
+        cdata_only_xmltv = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b"<tv>"
+            b'<channel id="ch1"><display-name>Test</display-name></channel>'
+            b"<desc><![CDATA[<programme type=\"x\">fake</programme>]]></desc>"
+            b"</tv>"
+        )
+        client = _make_xtream_client(xmltv_bytes=cdata_only_xmltv)
+
+        with (
+            patch("services.epg_ingest_manager.async_session_maker", side_effect=_make_session_ctx(delete_tracker)),
+            patch("services.epg_ingest_manager.resolve_account_password", return_value="pass"),
+            patch("services.epg_ingest_manager.XtreamClient", return_value=client),
+        ):
+            await manager._refresh_account(account, force=True)
+
+        self.assertEqual(
+            delete_tracker,
+            [],
+            "No DELETE must be issued when <programme text appears only inside CDATA. "
+            f"Got DELETE statements: {delete_tracker}",
+        )
+
     async def test_force_refresh_nonempty_xmltv_does_delete_rows(self):
         """DELETE is issued when provider returns an XMLTV body with programme entries."""
         manager = EPGIngestManager()


### PR DESCRIPTION
## What a user would notice

If your IPTV provider sends XMLTV data where a program description contains the text `<programme` inside a CDATA block (for example, a description referencing an XML format), a forced EPG refresh would silently wipe your entire guide and then insert nothing. The catchup page would appear empty until the next automatic refresh.

## What changed

The code that counts `<programme` elements before deciding whether to clear the guide was using a raw byte scan. That scan could not distinguish between real XML elements and the same text buried inside a CDATA section. CDATA content is opaque character data to the XML parser, so `ET.iterparse` correctly ignores it and yields zero programme events, but the byte count still returned 1, which triggered the delete.

The fix strips CDATA sections from the byte buffer before counting, so the guard only fires when real parseable programme elements exist.

```
Before fix:
  xmltv_bytes.count(b"<programme")  # counts CDATA text too -> 1
  -> force-delete fires, guide wiped, nothing inserted

After fix:
  re.sub(CDATA pattern, b"", xmltv_bytes).count(b"<programme")  # 0
  -> force-delete skipped, existing rows preserved
```

## How it was tested

Added `test_force_refresh_cdata_only_programme_text_does_not_delete_rows` to `test_epg_force_wipe_empty_xmltv.py`. The test sends an XMLTV document containing `<programme` only inside a CDATA section, calls `_refresh_account(force=True)`, and asserts no DELETE statement was issued.

The new test fails against the old code (DELETE fires) and passes with the fix. Full suite: 718 tests, OK.