### PR TITLE
test: failing regression for get_epg dict epg_listings coercion

### DIFF
--- a/backend/tests/test_xtream_client_epg_list_response.py
+++ b/backend/tests/test_xtream_client_epg_list_response.py
@@ -54,6 +54,19 @@ class GetEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
         result = await client.get_epg("123")
         self.assertEqual(result, [])
 
+    async def test_dict_response_dict_epg_listings_returns_list(self):
+        # Some providers return epg_listings as {"0": {...}, "1": {...}} instead
+        # of a list.  get_epg must coerce to list; returning a dict causes
+        # _backfill_from_api to silently skip all entries (dict keys are strings,
+        # not dicts) and fetch_live_epg to raise AttributeError on .get() calls.
+        entries = {"0": {"id": "1", "title": "News"}, "1": {"id": "2", "title": "Sport"}}
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_epg("123")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({e["title"] for e in result}, {"News", "Sport"})
+
 
 class GetShortEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
     async def test_bare_list_response_returns_list(self):
@@ -82,6 +95,16 @@ class GetShortEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
         client._get_session = _mock_session({"epg_listings": None})
         result = await client.get_short_epg("123")
         self.assertEqual(result, [])
+
+    async def test_dict_response_dict_epg_listings_returns_list(self):
+        # Same coercion bug as get_epg: dict epg_listings must be converted to list.
+        entries = {"0": {"id": "1", "title": "Movie"}, "1": {"id": "2", "title": "Sport"}}
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_short_epg("123")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({e["title"] for e in result}, {"Movie", "Sport"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What a user would notice

On providers that return `epg_listings` as a keyed object (`{"0": {...}, "1": {...}}`) instead of a list, the EPG guide silently comes up empty. No error shown to the user.

## What changed

Two failing regression tests added to `backend/tests/test_xtream_client_epg_list_response.py`, one for `get_epg` and one for `get_short_epg`. Both tests confirm the current code returns a dict when `epg_listings` is a dict, not a list as the method signature promises.

These tests fail now and are intended to be fixed by the maintainer. No production code is changed here.

## Root cause (for the fix PR)

`get_epg` and `get_short_epg` do `return data.get("epg_listings") or []`. When `epg_listings` is a dict, that returns the dict. `get_live_streams` in the same file already handles this correctly with `list(data.values()) if isinstance(data, dict) else data`.

Two downstream failures:
- `_backfill_from_api`: iterates the dict, gets string keys, skips all via `if not isinstance(entry, dict): continue`. Zero EPG rows written. Silent.
- `fetch_live_epg`: calls `entry.get("title", "")` on a string key, `AttributeError` caught by bare `except Exception`, returns empty guide. Silent.

## How it was tested

```
python3 -m unittest tests.test_xtream_client_epg_list_response
```

Before: 8 pass, 2 fail (the two new tests). After fix: all 10 should pass.

## Linked task

Discord #tasks thread: 1514015080470286507