### PR TITLE
design: show Aired time range on Downloads History cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -212,14 +212,9 @@ function DownloadCard({
           </Group>
         </Group>
 
-        <Group gap="xs" wrap="nowrap">
-          <Text size="xs" c="dimmed">
-            {formatAirDateTime(download, 'start', guideOffsetHours) || 'Unknown'}
-          </Text>
-          <Text size="xs" c="dimmed">
-            ({formatDuration(download.duration_minutes)})
-          </Text>
-        </Group>
+        <Text size="xs" c="dimmed">
+          Aired: {formatAirDateTime(download, 'start', guideOffsetHours) || 'Unknown'} - {formatChannelDateTime(download, 'end', guideOffsetHours, 'h:mm A') || 'Unknown'} ({formatDuration(download.duration_minutes)})
+        </Text>
 
         {isAdmin && (
           <Text size="xs" c="dimmed">


### PR DESCRIPTION
## What changed

Downloads History cards now show `Aired: [start] - [end] ([duration])` instead of just the unlabeled start time and duration.

**Before:** `Yesterday at 7:30 PM  (30m)`
**After:** `Aired: Yesterday at 7:30 PM - 8:00 PM (30m)`

## Why

A non-technical user scanning their download history could not tell whether the date shown was when the show aired, when the download was requested, or when it failed. The Scheduled Recordings History page already shows `Aired: [start] - [end] ([duration])` with a clear label and time range. Downloads History was inconsistent and less informative.

Adding the `Aired:` label and end time makes both pages consistent and answers "what was this a recording of?" at a glance.

## What was tested

- Downloads History tab: desktop (1280px) and mobile (390px) before/after screenshots in #design thread
- Downloads Active tab: confirmed empty state still renders correctly
- No console errors
- One file changed: `frontend/src/pages/Downloads.jsx`
- No backend changes

## Before / After screenshots

Screenshots posted in #design: Pixel iteration 40 thread.

**Before (desktop):** Date shown without label or end time.
**After (desktop):** "Aired: Yesterday at 7:30 PM - 8:00 PM (30m)" with label and time range.