### PR TITLE
fix: get_auth_context validates User.role for download_only sessions

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -129,7 +129,7 @@ async def get_auth_context(
 
     if role == "download_only" and user_id:
         result = await session.execute(
-            select(User).where(User.id == int(user_id))
+            select(User).where(User.id == int(user_id), User.role == "download_only")
         )
         user = result.scalar_one_or_none()
         if user and user.status == "active":

--- a/backend/tests/test_auth_context_role_check.py
+++ b/backend/tests/test_auth_context_role_check.py
@@ -1,0 +1,88 @@
+"""
+Regression test: get_auth_context must verify User.role == "download_only" in DB.
+
+Before fix: the download_only branch queried only by User.id, never checking
+User.role. A session cookie with auth_role="download_only" for an admin user_id
+was granted download_only access without DB role confirmation.
+
+After fix: the query filters on both User.id AND User.role == "download_only",
+consistent with how the admin branch already works. An admin user with a tampered
+download_only cookie gets AuthContext(authenticated=False).
+"""
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from auth import SESSION_AUTH_ROLE_KEY, SESSION_USER_ID_KEY, get_auth_context
+from database import Base
+from models import User
+
+
+def _mock_request(role, user_id):
+    req = MagicMock()
+    req.session = {SESSION_AUTH_ROLE_KEY: role, SESSION_USER_ID_KEY: user_id}
+    return req
+
+
+class AuthContextRoleCheckTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.Session = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _create_user(self, role):
+        async with self.Session() as session:
+            user = User(
+                role=role,
+                status="active",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            session.add(user)
+            await session.commit()
+            return user.id
+
+    async def test_download_only_user_authenticates(self):
+        """download_only cookie for download_only DB user authenticates correctly."""
+        uid = await self._create_user("download_only")
+        async with self.Session() as session:
+            ctx = await get_auth_context(_mock_request("download_only", uid), session)
+        self.assertTrue(ctx.authenticated)
+        self.assertEqual(ctx.role, "download_only")
+
+    async def test_admin_user_with_download_only_cookie_rejected(self):
+        """Admin DB user with a tampered download_only cookie must not authenticate.
+
+        Before fix: get_auth_context queried only by User.id and granted access.
+        After fix: the query also filters by User.role == "download_only", so the
+        admin row is not returned and the session is rejected.
+        """
+        uid = await self._create_user("admin")
+        async with self.Session() as session:
+            ctx = await get_auth_context(_mock_request("download_only", uid), session)
+        self.assertFalse(ctx.authenticated)
+
+    async def test_unknown_user_id_rejected(self):
+        """Non-existent user_id in download_only cookie must not authenticate."""
+        async with self.Session() as session:
+            ctx = await get_auth_context(_mock_request("download_only", 9999), session)
+        self.assertFalse(ctx.authenticated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

No visible change for normal users. This closes a consistency gap in how the app verifies who you are when you log in.

## What changed

When you log in, the app stores your role (admin or download-only) in a session cookie. When you make a request, it checks that cookie against the database to confirm you are still allowed in.

The admin path has always verified your role in the database: it only accepts a session if the database row also says admin. The download-only path was missing that same check. It confirmed your user ID but not your role, so the server was taking the cookie's word for it rather than checking the database.

The fix adds the matching role filter to the download-only branch. One line change in `backend/auth.py`:

**Before:**
```python
select(User).where(User.id == int(user_id))
```

**After:**
```python
select(User).where(User.id == int(user_id), User.role == "download_only")
```

## How it was tested

Three regression tests in `backend/tests/test_auth_context_role_check.py`:

1. A download-only DB user with a matching cookie authenticates correctly (unchanged behavior).
2. An admin DB user with a tampered download-only cookie is rejected. Before the fix this test would have failed because the query returned the admin row and granted access.
3. An unknown user ID is rejected.

Full suite: 730 tests, all pass.

**Before (without fix), test 2 would return:**
```
authenticated=True, role="download_only"
```

**After (with fix), test 2 returns:**
```
authenticated=False
```