### PR TITLE
fix: update Plex test fixtures broken by PR #314 signature change

### DIFF
--- a/backend/tests/test_plex_enabled_guard.py
+++ b/backend/tests/test_plex_enabled_guard.py
@@ -77,7 +77,7 @@ class PlexEnabledGuardTests(unittest.IsolatedAsyncioTestCase):
 
         async with self.session_factory() as session:
             with self.assertRaises(HTTPException) as ctx:
-                await plex_login_start(session)
+                await plex_login_start(_mock_request(), session)
 
         self.assertEqual(ctx.exception.status_code, 403)
 
@@ -88,7 +88,7 @@ class PlexEnabledGuardTests(unittest.IsolatedAsyncioTestCase):
         create_pin_mock = AsyncMock(return_value={"id": 1, "code": "ABCD", "expires_in": 300})
         with patch("api.auth.plex_service.create_pin", create_pin_mock):
             async with self.session_factory() as session:
-                result = await plex_login_start(session)
+                result = await plex_login_start(_mock_request(), session)
 
         create_pin_mock.assert_called_once()
         self.assertIn("id", result)

--- a/backend/tests/test_plex_start_rate_limit.py
+++ b/backend/tests/test_plex_start_rate_limit.py
@@ -36,6 +36,7 @@ def _mock_request(host="127.0.0.1"):
     req.client = MagicMock()
     req.client.host = host
     req.session = {}
+    req.headers = {}
     return req
 
 


### PR DESCRIPTION
## What a user would notice

Nothing in the app changes. This is a test-only fix that unblocks CI so all 9 queued PRs (#322-#330) can merge.

## What changed

PR #314 added a `request` parameter as the first argument to `plex_login_start`. Two tests in `test_plex_enabled_guard.py` were not updated and still called it with only `session`, causing a type error at test time. In `test_plex_start_rate_limit.py`, the `_mock_request()` helper did not set `req.headers = {}`, so the `MagicMock` default for `X-Forwarded-For` was truthy and `_client_key()` returned a mock object instead of the string `"10.0.0.1"`, so the rate-limit bucket never matched the pre-seeded key and HTTP 429 was never raised.

Three-line fix across two files:

- `test_plex_enabled_guard.py`: pass `_mock_request()` as the first argument to `plex_login_start` in the two tests that were missing it (lines 80 and 91).
- `test_plex_start_rate_limit.py`: add `req.headers = {}` to `_mock_request()` so the X-Forwarded-For check returns `None` (not a truthy mock) and the correct IP string is used as the bucket key.

No production code changed.

## How it was tested

**Before:**
```
ERROR: test_start_disabled_server_raises_403 - AttributeError: 'AsyncSession' object has no attribute 'client'
ERROR: test_start_enabled_server_proceeds - AttributeError: 'AsyncSession' object has no attribute 'client'
FAIL: test_eleventh_request_returns_429 - AssertionError: HTTPException not raised
FAIL: test_different_clients_have_independent_buckets - AssertionError: HTTPException not raised
```

**After:**
```
Ran 750 tests in 3.861s
OK
```

All 4 previously failing tests now pass. Full suite: 750 tests, 0 failures.

Closes the [TODO] task: "fix: broken Plex test fixtures block all CI (HIGH)".