### PR TITLE
design: add description to Plex Integration settings panel

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1276,7 +1276,8 @@ export default function Settings() {
 
   const renderPlex = () => (
     <Stack gap="md">
-      <Text fw={600}>Plex Integration</Text>
+      <Text fw={600} size="lg">Plex Integration</Text>
+      <Text size="sm" c="dimmed">Connect a Plex account to enable Plex-based sign-in and automatic library scanning when recordings complete.</Text>
       <Group align="center">
         <Button
           variant="light"


### PR DESCRIPTION
## What changed

Settings > Plex Integration was the only settings panel without a description subtitle. Every other panel (Accounts, Users, Recording, Post-Processing, File Naming, Guide, Appearance, Security) shows a dimmed one-line subtitle explaining what the section does. Plex Integration showed only the bold title with no context.

A non-technical operator had no way to know what Plex integration is for before clicking into it.

## Fix

Added a description subtitle: "Connect a Plex account to enable Plex-based sign-in and automatic library scanning when recordings complete."

Also corrected the title from plain `fw={600}` to `fw={600} size="lg"` to match every other panel.

One file changed: `frontend/src/pages/Settings.jsx`. No backend changes.

## Before

BEFORE (desktop): title only, no explanation.

![before](https://cdn.discordapp.com/attachments/1512586038969765908/1513911662397227139/audit_s_plex_integration.png)

## After

AFTER (desktop): title with description matching all other panels.

![after desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513911683138064635/plex_after_desktop.png)

AFTER (mobile, 390px): description wraps cleanly on narrow widths.

![after mobile](https://cdn.discordapp.com/attachments/1512586038969765908/1513911700510740650/plex_after_mobile.png)

## How it was tested

Launched the app locally. Navigated to Settings > Plex Integration at 1280px desktop and 390px mobile. Verified description renders, wraps correctly, and matches the visual style of every other settings panel.

_Note: reopened from design/plex-integration-section-description after the pre-push bidi-override hook blocked a rebase (test data from PR #321 in diff range). Same change, clean branch from current main._