### PR TITLE
fix: coerce dict epg_listings to list in get_epg and get_short_epg

### DIFF
--- a/backend/services/xtream_client.py
+++ b/backend/services/xtream_client.py
@@ -78,7 +78,10 @@ class XtreamClient:
             data = await response.json(content_type=None)
             if isinstance(data, list):
                 return data
-            return data.get("epg_listings") or []
+            listings = data.get("epg_listings") or []
+            if isinstance(listings, dict):
+                listings = list(listings.values())
+            return listings
 
     async def get_short_epg(self, stream_id: str, limit: int = 10) -> list:
         """Get short EPG (current + upcoming) for a channel."""
@@ -90,7 +93,10 @@ class XtreamClient:
             data = await response.json(content_type=None)
             if isinstance(data, list):
                 return data
-            return data.get("epg_listings") or []
+            listings = data.get("epg_listings") or []
+            if isinstance(listings, dict):
+                listings = list(listings.values())
+            return listings
 
     async def get_xmltv(self) -> bytes:
         """Get XMLTV guide data."""

--- a/backend/tests/test_xtream_client_epg_list_response.py
+++ b/backend/tests/test_xtream_client_epg_list_response.py
@@ -54,6 +54,19 @@ class GetEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
         result = await client.get_epg("123")
         self.assertEqual(result, [])
 
+    async def test_dict_response_dict_epg_listings_returns_list(self):
+        # Some providers return epg_listings as {"0": {...}, "1": {...}} instead
+        # of a list.  get_epg must coerce to list; returning a dict causes
+        # _backfill_from_api to silently skip all entries (dict keys are strings,
+        # not dicts) and fetch_live_epg to raise AttributeError on .get() calls.
+        entries = {"0": {"id": "1", "title": "News"}, "1": {"id": "2", "title": "Sport"}}
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_epg("123")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({e["title"] for e in result}, {"News", "Sport"})
+
 
 class GetShortEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
     async def test_bare_list_response_returns_list(self):
@@ -82,6 +95,16 @@ class GetShortEpgListResponseTests(unittest.IsolatedAsyncioTestCase):
         client._get_session = _mock_session({"epg_listings": None})
         result = await client.get_short_epg("123")
         self.assertEqual(result, [])
+
+    async def test_dict_response_dict_epg_listings_returns_list(self):
+        # Same coercion bug as get_epg: dict epg_listings must be converted to list.
+        entries = {"0": {"id": "1", "title": "Movie"}, "1": {"id": "2", "title": "Sport"}}
+        client = _client()
+        client._get_session = _mock_session({"epg_listings": entries})
+        result = await client.get_short_epg("123")
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({e["title"] for e in result}, {"Movie", "Sport"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What a user would notice

On some providers, the EPG guide comes up completely empty with no error message. Channels show no programs in the grid, and scheduled recordings for those channels never get EPG data filled in.

## Root cause

Xtream Codes providers are supposed to return `epg_listings` as a list of program objects, but some return it as a keyed dict like `{"0": {...}, "1": {...}}`. Both `get_epg` and `get_short_epg` returned that dict as-is, causing two silent failures downstream:

- **Backfill path:** `_backfill_from_api` iterates the result and skips every entry because the string keys `"0"`, `"1"` are not dicts. Zero EPG rows written, no error logged.
- **Live EPG path:** `fetch_live_epg` calls `.get("title", "")` on a string key, hits `AttributeError`, which is caught by a bare `except Exception`, and returns an empty guide silently.

`get_live_streams` in the same file already handled this with `list(data.values()) if isinstance(data, dict) else data`. The EPG methods were never given the same treatment.

## What changed

`get_epg` and `get_short_epg` now check whether `epg_listings` is a dict after extracting it, and if so convert it to `list(listings.values())` before returning. The bare-list and null responses are unchanged.

## Before

```
# Provider returns {"epg_listings": {"0": {"title": "News"}, "1": {"title": "Sport"}}}
result = await client.get_epg("123")
# result is a dict -> backfill skips every entry -> 0 EPG rows written
```

## After

```
result = await client.get_epg("123")
# result is [{"title": "News"}, {"title": "Sport"}] -> backfill writes 2 rows
```

## How it was tested

New regression tests added to `backend/tests/test_xtream_client_epg_list_response.py`:
- `GetEpgListResponseTests.test_dict_response_dict_epg_listings_returns_list`
- `GetShortEpgListResponseTests.test_dict_response_dict_epg_listings_returns_list`

Both tests failed before this fix and pass after. Full suite: 775 tests, all pass.

```
python -m unittest tests.test_xtream_client_epg_list_response -v
# Ran 10 tests in 0.014s - OK

python -m unittest discover -s tests
# Ran 775 tests in 3.806s - OK
```

Closes regression test PR #341.