### PR TITLE
design: add description to Accounts settings panel

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -515,12 +515,15 @@ export default function AccountsSection({ showTitle = true }) {
       <Flex
         direction={{ base: 'column', sm: 'row' }}
         justify={{ sm: 'space-between' }}
-        align={{ sm: 'center' }}
+        align={{ sm: 'flex-start' }}
         gap="xs"
       >
-        {showTitle ? <Title order={2}>Accounts</Title> : <Title order={4}>Accounts</Title>}
+        <Stack gap={2}>
+          {showTitle ? <Title order={2}>Accounts</Title> : <Title order={4}>Accounts</Title>}
+          <Text size="sm" c="dimmed">Connect your IPTV providers. Mustarrd reads your channel list and program guide from these accounts.</Text>
+        </Stack>
         {accounts?.length > 0 && (
-          <Group gap="xs">
+          <Group gap="xs" style={{ flexShrink: 0 }}>
             <Button
               variant="light"
               color="orange"


### PR DESCRIPTION
## What changed

Settings > Accounts had no description subtitle, unlike every other settings panel in the app.

Every other section (Recording, Post-Processing, File Naming, Guide, Appearance, Security, and now Users) shows a dimmed subtitle explaining what the section does. Accounts showed only the bold title with no context.

## What a user would notice

Before: clicking Settings > Accounts showed just "Accounts" with action buttons and no explanation of what this section is for.

After: a one-line description reads "Connect your IPTV providers. Mustarrd reads your channel list and program guide from these accounts."

The button group alignment also changed from center to flex-start so the buttons align to the top of the title and description stack rather than vertically centering against it. flexShrink: 0 was added to the button group to prevent squishing on narrow desktop widths.

## How it was tested

Playwright screenshots at 1280px desktop and 390px mobile confirm the description renders correctly at both widths.

## Files changed

- frontend/src/components/settings/AccountsSection.jsx: wrapped title in a Stack with the new description text, adjusted Flex alignment. One file, no backend changes.