### PR TITLE
design: add description to Download-Only Users settings panel

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1182,8 +1182,11 @@ export default function Settings() {
   )
 
   const renderUsers = () => (
-    <Stack gap="md">
-      <Text fw={600}>Download-Only Users</Text>
+    <Stack gap="lg">
+      <Stack gap={2}>
+        <Text fw={600} size="lg">Download-Only Users</Text>
+        <Text size="sm" c="dimmed">Can browse channels and download programs. Cannot access Settings or schedule recordings.</Text>
+      </Stack>
       <Alert color="blue" variant="light">
         <Group justify="space-between" align="center" wrap="nowrap">
           <Text size="sm">Plex Integration controls Plex-based sign-in and server/library sync.</Text>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1185,7 +1185,7 @@ export default function Settings() {
     <Stack gap="lg">
       <Stack gap={2}>
         <Text fw={600} size="lg">Download-Only Users</Text>
-        <Text size="sm" c="dimmed">Can browse channels and download programs. Cannot access Settings or schedule recordings.</Text>
+        <Text size="sm" c="dimmed">Can browse channels, schedule recordings, and download programs. Cannot access Settings.</Text>
       </Stack>
       <Alert color="blue" variant="light">
         <Group justify="space-between" align="center" wrap="nowrap">


### PR DESCRIPTION
## What changed

Settings > Users had no description subtitle and an undersized title, unlike every other settings panel in the app.

Every other section (Recording, Post-Processing, File Naming, Guide, Appearance, Security) shows a dimmed subtitle explaining what the section does. Users had only a bold title with no context.

## What a user would notice

Before: clicking Settings > Users showed "Download-Only Users" with no explanation of what these accounts can or cannot do.

After: a one-line description now reads: "Can browse channels, schedule recordings, and download programs. Cannot access Settings."

The description accurately reflects the actual permission model: download-only users can schedule recordings (POST /schedules allows them), but cannot access the Settings page.

## How it was tested

Playwright screenshots at 1280px desktop and 390px mobile confirm the description renders correctly at both widths.

## Files changed

- `frontend/src/pages/Settings.jsx`: added `size="lg"` to the title and a dimmed description line under it. One file, no backend changes.