### PR TITLE
design: add guidance to cancelled scheduled recording cards

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -198,6 +198,13 @@ function ScheduleCard({
           </Group>
         )}
 
+        {schedule.status === 'cancelled' && !schedule.status_message && !schedule.download_id && (
+          <Text size="xs" c="dimmed">
+            Cancelled before downloading. If this program is still in your provider&apos;s catchup window, you can find it in{' '}
+            <Link to="/browse" style={{ color: 'var(--mantine-color-orange-5)' }}>Browse EPG</Link>.
+          </Text>
+        )}
+
         {schedule.download_status === 'completed' && schedule.download_id && (
           <Group gap="xs">
             {isDesktop ? (


### PR DESCRIPTION
## What a user would notice

Before this change, cancelled scheduled recordings in Scheduled > History showed only the show title, channel, status badge, and air time. There was no explanation of what happened or any way to act on it. A user who did not deliberately cancel the recording had no idea why it was cancelled or what to do next.

After this change, cancelled cards that have no specific system message now show a short note: "Cancelled before downloading. If this program is still in your provider's catchup window, you can find it in Browse EPG." The words "Browse EPG" are a clickable link that takes the user directly there.

## What changed

Added a fallback text block to `ScheduleCard` in `Scheduled.jsx`. It renders only when `status === 'cancelled'` and no `status_message` or `download_id` is present (i.e., the recording was cancelled before a download was created). FAILED cards and cards with a specific system message are unaffected.

One file changed, no backend changes, no new dependencies.

## Before

Cancelled card shows title, channel, CANCELLED badge, and air time. Nothing else. No explanation, no next step.

## After

Cancelled card shows the same info plus: "Cancelled before downloading. If this program is still in your provider's catchup window, you can find it in Browse EPG."

## How it was tested

App started locally. Playwright screenshots taken before and after at desktop (1440x900) and mobile (390x844). Verified FAILED cards and COMPLETED cards are unchanged. Verified the Browse EPG link navigates correctly.