### PR TITLE
fix: rate-limit plex_login_start to prevent Plex.tv API exhaustion

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -34,6 +34,7 @@ RATE_LIMIT_WINDOW_SECONDS = 15 * 60
 RATE_LIMITS = {
     "setup": 6,
     "login": 20,
+    "plex_start": 10,
     "plex_complete": 30,
 }
 _attempt_log: dict[tuple[str, str], list[float]] = {}
@@ -369,7 +370,8 @@ async def login_download_user_legacy(
 
 
 @router.post("/plex/login/start")
-async def plex_login_start(session: AsyncSession = Depends(get_session)):
+async def plex_login_start(request: Request, session: AsyncSession = Depends(get_session)):
+    _enforce_rate_limit("plex_start", request)
     plex_result = await session.execute(select(PlexServer).limit(1))
     plex_server = plex_result.scalar_one_or_none()
     if not plex_server or not plex_server.auto_allow_all_server_users or not (plex_server.connection_uri or plex_server.base_url):

--- a/backend/tests/test_plex_start_rate_limit.py
+++ b/backend/tests/test_plex_start_rate_limit.py
@@ -1,0 +1,121 @@
+"""
+Regression test: plex_login_start must be rate-limited.
+
+Before fix: POST /api/auth/plex/login/start had no call to _enforce_rate_limit.
+An unauthenticated caller could loop the endpoint without bound, creating Plex.tv
+PINs until Plex.tv rate-limits the shared client identifier, breaking legitimate
+Plex logins for all users.
+
+After fix:
+- RATE_LIMITS["plex_start"] = 10 is defined.
+- plex_login_start calls _enforce_rate_limit("plex_start", request) before any DB work.
+- The 11th request from the same client within the window receives HTTP 429.
+- Requests below the limit still pass through to Plex.tv.
+"""
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import api.auth as auth_module
+from api.auth import RATE_LIMITS, plex_login_start
+from database import Base
+from models import PlexServer
+
+
+def _mock_request(host="127.0.0.1"):
+    req = MagicMock()
+    req.client = MagicMock()
+    req.client.host = host
+    req.session = {}
+    return req
+
+
+class PlexStartRateLimitTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+        auth_module._attempt_log.clear()
+
+    async def asyncTearDown(self):
+        auth_module._attempt_log.clear()
+        await self.engine.dispose()
+
+    async def _seed_plex_server(self):
+        async with self.session_factory() as session:
+            server = PlexServer(
+                base_url="http://plex.local",
+                token_encrypted="enc-tok",
+                access_token_encrypted="enc-tok",
+                auto_allow_all_server_users=True,
+            )
+            session.add(server)
+            await session.commit()
+
+    async def test_rate_limit_key_defined(self):
+        """plex_start must have an entry in RATE_LIMITS."""
+        self.assertIn("plex_start", RATE_LIMITS)
+        self.assertGreater(RATE_LIMITS["plex_start"], 0)
+
+    async def test_eleventh_request_returns_429(self):
+        """11th call from the same client within the window must get HTTP 429."""
+        limit = RATE_LIMITS["plex_start"]
+        key = ("plex_start", "10.0.0.1")
+        now = time.monotonic()
+        # Pre-fill the log to the limit (all within the rate window)
+        auth_module._attempt_log[key] = [now - 1] * limit
+
+        async with self.session_factory() as session:
+            with self.assertRaises(HTTPException) as ctx:
+                await plex_login_start(_mock_request("10.0.0.1"), session)
+
+        self.assertEqual(ctx.exception.status_code, 429)
+
+    async def test_under_limit_passes_through(self):
+        """Requests below the limit must reach plex_service.create_pin."""
+        await self._seed_plex_server()
+        fake_pin = {"id": 99, "code": "ABCD", "expires_in": 300}
+        with patch("api.auth.plex_service.create_pin", new=AsyncMock(return_value=fake_pin)):
+            async with self.session_factory() as session:
+                result = await plex_login_start(_mock_request("10.0.0.2"), session)
+
+        self.assertEqual(result["id"], 99)
+
+    async def test_different_clients_have_independent_buckets(self):
+        """Exhausting one client's bucket must not block a different client."""
+        limit = RATE_LIMITS["plex_start"]
+        now = time.monotonic()
+        # Fill up client A's bucket
+        auth_module._attempt_log[("plex_start", "10.0.0.3")] = [now - 1] * limit
+
+        # Client B (10.0.0.4) should still get through
+        await self._seed_plex_server()
+        fake_pin = {"id": 55, "code": "WXYZ", "expires_in": 300}
+        with patch("api.auth.plex_service.create_pin", new=AsyncMock(return_value=fake_pin)):
+            async with self.session_factory() as session:
+                result = await plex_login_start(_mock_request("10.0.0.4"), session)
+
+        self.assertEqual(result["id"], 55)
+
+        # Client A still blocked
+        async with self.session_factory() as session:
+            with self.assertRaises(HTTPException) as ctx:
+                await plex_login_start(_mock_request("10.0.0.3"), session)
+        self.assertEqual(ctx.exception.status_code, 429)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If Mustarrd is internet-exposed (NPM, Cloudflare Tunnel), an attacker could rapidly loop \`POST /api/auth/plex/login/start\` with no limit. Each call creates a real PIN on Plex.tv using the shared client identifier. If enough PINs are created, Plex.tv throttles the identifier and legitimate Plex users get \"Plex PIN create failed\" errors until the window expires.

## What changed

Added \`RATE_LIMITS["plex_start"] = 10\` and wired \`_enforce_rate_limit("plex_start", request)\` into \`plex_login_start\`, exactly matching the pattern \`plex_login_complete\` and the password login endpoints already use. The 11th request from the same client within the rate window returns HTTP 429. Requests below the limit are unaffected.

## Before

```
for i in $(seq 1 200); do curl -s -X POST http://host:4177/api/auth/plex/login/start; done
# All 200 return 200 OK and create real Plex.tv PINs
```

## After

```
# First 10 succeed; 11th returns:
{"detail":"Too many authentication attempts"}  HTTP 429
```

## Tests

4 new regression tests in \`backend/tests/test_plex_start_rate_limit.py\`:
- \`test_rate_limit_key_defined\`: asserts \`RATE_LIMITS["plex_start"]\` exists and is > 0
- \`test_eleventh_request_returns_429\`: pre-fills the log to the limit, verifies 429
- \`test_under_limit_passes_through\`: verifies calls below the limit still reach \`plex_service.create_pin\`
- \`test_different_clients_have_independent_buckets\`: exhausting client A's bucket doesn't block client B

Full suite: 728 tests, all pass.

## Steps to test

1. Configure Plex integration (or use a Mustarrd instance with \`auto_allow_all_server_users=True\`).
2. Before: 11 rapid POSTs all return 200. After: 11th returns 429.