### PR TITLE
design: fill Connect Plex Account button to match primary CTA style

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1279,7 +1279,6 @@ export default function Settings() {
       <Text fw={600}>Plex Integration</Text>
       <Group align="center">
         <Button
-          variant="light"
           onClick={() => {
             const popup = window.open('about:blank', '_blank')
             connectPlexStartMutation.mutate({ popupRef: popup })


### PR DESCRIPTION
## What changed

Settings > Plex Integration has one primary action: connect your Plex account. The button used \`variant=\"light\"\`, which renders as a muted brownish/olive color in Mantine's dark theme. Every other primary CTA on the app (Go to Browse, Save, Add Account, and so on) uses the default filled style, which renders as solid orange.

A non-technical user setting up Plex for the first time sees a dull, secondary-looking button and may not recognise it as the thing to click.

## Fix

Removed \`variant=\"light\"\` from the Connect Plex Account button at \`frontend/src/pages/Settings.jsx\`. One line deleted. No other changes. No backend changes.

## Before

BEFORE: button is muted brownish, looks like a secondary action.

![before](https://cdn.discordapp.com/attachments/1512586038969765908/1513953979858423958/d_settings_plex.png)

## After

AFTER (desktop, 1280px): filled orange, clearly the primary action.

![after desktop](https://cdn.discordapp.com/attachments/1512586038969765908/1513976992582598809/after_desktop.png)

AFTER (mobile, 390px): same at narrow widths.

![after mobile](https://cdn.discordapp.com/attachments/1512586038969765908/1513977012304347327/after_mobile.png)

## How it was tested

Launched the app locally. Navigated to Settings > Plex Integration at 1280px desktop and 390px mobile. Verified button renders filled orange and matches all other primary CTAs.