### PR TITLE
design: add description to Plex Integration settings panel

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1276,7 +1276,8 @@ export default function Settings() {
 
   const renderPlex = () => (
     <Stack gap="md">
-      <Text fw={600}>Plex Integration</Text>
+      <Text fw={600} size="lg">Plex Integration</Text>
+      <Text size="sm" c="dimmed">Connect a Plex account to enable Plex-based sign-in and automatic library scanning when recordings complete.</Text>
       <Group align="center">
         <Button
           variant="light"


### PR DESCRIPTION
## What changed

Settings > Plex Integration was the only settings panel without a description subtitle. Every other panel (Accounts, Users, Recording, Post-Processing, File Naming, Guide, Appearance, Security) shows a dimmed one-line subtitle explaining what the section does. Plex Integration showed only the bold title with no context.

A non-technical operator had no way to know what Plex integration is for before clicking into it.

## Fix

Added a description subtitle: "Connect a Plex account to enable Plex-based sign-in and automatic library scanning when recordings complete."

Also corrected the title from plain `fw={600}` to `fw={600} size="lg"` to match every other panel.

One file changed: `frontend/src/pages/Settings.jsx`. No backend changes.

## Before

BEFORE (desktop): title only, no explanation.

## After

AFTER (desktop): title with description matching all other panels.

AFTER (mobile, 390px): description wraps cleanly on narrow widths.

## How it was tested

Launched the app locally. Navigated to Settings > Plex Integration at 1280px desktop and 390px mobile. Verified description renders, wraps correctly, and matches the visual style of every other settings panel.