### PR TITLE
design: persist Downloads tab selection in URL

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -18,7 +18,7 @@ import {
   Select,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconDotsVertical,
@@ -402,6 +402,7 @@ function DownloadCard({
 
 export default function Downloads() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const queryClient = useQueryClient()
   const [localProgress, setLocalProgress] = useState({})
   const [localLogs, setLocalLogs] = useState({})
@@ -638,7 +639,10 @@ export default function Downloads() {
         )}
       </Group>
 
-      <Tabs defaultValue="active">
+      <Tabs
+        value={['active', 'upcoming', 'history'].includes(searchParams.get('tab')) ? searchParams.get('tab') : 'active'}
+        onChange={(val) => setSearchParams({ tab: val }, { replace: true })}
+      >
         <Tabs.List grow style={{ flexWrap: 'nowrap' }}>
           <Tabs.Tab value="active" leftSection={<IconDownload size={16} />}>
             Active {activeDownloads.length > 0 && `(${activeDownloads.length})`}


### PR DESCRIPTION
## What a user would notice

Before this change, navigating to the Downloads page always opened on the Active tab, regardless of the URL. Clicking the History or Upcoming tab, then refreshing the page, reset back to Active. Sharing a link to the History tab or bookmarking it also did not work.

After this change, each tab updates the URL to `/downloads?tab=active`, `/downloads?tab=upcoming`, or `/downloads?tab=history`. Refreshing preserves the tab. Deep links and browser Back work as expected.

## What changed

One file (`Downloads.jsx`): added `useSearchParams` from react-router-dom (already used in Settings.jsx for section routing). The `Tabs` component now reads its active value from `?tab=` and writes back on change. Unknown or missing values fall back to `active`.

## Before

`/downloads?tab=history` landed on the Active tab, showing "No active downloads" instead of the history list. Refreshing on any non-active tab reset to Active.

## After

`/downloads?tab=upcoming` opens directly on Upcoming. `/downloads?tab=history` opens History. Clicking a tab updates the URL. Refresh keeps the tab. Screenshots in #design.

## How it was tested

Playwright drove a browser to `/downloads?tab=upcoming` and `/downloads?tab=history` directly and confirmed the correct tabs loaded. Also confirmed clicking History updates the URL to `?tab=history`.

No backend changes. Design-only.