### PR TITLE
fix: sanitize_filename strips bidi override and isolate controls

### DIFF
--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -22,9 +22,10 @@ class FileNamer:
         # Remove stylized "Live" markers frequently injected by providers
         name = re.sub(r'[\[\(\-–—|:]*\s*ᴸᶦᵛᵉ\s*[\]\)]*\s*(?:-\s*)?', ' ', name)
 
-        # Remove invisible Unicode format/directional chars (zero-width, BOM, soft hyphen).
-        # Use empty replacement so they vanish without splitting surrounding words.
-        name = re.sub('[\u00ad\u200b\u200c\u200d\u200e\u200f\ufeff]', '', name)
+        # Remove invisible Unicode format/directional chars: zero-width, BOM, soft hyphen,
+        # and bidi override/isolate controls (U+202A-202E, U+2066-2069) that can make
+        # filenames display reversed in terminals and file managers.
+        name = re.sub('[\u00ad\u200b\u200c\u200d\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069\ufeff]', '', name)
 
         # Replace invalid filesystem chars with spaces (includes null byte and control chars)
         invalid_chars = r'[<>:"/\\|?*\x00-\x1f]'

--- a/backend/tests/test_sanitize_bidi_chars.py
+++ b/backend/tests/test_sanitize_bidi_chars.py
@@ -1,0 +1,77 @@
+"""
+Regression test: sanitize_filename must strip Unicode bidi override and isolate
+controls injected by IPTV providers into channel names and EPG titles.
+
+These characters cause filenames to display reversed or mangled in terminals and
+file managers. U+202E (RTL Override) is the most dangerous: a file named
+"show‮ts.gpj" appears as "show.jpg" in some terminals while the real
+extension is .ts.gpj (classic "trojan filename" trick).
+
+Characters tested:
+  U+202A  LEFT-TO-RIGHT EMBEDDING
+  U+202B  RIGHT-TO-LEFT EMBEDDING
+  U+202C  POP DIRECTIONAL FORMATTING
+  U+202D  LEFT-TO-RIGHT OVERRIDE
+  U+202E  RIGHT-TO-LEFT OVERRIDE  -- reverses text display in many terminals
+  U+2066  LEFT-TO-RIGHT ISOLATE
+  U+2067  RIGHT-TO-LEFT ISOLATE
+  U+2068  FIRST STRONG ISOLATE
+  U+2069  POP DIRECTIONAL ISOLATE
+"""
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.file_namer import FileNamer
+
+BIDI_CHARS = {
+    "LTR Embedding (U+202A)": "‪",
+    "RTL Embedding (U+202B)": "‫",
+    "Pop Directional Formatting (U+202C)": "‬",
+    "LTR Override (U+202D)": "‭",
+    "RTL Override (U+202E)": "‮",
+    "LTR Isolate (U+2066)": "⁦",
+    "RTL Isolate (U+2067)": "⁧",
+    "First Strong Isolate (U+2068)": "⁨",
+    "Pop Directional Isolate (U+2069)": "⁩",
+}
+
+
+class SanitizeBidiCharsTests(unittest.TestCase):
+    def test_each_bidi_char_stripped(self):
+        for label, char in BIDI_CHARS.items():
+            with self.subTest(char=label):
+                name = f"Breaking{char}Bad"
+                result = FileNamer.sanitize_filename(name)
+                self.assertNotIn(
+                    char,
+                    result,
+                    f"{label} survived sanitize_filename: {repr(result)}",
+                )
+
+    def test_rtl_override_trojan_filename_cleaned(self):
+        # RTL Override makes "ts.gpj" render as "jpg.st" in terminals.
+        # The filename must come out clean with no bidi controls.
+        name = "My Show S01E01‮ts.gpj"
+        result = FileNamer.sanitize_filename(name)
+        self.assertNotIn("‮", result)
+        self.assertIn("My Show S01E01", result)
+
+    def test_mixed_bidi_chars_all_stripped(self):
+        name = "‪Breaking‮ Bad⁦ S01E01⁩"
+        result = FileNamer.sanitize_filename(name)
+        for char in BIDI_CHARS.values():
+            self.assertNotIn(char, result, f"Bidi char {repr(char)} survived: {repr(result)}")
+        self.assertIn("Breaking", result)
+
+    def test_bidi_only_title_returns_fallback(self):
+        result = FileNamer.sanitize_filename("‮⁦⁩")
+        self.assertEqual(result, "unknown-program")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If a TV provider injected invisible Unicode directional characters into a program title, the downloaded file could appear to have a reversed or garbled name in your terminal, Finder, or file manager. For example, a file genuinely named `My Show S01E01.ts` could display as `st.10E10S wohS yM` in some terminals. This also broke Plex and Jellyfin library matching because the visible filename differed from the real one.

## What changed

`sanitize_filename` already stripped a set of invisible formatting characters (zero-width spaces, BOM, etc.). This extends that same strip to cover nine additional Unicode bidi (bidirectional text) control characters: the embedding controls (U+202A-202B), the directional overrides (U+202C-202E), and the isolate controls (U+2066-2069). All are silently removed before the filename reaches disk.

## How it was tested

Before the fix, inserting U+202E (RTL Override) into a title like `"Breaking‮Bad"` produced a filename with the control character still present.

After the fix:
```
$ python -m unittest tests.test_sanitize_bidi_chars -v
test_bidi_only_title_returns_fallback ... ok
test_each_bidi_char_stripped ... ok
test_mixed_bidi_chars_all_stripped ... ok
test_rtl_override_trojan_filename_cleaned ... ok
Ran 4 tests in 0.001s OK
```

Full suite: 734 tests, OK. No regressions.