### PR TITLE
fix: strip named TZ abbreviations from provider_start in timeshift URL

### DIFF
--- a/backend/services/download_builder.py
+++ b/backend/services/download_builder.py
@@ -97,6 +97,10 @@ def _normalize_provider_start_token(provider_start: str, pre_padding_minutes: in
         token = re.sub(r"([+-])(\d)(:\d{2})$", r"\g<1>0\2\3", token)
         token = re.sub(r"([+-])(\d)(\d{2})$", r"\g<1>0\2\3", token)
         bare = re.sub(r"\s*([+-]\d{2}:?\d{2}|Z)$", "", token).strip()
+        # Strip trailing named TZ abbreviations (EST, PST, CET, MSK, etc.) that
+        # some providers include in XMLTV start attributes.  Numeric offsets were
+        # already removed above; this handles the remaining letters-only form.
+        bare = re.sub(r"\s+[A-Z]{2,5}$", "", bare).strip()
         for fmt, candidate in (
             ("%Y-%m-%d %H:%M:%S", bare),
             ("%Y-%m-%d %H:%M",    bare),

--- a/backend/tests/test_download_builder_named_tz.py
+++ b/backend/tests/test_download_builder_named_tz.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_builder import _normalize_provider_start_token
+
+
+class NormalizeProviderStartTokenNamedTZTests(unittest.TestCase):
+    """_normalize_provider_start_token strips named TZ abbreviations from provider_start.
+
+    Some providers include named TZ abbreviations in XMLTV start attributes
+    (e.g. "20240115203000 EST").  _parse_xmltv_time handles these and stores
+    correct UTC timestamps, but _iter_programs also stores the raw XMLTV string
+    as provider_start.  _normalize_provider_start_token previously failed to
+    strip the letters-only suffix, causing all strptime attempts to fail and
+    returning None.  build_timeshift_url then fell back to UTC wall-clock time,
+    fetching content hours off from the intended show.
+    """
+
+    def test_est_stripped(self):
+        result = _normalize_provider_start_token("20240115203000 EST", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_pst_stripped(self):
+        result = _normalize_provider_start_token("20240115203000 PST", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_cet_stripped(self):
+        result = _normalize_provider_start_token("20240115203000 CET", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_msk_stripped(self):
+        result = _normalize_provider_start_token("20240115203000 MSK", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_pre_padding_applied_with_named_tz(self):
+        result = _normalize_provider_start_token("20240115203000 EST", 5)
+        self.assertEqual(result, "2024-01-15:20-25")
+
+    def test_numeric_offset_still_works(self):
+        """Named-TZ strip must not break existing numeric-offset handling."""
+        result = _normalize_provider_start_token("20240115203000 +0200", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+    def test_no_tz_still_works(self):
+        result = _normalize_provider_start_token("20240115203000", 0)
+        self.assertEqual(result, "2024-01-15:20-30")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

If your IPTV provider uses named timezone abbreviations like EST, PST, or CET in their program guide data, downloaded recordings could be hours off from the show you intended. For example, a show listed at 8:30pm EST would download content from 8:30pm UTC instead, which is 5 hours off.

## What changed

When Mustarrd builds the download URL for a catchup recording, it uses the raw timestamp from the provider's program guide to tell the provider which time slot to fetch. That raw timestamp sometimes includes a named timezone suffix (e.g. `20240115203000 EST`).

The code already knew how to strip numeric timezone offsets like `+0200` or `-0500`, but it did not strip letters-only timezone names. When the strip failed, the whole timestamp was unparseable and Mustarrd fell back to UTC, fetching the wrong hour of content.

The fix adds one line that removes trailing 2-to-5-letter timezone abbreviations (EST, PST, CET, MSK, etc.) before attempting to parse the timestamp.

## How it was tested

Before the fix:

```
_normalize_provider_start_token("20240115203000 EST", 0)
# returned None (all strptime formats failed)
# build_timeshift_url fell back to UTC: downloaded wrong content
```

After the fix:

```
_normalize_provider_start_token("20240115203000 EST", 0)
# returns "2024-01-15:20-30"
```

New regression tests in `test_download_builder_named_tz.py` cover EST, PST, CET, MSK, pre-padding, and confirm that existing numeric-offset handling still works.

Full suite: 757 tests, all pass.