### PR TITLE
design: replace duplicate error in Browse EPG right panel

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1043,26 +1043,14 @@ export default function Browse() {
                         </Text>
                       )}
                     </Stack>
-                  ) : channelsIsError ? (
-                    <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
-                      <IconAlertCircle size={48} color="var(--mantine-color-red-5)" opacity={0.6} />
-                      <Text c="dimmed" ta="center">
-                        {authStatus?.is_admin ? (
-                          <>
-                            Could not reach your provider.{' '}
-                            <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
-                              Check Settings → Accounts.
-                            </Link>
-                          </>
-                        ) : (
-                          'Could not reach the provider. Contact your administrator.'
-                        )}
-                      </Text>
-                    </Stack>
                   ) : (
                     <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
                       <IconVideo size={48} opacity={0.3} />
-                      <Text c="dimmed">Select a channel to view its EPG</Text>
+                      <Text c="dimmed" ta="center">
+                        {channelsIsError
+                          ? 'Channel guide will appear here once your provider is connected.'
+                          : 'Select a channel to view its program guide.'}
+                      </Text>
                     </Stack>
                   )}
                 </Stack>


### PR DESCRIPTION
## What changed

When your IPTV provider cannot be reached, Browse EPG was showing the same error message twice: once in the Channels list on the left, and again in the program guide panel on the right.

The right panel now shows a neutral placeholder instead: a video icon and the message "Channel guide will appear here once your provider is connected." The left panel still shows the actionable error with a link to Settings.

## Why

A non-technical user landing on Browse EPG while their provider is down saw two red alerts saying the same thing. The second one was redundant and made the page feel broken in two places instead of one. Now the error is in one place (the channel list, which is where the problem actually is), and the guide panel calmly explains what it will show once things are working.

## Before

Left panel: "Could not reach your provider. Check your account status in Settings > Accounts."
Right panel: same red alert icon and "Could not reach your provider. Check Settings > Accounts." again.

## After

Left panel: unchanged, still shows the actionable error.
Right panel: neutral video icon, "Channel guide will appear here once your provider is connected."

## How tested

Started the app locally with a misconfigured provider account (so the provider is unreachable). Confirmed the before state showed two errors. Applied the change and confirmed the after state shows one error on the left and the calm placeholder on the right.