### PR TITLE
fix: out-of-range start_timestamp returns HTTP 400 instead of 500

### DIFF
--- a/backend/api/schedules.py
+++ b/backend/api/schedules.py
@@ -39,8 +39,11 @@ def _parse_program(program: dict) -> tuple[datetime, datetime, int, int, int, st
     stop_timestamp = _coerce_ts(program.get("stop_timestamp"))
 
     if start_timestamp and stop_timestamp:
-        start_time = datetime.fromtimestamp(int(start_timestamp), tz=timezone.utc)
-        end_time = datetime.fromtimestamp(int(stop_timestamp), tz=timezone.utc)
+        try:
+            start_time = datetime.fromtimestamp(int(start_timestamp), tz=timezone.utc)
+            end_time = datetime.fromtimestamp(int(stop_timestamp), tz=timezone.utc)
+        except (OverflowError, OSError) as exc:
+            raise ValueError(f"Program timestamp out of range: {exc}") from exc
     elif isinstance(program.get("start_time"), str) and isinstance(program.get("end_time"), str):
         start_time = datetime.fromisoformat(program["start_time"])
         end_time = datetime.fromisoformat(program["end_time"])

--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -32,8 +32,11 @@ def _parse_program_times(program: dict) -> tuple[datetime, datetime, int, dateti
     ts_start = _coerce_ts(start_timestamp)
     ts_stop = _coerce_ts(stop_timestamp)
     if ts_start and ts_stop:
-        program_start_utc = datetime.fromtimestamp(ts_start, tz=timezone.utc)
-        program_end_utc = datetime.fromtimestamp(ts_stop, tz=timezone.utc)
+        try:
+            program_start_utc = datetime.fromtimestamp(ts_start, tz=timezone.utc)
+            program_end_utc = datetime.fromtimestamp(ts_stop, tz=timezone.utc)
+        except (OverflowError, OSError) as exc:
+            raise ValueError(f"Program timestamp out of range: {exc}") from exc
         duration_minutes = int((program_end_utc - program_start_utc).total_seconds() / 60)
     else:
         start_time = program.get("start_time")

--- a/backend/tests/test_timestamp_overflow.py
+++ b/backend/tests/test_timestamp_overflow.py
@@ -1,0 +1,59 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_builder import _parse_program_times
+from api.schedules import _parse_program
+
+# A timestamp value so large that datetime.fromtimestamp raises OverflowError
+# on all supported platforms (Linux/macOS/Windows 64-bit).
+_HUGE_TS = 99999999999999999999
+
+
+class TestTimestampOverflowDownloadBuilder(unittest.TestCase):
+    """_parse_program_times must raise ValueError (not OverflowError/OSError) for out-of-range timestamps."""
+
+    def test_overflow_start_raises_value_error(self):
+        program = {"start_timestamp": _HUGE_TS, "stop_timestamp": _HUGE_TS}
+        with self.assertRaises(ValueError):
+            _parse_program_times(program)
+
+    def test_overflow_stop_raises_value_error(self):
+        program = {"start_timestamp": 1743354000, "stop_timestamp": _HUGE_TS}
+        with self.assertRaises(ValueError):
+            _parse_program_times(program)
+
+    def test_normal_timestamp_unaffected(self):
+        """Regression: valid timestamps still parse correctly after the fix."""
+        program = {"start_timestamp": 1743354000, "stop_timestamp": 1743357600}
+        start, end, duration, _, _ = _parse_program_times(program)
+        self.assertEqual(duration, 60)
+
+
+class TestTimestampOverflowSchedules(unittest.TestCase):
+    """_parse_program must raise ValueError (not OverflowError/OSError) for out-of-range timestamps."""
+
+    def test_overflow_start_raises_value_error(self):
+        program = {"start_timestamp": _HUGE_TS, "stop_timestamp": _HUGE_TS}
+        with self.assertRaises(ValueError):
+            _parse_program(program)
+
+    def test_overflow_stop_raises_value_error(self):
+        program = {"start_timestamp": 1743354000, "stop_timestamp": _HUGE_TS}
+        with self.assertRaises(ValueError):
+            _parse_program(program)
+
+    def test_normal_timestamp_unaffected(self):
+        """Regression: valid timestamps still parse correctly after the fix."""
+        program = {"start_timestamp": 1743354000, "stop_timestamp": 1743357600}
+        _, _, start_ts, _, duration, _, _ = _parse_program(program)
+        self.assertEqual(start_ts, 1743354000)
+        self.assertEqual(duration, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Sending a POST request to `/api/downloads` or `/api/schedules` with a timestamp value that is impossibly large (for example, from a corrupted IPTV provider EPG or a crafted API request) caused a server crash and returned HTTP 500. The server logged an unhandled `OverflowError`. It should have returned HTTP 400.

Normal frontend use is not affected: EPG timestamps from providers are always valid. This matters for API integrations and IPTV providers with corrupted far-future timestamps in their guide data.

## What changed

Two call sites used `datetime.fromtimestamp()` without catching `OverflowError` or `OSError`, which Python raises when a timestamp exceeds the platform's `time_t` range:

- `backend/services/download_builder.py`: `_parse_program_times()`, used by `POST /api/downloads`
- `backend/api/schedules.py`: `_parse_program()`, used by `POST /api/schedules`

Both functions already raised `ValueError` for other bad inputs, and their callers already converted `ValueError` to HTTP 400. The fix wraps the `fromtimestamp` calls in a `try/except (OverflowError, OSError)` and re-raises as `ValueError`, so the same HTTP 400 path is used.

`GET /api/downloads/failed-count` already used this exact pattern at line 206.

## How it was tested

Six regression tests in `backend/tests/test_timestamp_overflow.py`:

- `TestTimestampOverflowDownloadBuilder`: overflow start, overflow stop, normal timestamp guard (3 tests)
- `TestTimestampOverflowSchedules`: same three cases for the schedules path

The overflow tests fail before this fix (`OverflowError` raised, not `ValueError`) and pass after. The normal-timestamp guards confirm no regression.

**Before:**
```
POST /api/downloads {"program": {"start_timestamp": 99999999999999999999, ...}}
=> HTTP 500  OverflowError: Python int too large to convert to C long
```

**After:**
```
POST /api/downloads {"program": {"start_timestamp": 99999999999999999999, ...}}
=> HTTP 400  Invalid program payload
```

Full suite: 724 tests, all pass.

Fixes: https://discord.com/channels/1512584990910763059/1513867873800552590