### PR TITLE
fix: scheduler expiry check uses program start, not end

### DIFF
--- a/backend/services/scheduled_manager.py
+++ b/backend/services/scheduled_manager.py
@@ -78,8 +78,15 @@ class ScheduledManager:
                         continue
                     catchup_expiry = now_utc - timedelta(days=archive_days)
                     program_end_utc = available_at - timedelta(minutes=int(schedule.post_padding_minutes or 0))
-                    if program_end_utc <= catchup_expiry:
-                        age = now_utc - program_end_utc
+                    # Timeshift URLs are keyed to program start; compare padded start
+                    # against the boundary, not program end.
+                    if schedule.start_timestamp:
+                        prog_start_utc = datetime.fromtimestamp(int(schedule.start_timestamp), tz=timezone.utc)
+                    else:
+                        prog_start_utc = program_end_utc - timedelta(minutes=int(schedule.duration_minutes or 0))
+                    padded_start_utc = prog_start_utc - timedelta(minutes=int(schedule.pre_padding_minutes or 0))
+                    if padded_start_utc <= catchup_expiry:
+                        age = now_utc - prog_start_utc
                         total_hours = int(age.total_seconds() / 3600)
                         age_str = f"about {age.days} days" if age.days >= 2 else f"about {total_hours} hours"
                         schedule.status = ScheduledStatus.FAILED.value

--- a/backend/tests/test_scheduler_expiry_uses_start.py
+++ b/backend/tests/test_scheduler_expiry_uses_start.py
@@ -1,0 +1,216 @@
+"""
+Regression: scheduler expiry check compared program END against the catchup
+boundary.  A program whose end fell inside the window but whose start fell
+outside was dispatched, then failed at the provider with a cryptic 404.
+
+Fix: compare padded program START against the boundary.
+"""
+import asyncio
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import AppSettings, ScheduledRecording, ScheduledStatus
+from services.scheduled_manager import ScheduledManager
+
+
+def _make_session_maker(schedule):
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = [schedule]
+
+    schedules_exec_result = MagicMock()
+    schedules_exec_result.scalars.return_value = scalars_result
+
+    settings_obj = AppSettings()
+    settings_obj.download_folder = "/tmp/downloads"
+    settings_obj.min_free_space_gb = 1
+    settings_exec_result = MagicMock()
+    settings_exec_result.scalar_one_or_none.return_value = settings_obj
+
+    call_count = [0]
+
+    async def execute(stmt):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return schedules_exec_result
+        return settings_exec_result
+
+    session = AsyncMock()
+    session.execute = execute
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def ctx():
+        yield session
+
+    return ctx
+
+
+async def _run_queue(schedule, archive_days: int) -> list:
+    queued: list = []
+
+    async def fake_build(*args, **kwargs):
+        dl = MagicMock()
+        dl.id = 99
+        return dl
+
+    async def fake_queue(dl):
+        queued.append(dl.id)
+        return dl
+
+    fake_dm = MagicMock()
+    fake_dm.queue_download = AsyncMock(side_effect=fake_queue)
+
+    manager = ScheduledManager()
+    session_maker = _make_session_maker(schedule)
+
+    with (
+        patch("services.scheduled_manager.async_session_maker", session_maker),
+        patch("services.scheduled_manager.build_download_from_program", new=fake_build),
+        patch("services.scheduled_manager.download_manager", fake_dm),
+        patch.object(manager, "_get_free_space_gb", return_value=100.0),
+        patch.object(
+            manager,
+            "_get_catchup_window_days",
+            new=AsyncMock(return_value=archive_days),
+        ),
+    ):
+        await manager._queue_ready_recordings()
+
+    return queued
+
+
+class SchedulerExpiryUsesStartTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_start_outside_window_end_inside_not_dispatched(self):
+        """Program started outside the catchup window must be FAILED, not dispatched.
+
+        Before the fix: expiry check used program END, so a long show whose end
+        fell inside the window slipped through and dispatched to the provider, which
+        returned 404.
+        """
+        now = datetime.now(timezone.utc)
+        archive_days = 7
+        # Start is 2 hours past the boundary; end is 30 minutes inside the boundary.
+        prog_start = now - timedelta(days=archive_days, hours=2)
+        prog_end = now - timedelta(days=archive_days) + timedelta(minutes=30)
+        duration_minutes = int((prog_end - prog_start).total_seconds() / 60)
+
+        schedule = ScheduledRecording(
+            account_id=1,
+            channel_id="ch1",
+            channel_name="Test",
+            program_title="Boundary Show",
+            program_start=prog_start.replace(tzinfo=None),
+            program_end=prog_end.replace(tzinfo=None),
+            start_timestamp=int(prog_start.timestamp()),
+            stop_timestamp=int(prog_end.timestamp()),
+            duration_minutes=duration_minutes,
+            pre_padding_minutes=0,
+            post_padding_minutes=0,
+            status=ScheduledStatus.SCHEDULED.value,
+        )
+
+        dispatched = await _run_queue(schedule, archive_days=archive_days)
+
+        self.assertEqual(dispatched, [], "Schedule with start outside window must not dispatch.")
+        self.assertEqual(schedule.status, ScheduledStatus.FAILED.value)
+        self.assertIn("catchup", schedule.status_message.lower())
+
+    async def test_start_inside_window_dispatched(self):
+        """Program that started inside the catchup window must dispatch normally."""
+        now = datetime.now(timezone.utc)
+        archive_days = 7
+        prog_end = now - timedelta(hours=1)
+        prog_start = prog_end - timedelta(hours=1)
+
+        schedule = ScheduledRecording(
+            account_id=1,
+            channel_id="ch2",
+            channel_name="Test",
+            program_title="Recent Show",
+            program_start=prog_start.replace(tzinfo=None),
+            program_end=prog_end.replace(tzinfo=None),
+            start_timestamp=int(prog_start.timestamp()),
+            stop_timestamp=int(prog_end.timestamp()),
+            duration_minutes=60,
+            pre_padding_minutes=0,
+            post_padding_minutes=0,
+            status=ScheduledStatus.SCHEDULED.value,
+        )
+
+        dispatched = await _run_queue(schedule, archive_days=archive_days)
+
+        self.assertEqual(dispatched, [99], "Schedule with start inside window must dispatch.")
+
+    async def test_pre_padding_outside_window_not_dispatched(self):
+        """Pre-padding that extends past the catchup boundary must prevent dispatch.
+
+        If the padded start falls outside the window the provider cannot serve
+        that portion of the recording.
+        """
+        now = datetime.now(timezone.utc)
+        archive_days = 7
+        # Program start is 15 minutes inside the window; pre-padding of 30 min
+        # shifts the padded start 15 minutes outside the boundary.
+        prog_start = now - timedelta(days=archive_days) + timedelta(minutes=15)
+        prog_end = prog_start + timedelta(hours=1)
+
+        schedule = ScheduledRecording(
+            account_id=1,
+            channel_id="ch3",
+            channel_name="Test",
+            program_title="Padded Show",
+            program_start=prog_start.replace(tzinfo=None),
+            program_end=prog_end.replace(tzinfo=None),
+            start_timestamp=int(prog_start.timestamp()),
+            stop_timestamp=int(prog_end.timestamp()),
+            duration_minutes=60,
+            pre_padding_minutes=30,
+            post_padding_minutes=0,
+            status=ScheduledStatus.SCHEDULED.value,
+        )
+
+        dispatched = await _run_queue(schedule, archive_days=archive_days)
+
+        self.assertEqual(dispatched, [], "Pre-padding outside window must prevent dispatch.")
+        self.assertEqual(schedule.status, ScheduledStatus.FAILED.value)
+
+    async def test_start_timestamp_zero_falls_back_to_duration(self):
+        """When start_timestamp is 0, start is estimated from end minus duration_minutes."""
+        now = datetime.now(timezone.utc)
+        archive_days = 7
+        prog_end = now - timedelta(days=archive_days) + timedelta(minutes=30)
+        # 150-minute show: estimated start = prog_end - 150 min = 2 hours outside window
+        duration_minutes = 150
+
+        schedule = ScheduledRecording(
+            account_id=1,
+            channel_id="ch4",
+            channel_name="Test",
+            program_title="Long Show",
+            program_start=(prog_end - timedelta(minutes=duration_minutes)).replace(tzinfo=None),
+            program_end=prog_end.replace(tzinfo=None),
+            start_timestamp=0,
+            stop_timestamp=int(prog_end.timestamp()),
+            duration_minutes=duration_minutes,
+            pre_padding_minutes=0,
+            post_padding_minutes=0,
+            status=ScheduledStatus.SCHEDULED.value,
+        )
+
+        dispatched = await _run_queue(schedule, archive_days=archive_days)
+
+        self.assertEqual(dispatched, [], "Estimated start outside window must not dispatch.")
+        self.assertEqual(schedule.status, ScheduledStatus.FAILED.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

The scheduler was checking whether a program's **end time** had expired past the provider's catchup window. It should be checking the program **start time** (minus pre-padding), because timeshift URLs are keyed to the start of a program. A program whose start is outside the window cannot be retrieved, even if its end falls inside it.

### Before

A 2-hour show that started 7 days and 2 hours ago on a 7-day catchup provider would be dispatched: its end time (7 days minus 30 minutes ago) is still inside the window, so the old check passed. The download would then fail at the provider with a cryptic 404 or wrong content.

### After

The same show is marked **FAILED** at poll time with a plain message: *"Program is no longer available for catchup. It aired about 7 days ago, past the 7-day catchup window."* No download is attempted.

Pre-padding is also checked: if the padded start would fall outside the window, the schedule is marked FAILED rather than dispatching a URL the provider cannot serve.

When `start_timestamp` is not stored, the start is estimated from program end minus `duration_minutes` (same fallback used elsewhere).

## How to reproduce the bug (before fix)

1. Connect an account with a 7-day catchup provider.
2. Schedule a 2-hour recording for a program that started 7 days and 2 hours ago (end: 7 days minus 30 minutes ago).
3. Wait for the scheduler poll (up to 30 seconds).
4. **Before fix:** schedule dispatches, download fails with provider 404.
5. **After fix:** schedule is marked FAILED immediately with a clear message.

## How it was tested

Four new unit tests in `backend/tests/test_scheduler_expiry_uses_start.py`:

- `test_start_outside_window_end_inside_not_dispatched`: the core regression case, fails before the fix, passes after.
- `test_start_inside_window_dispatched`: sanity check that a normal recent show still dispatches.
- `test_pre_padding_outside_window_not_dispatched`: pre-padding that extends past the boundary blocks dispatch.
- `test_start_timestamp_zero_falls_back_to_duration`: covers the fallback estimation path.

All 773 tests pass.

Closes #1514002510287863849 (Discord task: Scheduler expiry check uses program end, not start)