### PR TITLE
fix: download + post-processing reliability — 12 data-loss and cleanup bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: Temporary files are now cleaned up when post-processing fails or is cancelled
+
+**What you would notice:** Cancelling a recording during commercial detection or transcoding, or having post-processing fail partway through, no longer leaves junk behind in your download folder. Previously, half-written video files, Comskip working files (`.edl`, `.txt`, `.logo` and similar), and intermediate `_comskip_input` files could silently pile up and eat disk space. Cancelling now also actually stops the background FFmpeg helpers instead of leaving them running and writing to disk. In addition: empty Show/Season folders are removed from the download folder after a series episode moves to your completed folder; post-processing now checks free disk space before starting a transcode and fails with a clear error instead of dying mid-write and leaving a partial file; and a corrupt recording can no longer freeze post-processing forever while probing the file.
+
+**What changed:** The post-processing pipeline cleans up its working files (Comskip sidecars, segment temp files, and partial transcode outputs) on every exit path — success, failure, and cancellation — while always keeping the raw recording in the download folder on failure. FFmpeg subprocesses used for Comskip input preparation and segment extraction are terminated when a job is cancelled. The file probe (ffprobe) now has a 60-second timeout with a clean fallback. A disk-space preflight (using the existing minimum free space setting) runs before any transcode or commercial removal starts. After moving a series episode to the completed folder, now-empty Show/Season directories are removed up to — but never including — the configured download folder. Backend only, no user settings or configuration were changed.
+
+---
+
 ### Fixed: Guide (EPG) refresh is more resilient — no more wiped guides, missing channels, or wrong-time downloads
 
 **What you would notice:** Several guide problems that could appear after an EPG refresh are gone:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: Recordings are no longer lost when a cancel or an error arrives just as a download finishes
+
+**What you would notice:** Pressing Cancel at the exact moment a recording finished downloading could delete the fully-downloaded file and mark the recording as cancelled, even though every byte was already on disk. Similarly, a hiccup at the very end of a download or during post-processing — for example the database briefly failing while saving the final status, or a crash right after the file was moved into your completed folder — could leave the recording stuck, marked as failed, or queued for a full re-download even though the finished file was sitting safely in the completed folder (and retrying such a "failed" recording could overwrite or delete the good file). After this fix, once the last byte has been written, the recording is always kept: it is moved to the completed folder and shown as completed, regardless of late cancels, database errors, or post-processing crashes.
+
+**What changed:** The download manager now remembers when a transfer has fully finished and when the file has been moved to the completed folder. Cancel and error handlers check this before touching the file, finalize the recording as completed (retrying on a fresh database session if the original one broke), and never delete a file that reached the completed folder. Backend only, no user settings or configuration were changed.
+
+---
+
 ### Fixed: Temporary files are now cleaned up when post-processing fails or is cancelled
 
 **What you would notice:** Cancelling a recording during commercial detection or transcoding, or having post-processing fail partway through, no longer leaves junk behind in your download folder. Previously, half-written video files, Comskip working files (`.edl`, `.txt`, `.logo` and similar), and intermediate `_comskip_input` files could silently pile up and eat disk space. Cancelling now also actually stops the background FFmpeg helpers instead of leaving them running and writing to disk. In addition: empty Show/Season folders are removed from the download folder after a series episode moves to your completed folder; post-processing now checks free disk space before starting a transcode and fails with a clear error instead of dying mid-write and leaving a partial file; and a corrupt recording can no longer freeze post-processing forever while probing the file.

--- a/backend/services/disk_space.py
+++ b/backend/services/disk_space.py
@@ -1,12 +1,26 @@
 import asyncio
 import os
 import shutil
+from typing import Optional, Tuple
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from config import settings
 from models import AppSettings
+
+
+async def get_free_space_shortfall(folder: str, min_free_gb: float) -> Optional[Tuple[float, float]]:
+    """Return (free_gb, min_free_gb) when *folder* has less free space than required, else None."""
+    if not min_free_gb or min_free_gb <= 0:
+        return None
+    if not await asyncio.to_thread(os.path.exists, folder):
+        return None
+    usage = await asyncio.to_thread(shutil.disk_usage, folder)
+    free_gb = usage.free / (1024 ** 3)
+    if free_gb < min_free_gb:
+        return free_gb, min_free_gb
+    return None
 
 
 async def check_disk_space(session: AsyncSession) -> None:
@@ -23,15 +37,14 @@ async def check_disk_space(session: AsyncSession) -> None:
         if app_settings_row and app_settings_row.min_free_space_gb is not None
         else 25
     )
-    if min_free_gb and min_free_gb > 0 and await asyncio.to_thread(os.path.exists, download_folder):
-        usage = await asyncio.to_thread(shutil.disk_usage, download_folder)
-        free_gb = usage.free / (1024 ** 3)
-        if free_gb < min_free_gb:
-            raise HTTPException(
-                status_code=507,
-                detail=(
-                    f"Not enough disk space to start this download. "
-                    f"{free_gb:.1f} GB free, {min_free_gb} GB required. "
-                    f"Free up space or lower the minimum free space setting."
-                ),
-            )
+    shortfall = await get_free_space_shortfall(download_folder, min_free_gb)
+    if shortfall:
+        free_gb, required_gb = shortfall
+        raise HTTPException(
+            status_code=507,
+            detail=(
+                f"Not enough disk space to start this download. "
+                f"{free_gb:.1f} GB free, {required_gb} GB required. "
+                f"Free up space or lower the minimum free space setting."
+            ),
+        )

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -17,6 +17,7 @@ from config import settings as app_settings, is_docker_env
 from database import async_session_maker
 from services.log_stream import backend_log_stream
 from services.credential_crypto import credential_crypto
+from services.disk_space import get_free_space_shortfall
 from services.plex_service import plex_service
 
 logger = logging.getLogger(__name__)
@@ -1469,6 +1470,25 @@ class DownloadManager:
 
         if not will_comskip and not will_transcode:
             return current_path, warnings
+
+        # Disk-space preflight: transcoding/commercial removal writes a second
+        # copy of the recording next to the original. Refuse to start when free
+        # space is already below the configured minimum so ffmpeg cannot die
+        # mid-write with ENOSPC and leave a partial output behind.
+        min_free_gb = (
+            settings.min_free_space_gb if settings.min_free_space_gb is not None else 25
+        )
+        shortfall = await get_free_space_shortfall(
+            self._resolve_download_folder(settings), min_free_gb
+        )
+        if shortfall:
+            free_gb, required_gb = shortfall
+            raise Exception(
+                f"Not enough disk space to start post-processing. "
+                f"{free_gb:.1f} GB free, {required_gb} GB required. "
+                f"The raw recording is still in the download folder. "
+                f"Free up space and retry."
+            )
 
         async def log_callback(message: str):
             await self._broadcast_log(download_id, message)

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -831,6 +831,8 @@ class DownloadManager:
     async def _execute_post_process(self, download_id: int):
         """Execute post-processing for a downloaded file."""
         async with async_session_maker() as session:
+            working_input_path: Optional[str] = None
+            completed_output_path: Optional[str] = None
             try:
                 result = await session.execute(
                     select(Download).where(Download.id == download_id)
@@ -853,6 +855,7 @@ class DownloadManager:
                 download_folder = self._resolve_download_folder(settings)
 
                 original_path = download.output_path
+                working_input_path = original_path
                 original_file = Path(original_path)
                 if not original_file.is_file():
                     processed_found = None
@@ -901,6 +904,7 @@ class DownloadManager:
 
                 final_path = self._select_final_path(original_path, final_path)
                 completed_path = self._move_to_completed(final_path, completed_folder, download_folder)
+                completed_output_path = completed_path
                 download.output_path = completed_path
                 if warnings:
                     download.error_message = f"Completed with warnings: {'; '.join(warnings)}"
@@ -954,6 +958,15 @@ class DownloadManager:
                     download.status = DownloadStatus.CANCELLED.value
                     await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                     await session.commit()
+                    # Remove Comskip artifacts and partial transcode outputs left
+                    # by the cancelled run. The original recording is kept.
+                    if working_input_path:
+                        self._cleanup_working_files(
+                            working_input_path,
+                            completed_output_path or working_input_path,
+                            keep_logs=False,
+                            delete_original=False,
+                        )
                     await self._broadcast_progress(
                         download_id, download.progress, DownloadStatus.CANCELLED.value
                     )
@@ -971,6 +984,17 @@ class DownloadManager:
                     download.error_message = _friendly_error(e)
                     await self._sync_schedule_status(session, download_id, DownloadStatus.FAILED.value)
                     await session.commit()
+
+                # Remove Comskip artifacts and partial transcode outputs left by
+                # the failed run. Logs are kept for debugging and the original
+                # recording stays in the download folder.
+                if working_input_path:
+                    self._cleanup_working_files(
+                        working_input_path,
+                        completed_output_path or working_input_path,
+                        keep_logs=True,
+                        delete_original=False,
+                    )
 
                 await self._broadcast_progress(
                     download_id,

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -618,6 +618,12 @@ class DownloadManager:
 
     async def _execute_download(self, download_id: int):
         """Execute a single download."""
+        # These survive into the except handlers: once the full payload has
+        # been written to disk (and possibly moved to the completed folder),
+        # cancel/error handling must never destroy a complete recording.
+        transfer_complete = False
+        moved_completed_path: Optional[str] = None
+        settings = None
         async with async_session_maker() as session:
             download = None
             try:
@@ -680,6 +686,7 @@ class DownloadManager:
                         "Provider returned an empty response. "
                         "The catchup window for this program may have expired."
                     )
+                transfer_complete = True
                 await self._broadcast_log(download_id, "Download transfer complete.")
 
                 settings_result = await session.execute(select(AppSettings))
@@ -736,6 +743,7 @@ class DownloadManager:
                     await self._broadcast_log(download_id, f"Download failed: {msg}", level="error")
                     return
                 download.output_path = completed_path
+                moved_completed_path = completed_path
 
                 download.status = DownloadStatus.COMPLETED.value
                 download.progress = 100.0
@@ -759,21 +767,43 @@ class DownloadManager:
                         select(Download).where(Download.id == download_id)
                     )
                     download = result.scalar_one_or_none()
+                completed_path = moved_completed_path
+                if (
+                    completed_path is None
+                    and transfer_complete
+                    and download is not None
+                    and download.output_path
+                    and os.path.exists(download.output_path)
+                ):
+                    # The final byte was already written before the cancel
+                    # arrived: the recording is complete. Move it to the
+                    # completed folder instead of deleting it.
+                    if settings is None:
+                        settings = await self._load_app_settings()
+                    try:
+                        completed_path = self._move_to_completed(
+                            download.output_path,
+                            self._resolve_completed_folder(settings),
+                            self._resolve_download_folder(settings),
+                        )
+                    except OSError:
+                        # Move failed; keep the recording where it is.
+                        completed_path = download.output_path
+                if download is not None and completed_path is not None:
+                    # Cancel arrived after the download already finished (and
+                    # possibly after the move). Treat the recording as complete
+                    # and leave the file untouched.
+                    self._cancelled.discard(download_id)
+                    await self._finalize_completed_after_interrupt(
+                        session, download_id, completed_path
+                    )
+                    await self._broadcast_log(
+                        download_id,
+                        f"Download completed: {os.path.basename(completed_path)}"
+                    )
+                    await self._trigger_plex_refresh(completed_path)
+                    return
                 if download:
-                    if download.status == DownloadStatus.COMPLETED.value:
-                        # Cancel arrived after the file was already moved to the
-                        # completed folder. Commit the completed state and leave
-                        # the file untouched.
-                        await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
-                        await session.commit()
-                        await self._broadcast_progress(
-                            download_id, 100, DownloadStatus.COMPLETED.value
-                        )
-                        await self._broadcast_log(
-                            download_id,
-                            f"Download completed: {os.path.basename(download.output_path)}"
-                        )
-                        return
                     download.status = DownloadStatus.CANCELLED.value
                     await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                     await session.commit()
@@ -1013,12 +1043,74 @@ class DownloadManager:
                     select(Download).where(Download.id == download_id)
                 )
                 dl = result.scalar_one_or_none()
-                if dl and dl.output_path:
+                # Never delete a recording that was already finalized: a stale
+                # cancel flag must not destroy a COMPLETED file.
+                if dl and dl.output_path and dl.status != DownloadStatus.COMPLETED.value:
                     path = Path(dl.output_path)
                     if path.is_file():
                         path.unlink()
         except Exception:
             pass
+
+    async def _load_app_settings(self) -> Optional[AppSettings]:
+        """Load AppSettings on a fresh session; returns None when unavailable."""
+        try:
+            async with async_session_maker() as session:
+                result = await session.execute(select(AppSettings))
+                return result.scalar_one_or_none()
+        except Exception:
+            return None
+
+    async def _finalize_completed_after_interrupt(
+        self,
+        session: AsyncSession,
+        download_id: int,
+        completed_path: str,
+        error_message: Optional[str] = None,
+    ) -> None:
+        """Persist COMPLETED for a recording whose file already survived on disk.
+
+        Called from cancel/error handlers once the full recording has been
+        written (and usually moved to the completed folder). The file must
+        never be lost just because the caller's session is unusable (e.g. a
+        failed commit left it pending rollback), so this retries once on a
+        fresh session and never raises a DB error back to the caller.
+        """
+        values = {
+            "status": DownloadStatus.COMPLETED.value,
+            "output_path": completed_path,
+            "progress": 100.0,
+            "completed_at": datetime.utcnow(),
+            "error_message": error_message,
+        }
+        try:
+            await session.execute(
+                update(Download).where(Download.id == download_id).values(**values)
+            )
+            await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
+            await session.commit()
+        except Exception:
+            try:
+                await session.rollback()
+            except Exception:
+                pass
+            try:
+                async with async_session_maker() as fresh_session:
+                    await fresh_session.execute(
+                        update(Download).where(Download.id == download_id).values(**values)
+                    )
+                    await self._sync_schedule_status(
+                        fresh_session, download_id, DownloadStatus.COMPLETED.value
+                    )
+                    await fresh_session.commit()
+            except Exception:
+                logger.exception(
+                    "Could not persist COMPLETED state for download %s; "
+                    "file preserved at %s",
+                    download_id,
+                    completed_path,
+                )
+        await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
 
     async def _resolve_download_owner(self, download_id: int) -> int | None:
         if download_id in self._download_owners:

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -862,6 +862,10 @@ class DownloadManager:
 
     async def _execute_post_process(self, download_id: int):
         """Execute post-processing for a downloaded file."""
+        # Set once the output file has been moved to the completed folder so
+        # cancel/error handling never marks a surviving recording CANCELLED or
+        # FAILED (which would expose it to later cleanup/retry deletion).
+        moved_completed_path: Optional[str] = None
         async with async_session_maker() as session:
             working_input_path: Optional[str] = None
             completed_output_path: Optional[str] = None
@@ -897,6 +901,7 @@ class DownloadManager:
                             break
                     if processed_found:
                         completed_path = self._move_to_completed(processed_found, completed_folder, download_folder)
+                        moved_completed_path = completed_path
                         download.output_path = completed_path
                         download.status = DownloadStatus.COMPLETED.value
                         download.progress = 100.0
@@ -913,6 +918,7 @@ class DownloadManager:
 
                 if not self._needs_post_processing(download, settings):
                     completed_path = self._move_to_completed(original_path, completed_folder, download_folder)
+                    moved_completed_path = completed_path
                     download.output_path = completed_path
                     download.status = DownloadStatus.COMPLETED.value
                     download.progress = 100.0
@@ -937,6 +943,7 @@ class DownloadManager:
                 final_path = self._select_final_path(original_path, final_path)
                 completed_path = self._move_to_completed(final_path, completed_folder, download_folder)
                 completed_output_path = completed_path
+                moved_completed_path = completed_path
                 download.output_path = completed_path
                 if warnings:
                     download.error_message = f"Completed with warnings: {'; '.join(warnings)}"
@@ -970,19 +977,20 @@ class DownloadManager:
                 await self._trigger_plex_refresh(completed_path)
 
             except asyncio.CancelledError:
+                if moved_completed_path is not None:
+                    # File was already moved to the completed folder before the
+                    # cancel arrived. Persist COMPLETED so the recording is not
+                    # left as PROCESSING/CANCELLED with an orphaned file.
+                    self._cancelled.discard(download_id)
+                    await self._finalize_completed_after_interrupt(
+                        session, download_id, moved_completed_path
+                    )
+                    return
                 result = await session.execute(
                     select(Download).where(Download.id == download_id)
                 )
                 download = result.scalar_one_or_none()
-                if download and download.status == DownloadStatus.COMPLETED.value:
-                    # File was already moved to the completed folder before the cancel
-                    # arrived. The in-memory COMPLETED state was never committed because
-                    # the session shares the same identity map. Commit it now so the
-                    # recording is not left as PROCESSING with an orphaned file.
-                    await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
-                    await session.commit()
-                    await self._broadcast_progress(download_id, 100, DownloadStatus.COMPLETED.value)
-                elif download and download.status in [
+                if download and download.status in [
                     DownloadStatus.PENDING.value,
                     DownloadStatus.DOWNLOADING.value,
                     DownloadStatus.PROCESSING.value,
@@ -1005,6 +1013,26 @@ class DownloadManager:
                     await self._broadcast_log(download_id, "Post-processing cancelled.", level="warning")
 
             except Exception as e:
+                if moved_completed_path is not None and os.path.exists(moved_completed_path):
+                    # Post-processing crashed after the file was already moved
+                    # to the completed folder. The artifact survived, so record
+                    # the download as COMPLETED instead of FAILED (a FAILED row
+                    # pointing at the completed file would let retry/cleanup
+                    # overwrite or delete a good recording).
+                    await self._finalize_completed_after_interrupt(
+                        session,
+                        download_id,
+                        moved_completed_path,
+                        error_message=f"Completed with warnings: {_friendly_error(e)}",
+                    )
+                    await self._broadcast_log(
+                        download_id,
+                        f"Post-processing error after the file was finalized ({e}); "
+                        f"recording kept: {os.path.basename(moved_completed_path)}",
+                        level="warning",
+                    )
+                    await self._trigger_plex_refresh(moved_completed_path)
+                    return
                 result = await session.execute(
                     select(Download).where(Download.id == download_id)
                 )

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -818,26 +818,27 @@ class DownloadManager:
                 await self._broadcast_log(download_id, "Download cancelled.", level="warning")
 
             except Exception as e:
+                if moved_completed_path is not None:
+                    # The file already reached the completed folder. A late
+                    # failure (e.g. the final DB commit) must never delete or
+                    # fail a recording that survived on disk. This also covers
+                    # a failed commit leaving the session pending rollback: the
+                    # finalize helper retries on a fresh session.
+                    await self._finalize_completed_after_interrupt(
+                        session, download_id, moved_completed_path
+                    )
+                    await self._broadcast_log(
+                        download_id,
+                        f"Download completed: {os.path.basename(moved_completed_path)} "
+                        f"(ignored post-completion error: {e})"
+                    )
+                    await self._trigger_plex_refresh(moved_completed_path)
+                    return
                 # Download failed
                 result = await session.execute(
                     select(Download).where(Download.id == download_id)
                 )
                 download = result.scalar_one_or_none()
-                if download and download.status == DownloadStatus.COMPLETED.value:
-                    # Exception fired after _move_to_completed updated output_path in
-                    # memory but before (or during) session.commit(). The file is
-                    # already in the completed folder; commit the completed state and
-                    # leave it untouched, mirroring the CancelledError guard above.
-                    await self._sync_schedule_status(session, download_id, DownloadStatus.COMPLETED.value)
-                    await session.commit()
-                    await self._broadcast_progress(
-                        download_id, 100, DownloadStatus.COMPLETED.value
-                    )
-                    await self._broadcast_log(
-                        download_id,
-                        f"Download completed: {os.path.basename(download.output_path)}"
-                    )
-                    return
                 if download:
                     download.status = DownloadStatus.FAILED.value
                     if not download.completed_at:

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1129,7 +1129,30 @@ class DownloadManager:
             except OSError:
                 pass
             raise
+        if download_folder:
+            # Series episodes live in Show/Season subfolders of the download
+            # folder; remove any now-empty parents so they don't accumulate.
+            self._prune_empty_parent_dirs(os.path.dirname(path), download_folder)
         return dest
+
+    def _prune_empty_parent_dirs(self, start_dir: str, root: str) -> None:
+        """Remove empty directories from *start_dir* up to, but never including, *root*."""
+        try:
+            root_real = os.path.realpath(os.path.abspath(root))
+            current = os.path.realpath(os.path.abspath(start_dir))
+            while current != root_real and self._path_is_under(current, root):
+                try:
+                    if not os.path.isdir(current) or os.listdir(current):
+                        break
+                    os.rmdir(current)
+                except OSError:
+                    break
+                parent = os.path.dirname(current)
+                if parent == current:
+                    break
+                current = parent
+        except Exception:
+            pass
 
     def _cleanup_working_files(self, original_path: str, completed_path: str, keep_logs: bool, delete_original: bool = True) -> None:
         try:

--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -59,6 +59,8 @@ class PostProcessor:
 
     VAAPI_RENDER_DEVICE = Path("/dev/dri/renderD128")
     VAAPI_SYSFS_DRM_CLASS = Path("/sys/class/drm")
+    # Corrupt input can make ffprobe hang forever; cap how long we wait for it.
+    FFPROBE_TIMEOUT_SECONDS = 60.0
     VAAPI_DEFAULT_DRIVERS_PATH = (
         "/usr/local/lib/x86_64-linux-gnu/dri:/usr/local/lib/aarch64-linux-gnu/dri:"
         "/usr/lib/x86_64-linux-gnu/dri:/usr/lib/aarch64-linux-gnu/dri"
@@ -696,7 +698,21 @@ class PostProcessor:
         except FileNotFoundError:
             return self._primary_av_map_args()
 
-        stdout, stderr = await process.communicate()
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(), timeout=self.FFPROBE_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            await self._terminate_process(process)
+            await self._notify_log(
+                log_callback,
+                f"ffprobe stream probe timed out after {self.FFPROBE_TIMEOUT_SECONDS:.0f}s; "
+                "falling back to primary streams."
+            )
+            return self._primary_av_map_args()
+        except asyncio.CancelledError:
+            await self._terminate_process(process)
+            raise
         if process.returncode != 0:
             stderr_text = (stderr or b"").decode(errors="ignore").strip()
             if stderr_text:
@@ -1527,7 +1543,21 @@ class PostProcessor:
             )
             return 0
 
-        stdout, stderr = await process.communicate()
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(), timeout=self.FFPROBE_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            await self._terminate_process(process)
+            await self._notify_log(
+                log_callback,
+                f"ffprobe timed out after {self.FFPROBE_TIMEOUT_SECONDS:.0f}s; "
+                "duration unavailable."
+            )
+            return 0
+        except asyncio.CancelledError:
+            await self._terminate_process(process)
+            raise
         if process.returncode != 0:
             stderr_text = stderr.decode(errors="ignore").strip()
             if stderr_text:

--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -630,6 +630,14 @@ class PostProcessor:
             env_cmd.append(f"LIBVA_DRIVER_NAME={details['driver']}")
         return [*env_cmd, *cmd]
 
+    def _remove_partial_output(self, output_path: Path) -> None:
+        """Remove a partially-written ffmpeg output file, ignoring errors."""
+        try:
+            if output_path.exists():
+                output_path.unlink()
+        except Exception:
+            pass
+
     def _escape_concat_path(self, path: Path) -> str:
         text = str(path)
         text = text.replace("\\", "\\\\")
@@ -876,67 +884,74 @@ class PostProcessor:
 
         # Run ffmpeg with progress
         duration = await self._get_duration(input_path, log_callback=log_callback)
-        returncode, stderr = await self._run_ffmpeg_with_progress(
-            cmd,
-            duration,
-            progress_callback,
-            env=ffmpeg_env,
-        )
-        if returncode != 0:
-            if remux_only and output_format in [OutputFormat.MP4, OutputFormat.MKV]:
-                await self._notify_log(
-                    log_callback,
-                    "ffmpeg remux failed; retrying with full transcode (video+audio)."
-                )
-                if output_path.exists():
-                    try:
-                        output_path.unlink()
-                    except Exception:
-                        pass
-                retry_cmd = [self._ffmpeg_path]
-                if hw_accel == HardwareAccel.VAAPI:
-                    retry_cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
-                retry_cmd.extend([
-                    "-i", str(input_path),
-                    "-y",
-                ])
-                retry_cmd = self._with_error_tolerant_flags(retry_cmd)
-                if input_file.suffix.lower() == ".ts":
-                    retry_cmd.extend(selected_map_args)
-                else:
-                    retry_cmd.extend(["-map", "0"])
-                retry_cmd.extend(self._get_encoder_args(
-                    hw_accel,
-                    self._preferred_video_codec(hw_accel),
-                    quality
-                ))
-                retry_cmd.extend(["-c:a", "aac", "-avoid_negative_ts", "make_zero"])
-                retry_cmd.extend([
-                    "-progress", "pipe:1",
-                    "-nostats",
-                    str(output_path)
-                ])
-                await self._notify_log(
-                    log_callback,
-                    f"ffmpeg retry cmd: {' '.join(shlex.quote(str(c)) for c in retry_cmd)}"
-                )
-                if hw_accel == HardwareAccel.VAAPI:
-                    retry_cmd = self._prepend_vaapi_env(retry_cmd)
-                returncode, stderr = await self._run_ffmpeg_with_progress(
-                    retry_cmd,
-                    duration,
-                    progress_callback,
-                    env=ffmpeg_env,
-                )
-                if returncode == 0:
-                    if remove_original and output_path.exists():
-                        os.remove(input_path)
-                    return str(output_path)
+        try:
+            returncode, stderr = await self._run_ffmpeg_with_progress(
+                cmd,
+                duration,
+                progress_callback,
+                env=ffmpeg_env,
+            )
+            if returncode != 0:
+                if remux_only and output_format in [OutputFormat.MP4, OutputFormat.MKV]:
+                    await self._notify_log(
+                        log_callback,
+                        "ffmpeg remux failed; retrying with full transcode (video+audio)."
+                    )
+                    if output_path.exists():
+                        try:
+                            output_path.unlink()
+                        except Exception:
+                            pass
+                    retry_cmd = [self._ffmpeg_path]
+                    if hw_accel == HardwareAccel.VAAPI:
+                        retry_cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
+                    retry_cmd.extend([
+                        "-i", str(input_path),
+                        "-y",
+                    ])
+                    retry_cmd = self._with_error_tolerant_flags(retry_cmd)
+                    if input_file.suffix.lower() == ".ts":
+                        retry_cmd.extend(selected_map_args)
+                    else:
+                        retry_cmd.extend(["-map", "0"])
+                    retry_cmd.extend(self._get_encoder_args(
+                        hw_accel,
+                        self._preferred_video_codec(hw_accel),
+                        quality
+                    ))
+                    retry_cmd.extend(["-c:a", "aac", "-avoid_negative_ts", "make_zero"])
+                    retry_cmd.extend([
+                        "-progress", "pipe:1",
+                        "-nostats",
+                        str(output_path)
+                    ])
+                    await self._notify_log(
+                        log_callback,
+                        f"ffmpeg retry cmd: {' '.join(shlex.quote(str(c)) for c in retry_cmd)}"
+                    )
+                    if hw_accel == HardwareAccel.VAAPI:
+                        retry_cmd = self._prepend_vaapi_env(retry_cmd)
+                    returncode, stderr = await self._run_ffmpeg_with_progress(
+                        retry_cmd,
+                        duration,
+                        progress_callback,
+                        env=ffmpeg_env,
+                    )
+                    if returncode == 0:
+                        if remove_original and output_path.exists():
+                            os.remove(input_path)
+                        return str(output_path)
 
-            log_path = self._write_ffmpeg_log(str(input_path), "transcode", stderr)
-            if log_path:
-                await self._notify_log(log_callback, f"ffmpeg log saved: {log_path}")
-            raise Exception(f"ffmpeg failed: {stderr.decode(errors='ignore')}")
+                log_path = self._write_ffmpeg_log(str(input_path), "transcode", stderr)
+                if log_path:
+                    await self._notify_log(log_callback, f"ffmpeg log saved: {log_path}")
+                self._remove_partial_output(output_path)
+                raise Exception(f"ffmpeg failed: {stderr.decode(errors='ignore')}")
+        except asyncio.CancelledError:
+            # The ffmpeg process was already terminated by _run_ffmpeg_with_progress;
+            # remove whatever partial output it left behind.
+            self._remove_partial_output(output_path)
+            raise
 
         # Remove original if requested
         if remove_original and output_path.exists():
@@ -1305,7 +1320,11 @@ class PostProcessor:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE
                 )
-                _, seg_stderr = await process.communicate()
+                try:
+                    _, seg_stderr = await process.communicate()
+                except asyncio.CancelledError:
+                    await self._terminate_process(process)
+                    raise
                 if process.returncode != 0:
                     log_path = self._write_ffmpeg_log(str(input_path), f"seg{i}", seg_stderr or b"")
                     if log_path:
@@ -1428,8 +1447,10 @@ class PostProcessor:
                     os.remove(temp_path)
             if concat_file.exists():
                 os.remove(concat_file)
-            if same_path_output and not concat_succeeded and work_output_path.exists():
-                work_output_path.unlink()
+            # Remove the partially-written output on any failed or cancelled run.
+            # When concat succeeded, work_output_path is the finished recording.
+            if not concat_succeeded:
+                self._remove_partial_output(work_output_path)
 
         self._cleanup_comskip_outputs(input_path, edl_path)
 

--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -1049,80 +1049,85 @@ class PostProcessor:
                 return f"...{value[-max_len:]}"
             return value
 
+        async def run_prep_ffmpeg(cmd: List[str]) -> tuple[int, bytes]:
+            """Run a Comskip prep ffmpeg command, killing it if the task is cancelled."""
+            prep_process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            try:
+                _, prep_stderr = await prep_process.communicate()
+            except asyncio.CancelledError:
+                await self._terminate_process(prep_process)
+                raise
+            prep_returncode = prep_process.returncode if prep_process.returncode is not None else -1
+            return prep_returncode, prep_stderr or b""
+
         returncode, combined_output = await run_comskip_once(input_path)
         active_input_file = input_file
         temp_probe_file: Optional[Path] = None
 
-        if returncode != 0 and input_file.suffix.lower() == ".ts" and self.ffmpeg_available:
-            failed_excerpt = excerpt(combined_output, 600)
-            if failed_excerpt:
-                await self._notify_log(log_callback, f"Comskip failed (exit {returncode}): {failed_excerpt}")
-            await self._notify_log(
-                log_callback,
-                "Comskip failed on TS input; retrying on normalized intermediate file."
-            )
-            selected_map_args = await self._select_best_av_map_args(input_path, log_callback)
-            video_map = selected_map_args[1] if len(selected_map_args) >= 2 else "0:v:0"
-            temp_probe_file = input_file.with_stem(f"{input_file.stem}_comskip_input").with_suffix(".mkv")
-
-            prep_cmd = [self._ffmpeg_path, "-i", str(input_file), "-y"]
-            prep_cmd = self._with_error_tolerant_flags(prep_cmd)
-            prep_cmd.extend(selected_map_args)
-            prep_cmd.extend([
-                "-c:v", "copy",
-                "-c:a", "aac",
-                "-af", "aresample=async=1:first_pts=0",
-                "-avoid_negative_ts", "make_zero",
-                str(temp_probe_file)
-            ])
-            await self._notify_log(
-                log_callback,
-                f"Comskip prep cmd: {' '.join(shlex.quote(str(c)) for c in prep_cmd)}"
-            )
-            prep_process = await asyncio.create_subprocess_exec(
-                *prep_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-            _, prep_stderr = await prep_process.communicate()
-
-            if prep_process.returncode != 0:
+        try:
+            if returncode != 0 and input_file.suffix.lower() == ".ts" and self.ffmpeg_available:
+                failed_excerpt = excerpt(combined_output, 600)
+                if failed_excerpt:
+                    await self._notify_log(log_callback, f"Comskip failed (exit {returncode}): {failed_excerpt}")
                 await self._notify_log(
                     log_callback,
-                    "Comskip prep with audio failed; retrying prep with video-only stream."
+                    "Comskip failed on TS input; retrying on normalized intermediate file."
                 )
-                video_only_cmd = [self._ffmpeg_path, "-i", str(input_file), "-y"]
-                video_only_cmd = self._with_error_tolerant_flags(video_only_cmd)
-                video_only_cmd.extend([
-                    "-map", video_map,
-                    "-an",
+                selected_map_args = await self._select_best_av_map_args(input_path, log_callback)
+                video_map = selected_map_args[1] if len(selected_map_args) >= 2 else "0:v:0"
+                temp_probe_file = input_file.with_stem(f"{input_file.stem}_comskip_input").with_suffix(".mkv")
+
+                prep_cmd = [self._ffmpeg_path, "-i", str(input_file), "-y"]
+                prep_cmd = self._with_error_tolerant_flags(prep_cmd)
+                prep_cmd.extend(selected_map_args)
+                prep_cmd.extend([
                     "-c:v", "copy",
+                    "-c:a", "aac",
+                    "-af", "aresample=async=1:first_pts=0",
                     "-avoid_negative_ts", "make_zero",
                     str(temp_probe_file)
                 ])
                 await self._notify_log(
                     log_callback,
-                    f"Comskip prep cmd (video-only): {' '.join(shlex.quote(str(c)) for c in video_only_cmd)}"
+                    f"Comskip prep cmd: {' '.join(shlex.quote(str(c)) for c in prep_cmd)}"
                 )
-                prep_process = await asyncio.create_subprocess_exec(
-                    *video_only_cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE
-                )
-                _, prep_stderr = await prep_process.communicate()
+                prep_returncode, prep_stderr = await run_prep_ffmpeg(prep_cmd)
 
-            if prep_process.returncode == 0:
-                active_input_file = temp_probe_file
-                returncode, combined_output = await run_comskip_once(
-                    str(temp_probe_file),
-                    progress_prefix="Comskip retry"
-                )
-            else:
-                prep_excerpt = excerpt((prep_stderr or b"").decode(errors="ignore"), 400)
-                if prep_excerpt:
-                    await self._notify_log(log_callback, f"Comskip prep failed: {prep_excerpt}")
+                if prep_returncode != 0:
+                    await self._notify_log(
+                        log_callback,
+                        "Comskip prep with audio failed; retrying prep with video-only stream."
+                    )
+                    video_only_cmd = [self._ffmpeg_path, "-i", str(input_file), "-y"]
+                    video_only_cmd = self._with_error_tolerant_flags(video_only_cmd)
+                    video_only_cmd.extend([
+                        "-map", video_map,
+                        "-an",
+                        "-c:v", "copy",
+                        "-avoid_negative_ts", "make_zero",
+                        str(temp_probe_file)
+                    ])
+                    await self._notify_log(
+                        log_callback,
+                        f"Comskip prep cmd (video-only): {' '.join(shlex.quote(str(c)) for c in video_only_cmd)}"
+                    )
+                    prep_returncode, prep_stderr = await run_prep_ffmpeg(video_only_cmd)
 
-        try:
+                if prep_returncode == 0:
+                    active_input_file = temp_probe_file
+                    returncode, combined_output = await run_comskip_once(
+                        str(temp_probe_file),
+                        progress_prefix="Comskip retry"
+                    )
+                else:
+                    prep_excerpt = excerpt((prep_stderr or b"").decode(errors="ignore"), 400)
+                    if prep_excerpt:
+                        await self._notify_log(log_callback, f"Comskip prep failed: {prep_excerpt}")
+
             if returncode != 0:
                 failed_excerpt = excerpt(combined_output, 600)
                 if failed_excerpt:
@@ -1148,11 +1153,22 @@ class PostProcessor:
                 await self._notify_log(log_callback, "Comskip finished without EDL output.")
             return None
         finally:
-            if temp_probe_file and temp_probe_file.exists():
-                try:
-                    os.remove(temp_probe_file)
-                except Exception:
-                    pass
+            if temp_probe_file:
+                # Remove the intermediate probe file plus any Comskip sidecar
+                # outputs generated for it (.edl excluded: it may be the result
+                # returned to the caller). The "_comskip_input" stem is generated
+                # by this run, so these are never user files.
+                cleanup_candidates = [temp_probe_file]
+                cleanup_candidates.extend(
+                    temp_probe_file.with_suffix(suffix)
+                    for suffix in (".txt", ".log", ".logo", ".csv", ".vdr", ".xml")
+                )
+                for candidate in cleanup_candidates:
+                    if candidate.exists():
+                        try:
+                            os.remove(candidate)
+                        except Exception:
+                            pass
 
     async def remove_commercials(
         self,

--- a/backend/tests/test_cancel_after_last_byte.py
+++ b/backend/tests/test_cancel_after_last_byte.py
@@ -1,0 +1,171 @@
+"""
+Regression test: cancel arriving right after the final byte must not destroy
+the recording.
+
+In _execute_download there is a window between _download_file returning the
+full payload and download.status being set to COMPLETED (the transfer-complete
+log broadcast and the AppSettings query are awaits). If Task.cancel() lands in
+that window, the CancelledError handler previously saw the in-memory status
+DOWNLOADING, marked the download CANCELLED and os.unlink'ed the fully
+downloaded file:
+
+  - Bug 1: the complete recording was deleted from disk.
+  - Bug 2: the download ended CANCELLED although the data was complete.
+
+Fix: _execute_download tracks a transfer_complete flag; when a cancel arrives
+after the final byte, the handler moves the finished file to the completed
+folder and finalizes the download as COMPLETED instead.
+"""
+import asyncio
+import contextlib
+import sys
+import tempfile
+import shutil
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class CancelAfterLastByteTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_settings(self, download_folder: str, completed_folder: str) -> None:
+        async with self.session_factory() as session:
+            settings = AppSettings(
+                download_folder=download_folder,
+                completed_folder=completed_folder,
+                transcode_enabled=False,
+                comskip_enabled=False,
+            )
+            session.add(settings)
+            await session.commit()
+
+    async def _seed_pending_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            download = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PENDING.value,
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id
+
+    async def _run_cancel_after_last_byte(self):
+        """Drive _execute_download so a cancel lands right after the last byte.
+
+        The fake _download_file writes the full payload and registers the
+        cooperative cancel flag (as cancel_download() would). The patched
+        _broadcast_log then raises CancelledError on the transfer-complete
+        message -- the first await after the final byte, before the status
+        flips to COMPLETED -- simulating Task.cancel() delivery.
+        """
+        downloads_dir = Path(self.tmpdir) / "downloads"
+        downloads_dir.mkdir()
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        await self._seed_settings(str(downloads_dir), str(completed_dir))
+
+        output_path = str(downloads_dir / "test_show.ts")
+        download_id = await self._seed_pending_download(output_path)
+        manager = self.manager
+
+        async def fake_download_file(url, path, did, session, offset=0):
+            Path(path).write_bytes(b"x" * 2048)
+            manager._cancelled.add(did)
+            return 2048
+
+        async def cancel_on_transfer_complete(did, message, level="info"):
+            if message == "Download transfer complete.":
+                raise asyncio.CancelledError()
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with patch("services.download_manager.async_session_maker", patched_session_maker), \
+                 patch.object(self.manager, "_download_file", fake_download_file), \
+                 patch.object(self.manager, "_broadcast_log", cancel_on_transfer_complete), \
+                 patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+                 patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock):
+                await self.manager._execute_download(download_id)
+        except asyncio.CancelledError:
+            pass
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+        return dl, Path(output_path), completed_dir / "test_show.ts"
+
+    async def test_cancel_after_last_byte_preserves_file(self):
+        """Bug 1: the fully-downloaded file must survive a last-moment cancel."""
+        dl, original_path, completed_path = await self._run_cancel_after_last_byte()
+
+        self.assertTrue(
+            completed_path.exists(),
+            "The complete recording must be moved to the completed folder, not "
+            "deleted, when cancel arrives right after the final byte. Before "
+            "the fix the CancelledError handler os.unlink'ed the file.",
+        )
+        self.assertFalse(
+            original_path.exists(),
+            "The finished file should have been moved out of the download folder.",
+        )
+
+    async def test_cancel_after_last_byte_finalizes_completed(self):
+        """Bug 2: the download must end COMPLETED, not CANCELLED."""
+        dl, _original_path, completed_path = await self._run_cancel_after_last_byte()
+
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.COMPLETED.value,
+            "Download must end COMPLETED when cancel arrives after the final "
+            "byte. Before the fix the handler overwrote it with CANCELLED.",
+        )
+        self.assertEqual(dl.output_path, str(completed_path))
+        self.assertNotIn(
+            dl.id,
+            self.manager._cancelled,
+            "The stale cancel flag must be cleared so the finalized recording "
+            "cannot be deleted by a later queue pass.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_commit_failure_after_move.py
+++ b/backend/tests/test_commit_failure_after_move.py
@@ -1,0 +1,151 @@
+"""
+Regression test: a failed DB commit after _move_to_completed must not lose the
+completed recording.
+
+In _execute_download the success path moves the file to the completed folder
+and then commits the COMPLETED state. If that commit fails (SQLite busy, disk
+I/O error, NAS going offline), SQLAlchemy leaves the session pending rollback.
+The except Exception handler then re-queried through the same session, which
+raised PendingRollbackError, so neither COMPLETED nor FAILED was ever
+persisted: the row stayed DOWNLOADING forever and a restart re-downloaded (or
+failed) a recording whose file was already safely in the completed folder.
+
+Fix: the handler keys off the local moved-completed path and persists the
+COMPLETED state through _finalize_completed_after_interrupt, which rolls back
+the broken session and retries on a fresh one. The completed file is never
+deleted.
+"""
+import contextlib
+import sys
+import tempfile
+import shutil
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class CommitFailureAfterMoveTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_pending_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            download = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PENDING.value,
+                progress=0.0,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id
+
+    async def test_commit_failure_after_move_keeps_completed_recording(self):
+        """The recording must end COMPLETED (file intact) when the final commit fails.
+
+        The hooked _sync_schedule_status (the last await before the final
+        commit on the success path) sets a NOT NULL column to None, so the
+        real session.commit() fails with IntegrityError and leaves the session
+        in the pending-rollback state -- exactly what a real failed commit
+        does. Before the fix the except handler crashed on the unusable
+        session and the row stayed DOWNLOADING.
+        """
+        download_path = str(Path(self.tmpdir) / "test_show.ts")
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        completed_path = str(completed_dir / "test_show.ts")
+        # Simulate the file already residing in the completed folder after a
+        # successful _move_to_completed call.
+        Path(completed_path).touch()
+
+        download_id = await self._seed_pending_download(download_path)
+
+        sync_calls = [0]
+
+        async def poison_first_commit(session, did, status):
+            sync_calls[0] += 1
+            if sync_calls[0] == 1:
+                obj = await session.get(Download, did)
+                # NOT NULL column: the success-path commit right after this
+                # call fails with IntegrityError.
+                obj.source_url = None
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with (
+                patch("services.download_manager.async_session_maker", patched_session_maker),
+                patch.object(self.manager, "_download_file", new_callable=AsyncMock, return_value=1024),
+                patch.object(self.manager, "_needs_post_processing", return_value=False),
+                patch.object(self.manager, "_move_to_completed", return_value=completed_path),
+                patch.object(self.manager, "_sync_schedule_status", side_effect=poison_first_commit),
+                patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+                patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+                patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock),
+            ):
+                await self.manager._execute_download(download_id)
+        except Exception:
+            pass
+
+        self.assertTrue(
+            Path(completed_path).exists(),
+            "A DB commit failure must never delete a recording that was "
+            "already moved to the completed folder.",
+        )
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.COMPLETED.value,
+            "Download must be persisted as COMPLETED even when the original "
+            "commit fails and poisons the session. Before the fix the row "
+            "stayed DOWNLOADING and the recording was re-downloaded or failed "
+            "on restart.",
+        )
+        self.assertEqual(
+            dl.output_path,
+            completed_path,
+            "output_path must point at the completed file so the app can find it.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_comskip_exception_fallthrough.py
+++ b/backend/tests/test_comskip_exception_fallthrough.py
@@ -43,6 +43,7 @@ class ComSkipExceptionFallthroughTests(unittest.IsolatedAsyncioTestCase):
             transcode_enabled=True,
             remux_only=False,
             transcode_format="mkv",
+            min_free_space_gb=0,
         )
         session.add(settings)
         await session.commit()

--- a/backend/tests/test_comskip_failure_error_message.py
+++ b/backend/tests/test_comskip_failure_error_message.py
@@ -53,6 +53,7 @@ class ComSkipFailureErrorMessageTests(unittest.IsolatedAsyncioTestCase):
                 remux_only=False,
                 download_folder=self.tmpdir,
                 completed_folder=self.tmpdir,
+                min_free_space_gb=0,
             )
             session.add(settings)
             await session.flush()

--- a/backend/tests/test_comskip_prep_cancel_cleanup.py
+++ b/backend/tests/test_comskip_prep_cancel_cleanup.py
@@ -1,0 +1,125 @@
+"""
+Regression test: cancelling a download during the Comskip prep FFmpeg step must
+kill the FFmpeg subprocess and remove the partial _comskip_input.mkv file.
+
+Bug: in detect_commercials, the prep FFmpeg (which normalizes a failing TS into
+an intermediate MKV for the Comskip retry) was awaited via communicate() with no
+CancelledError handling, and the temp probe file cleanup lived in a try/finally
+that only started AFTER the prep block. Cancelling the post-processing task
+while prep was running left the FFmpeg process alive (still writing) and the
+partial {stem}_comskip_input.mkv orphaned on disk.
+
+Fix: prep FFmpeg runs through a helper that terminates the subprocess on
+CancelledError, and the try/finally now wraps the whole retry block so the
+probe file is removed on every exit path.
+"""
+import asyncio
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_prep_cancel_test", MODULE_PATH)
+PP_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PP_MODULE)
+
+PostProcessor = PP_MODULE.PostProcessor
+
+
+def make_failed_comskip_proc():
+    """Fake comskip process that exits non-zero (triggers the TS retry path)."""
+    proc = MagicMock()
+    stdout = asyncio.StreamReader()
+    stdout.feed_eof()
+    stderr = asyncio.StreamReader()
+    stderr.feed_data(b"comskip: could not parse TS\n")
+    stderr.feed_eof()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = 1
+    proc.wait = AsyncMock(return_value=1)
+    return proc
+
+
+class HangingPrepProcess:
+    """Fake prep FFmpeg that writes a partial probe file then blocks forever."""
+
+    def __init__(self, probe_path: Path):
+        self.returncode = None
+        self.terminate_called = False
+        self.kill_called = False
+        self.started = asyncio.Event()
+        self._probe_path = probe_path
+
+    async def communicate(self):
+        self._probe_path.write_bytes(b"\x00" * 256)  # partial ffmpeg output
+        self.started.set()
+        await asyncio.sleep(3600)
+
+    def terminate(self):
+        self.terminate_called = True
+        self.returncode = -15
+
+    def kill(self):
+        self.kill_called = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+class ComskipPrepCancelCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    async def test_cancel_during_prep_kills_ffmpeg_and_removes_probe_file(self):
+        ts_path = Path(self.tmp) / "Show.ts"
+        ts_path.write_bytes(b"\x47" * 188)
+        probe_path = Path(self.tmp) / "Show_comskip_input.mkv"
+
+        processor = PostProcessor()
+        processor._comskip_path = "/usr/bin/comskip"
+        processor._ffmpeg_path = "/usr/bin/ffmpeg"
+
+        prep_proc = HangingPrepProcess(probe_path)
+        subprocesses = [make_failed_comskip_proc(), prep_proc]
+
+        with patch.object(
+            type(processor), "comskip_available",
+            new_callable=PropertyMock, return_value=True,
+        ), patch.object(
+            type(processor), "ffmpeg_available",
+            new_callable=PropertyMock, return_value=True,
+        ), patch.object(
+            processor, "_select_best_av_map_args",
+            new=AsyncMock(return_value=["-map", "0:v:0", "-map", "0:a:0?"]),
+        ), patch(
+            "asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=subprocesses),
+        ):
+            task = asyncio.create_task(processor.detect_commercials(str(ts_path)))
+            await asyncio.wait_for(prep_proc.started.wait(), timeout=5.0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertTrue(
+            prep_proc.terminate_called or prep_proc.kill_called,
+            "The prep FFmpeg subprocess must be terminated when the post-process "
+            "task is cancelled; otherwise it keeps running and writing to disk.",
+        )
+        self.assertFalse(
+            probe_path.exists(),
+            "The partial _comskip_input.mkv must be removed when the task is "
+            "cancelled during the Comskip prep step.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_comskip_probe_sidecar_cleanup.py
+++ b/backend/tests/test_comskip_probe_sidecar_cleanup.py
@@ -1,0 +1,159 @@
+"""
+Regression test: Comskip sidecar files generated for the retry probe must be
+cleaned up by detect_commercials.
+
+Bug: when Comskip fails on a TS input, detect_commercials creates an
+intermediate {stem}_comskip_input.mkv and re-runs Comskip on it. Comskip writes
+its sidecar outputs (.txt/.log/.logo/.csv/.vdr/.xml depending on ini settings)
+next to that probe file. The finally block removed only the .mkv probe itself,
+so when the retry failed (or finished without an EDL) those sidecars were
+orphaned in the download folder forever.
+
+Fix: the finally block in detect_commercials also removes
+{stem}_comskip_input.{txt,log,logo,csv,vdr,xml}. The .edl is excluded because
+it can be the value returned to the caller (and is cleaned later by
+_cleanup_comskip_outputs).
+"""
+import asyncio
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_probe_sidecar_test", MODULE_PATH)
+PP_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PP_MODULE)
+
+PostProcessor = PP_MODULE.PostProcessor
+
+SIDECAR_SUFFIXES = (".txt", ".log", ".logo", ".csv", ".vdr", ".xml")
+
+
+def make_comskip_proc(returncode: int, on_finish=None):
+    """Fake comskip subprocess with empty streams and the given exit code."""
+    proc = MagicMock()
+    stdout = asyncio.StreamReader()
+    stdout.feed_eof()
+    stderr = asyncio.StreamReader()
+    stderr.feed_data(b"comskip output\n")
+    stderr.feed_eof()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+
+    async def _wait():
+        if on_finish:
+            on_finish()
+        return returncode
+
+    proc.wait = AsyncMock(side_effect=_wait)
+    return proc
+
+
+def make_prep_proc(returncode: int, probe_path: Path):
+    """Fake prep ffmpeg subprocess that writes the probe file on success."""
+    proc = MagicMock()
+
+    async def _communicate():
+        if returncode == 0:
+            probe_path.write_bytes(b"\x00" * 256)
+        return b"", b""
+
+    proc.communicate = AsyncMock(side_effect=_communicate)
+    proc.returncode = returncode
+    return proc
+
+
+class ComskipProbeSidecarCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    async def _run_detect(self, processor, ts_path, subprocesses):
+        with patch.object(
+            type(processor), "comskip_available",
+            new_callable=PropertyMock, return_value=True,
+        ), patch.object(
+            type(processor), "ffmpeg_available",
+            new_callable=PropertyMock, return_value=True,
+        ), patch.object(
+            processor, "_select_best_av_map_args",
+            new=AsyncMock(return_value=["-map", "0:v:0", "-map", "0:a:0?"]),
+        ), patch(
+            "asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=subprocesses),
+        ):
+            return await processor.detect_commercials(str(ts_path))
+
+    async def test_probe_sidecars_removed_when_comskip_retry_fails(self):
+        """All probe sidecar files must be gone after a failed Comskip retry."""
+        ts_path = Path(self.tmp) / "Show.ts"
+        ts_path.write_bytes(b"\x47" * 188)
+        probe_path = Path(self.tmp) / "Show_comskip_input.mkv"
+
+        processor = PostProcessor()
+        processor._comskip_path = "/usr/bin/comskip"
+        processor._ffmpeg_path = "/usr/bin/ffmpeg"
+
+        def write_sidecars():
+            # Simulate Comskip writing its sidecar outputs for the probe input.
+            for suffix in SIDECAR_SUFFIXES:
+                probe_path.with_suffix(suffix).write_text("comskip sidecar")
+
+        subprocesses = [
+            make_comskip_proc(1),                            # first comskip run fails
+            make_prep_proc(0, probe_path),                   # prep ffmpeg succeeds
+            make_comskip_proc(1, on_finish=write_sidecars),  # retry fails, leaves sidecars
+        ]
+
+        with self.assertRaises(Exception):
+            await self._run_detect(processor, ts_path, subprocesses)
+
+        self.assertFalse(probe_path.exists(), "Probe .mkv must be removed.")
+        for suffix in SIDECAR_SUFFIXES:
+            sidecar = probe_path.with_suffix(suffix)
+            self.assertFalse(
+                sidecar.exists(),
+                f"Probe sidecar {sidecar.name} must be removed after a failed "
+                "Comskip retry; it currently orphans in the download folder.",
+            )
+
+    async def test_probe_edl_survives_cleanup_when_retry_succeeds(self):
+        """The probe .edl returned to the caller must NOT be removed."""
+        ts_path = Path(self.tmp) / "Show.ts"
+        ts_path.write_bytes(b"\x47" * 188)
+        probe_path = Path(self.tmp) / "Show_comskip_input.mkv"
+        probe_edl = probe_path.with_suffix(".edl")
+
+        processor = PostProcessor()
+        processor._comskip_path = "/usr/bin/comskip"
+        processor._ffmpeg_path = "/usr/bin/ffmpeg"
+
+        def write_outputs():
+            probe_edl.write_text("60.0 120.0 0\n")
+            probe_path.with_suffix(".txt").write_text("comskip sidecar")
+
+        subprocesses = [
+            make_comskip_proc(1),                           # first comskip run fails
+            make_prep_proc(0, probe_path),                  # prep ffmpeg succeeds
+            make_comskip_proc(0, on_finish=write_outputs),  # retry succeeds with EDL
+        ]
+
+        edl_result = await self._run_detect(processor, ts_path, subprocesses)
+
+        self.assertEqual(edl_result, str(probe_edl), "detect_commercials must return the probe EDL.")
+        self.assertTrue(probe_edl.exists(), "The returned .edl must not be deleted by the cleanup.")
+        self.assertFalse(probe_path.exists(), "Probe .mkv must be removed.")
+        self.assertFalse(
+            probe_path.with_suffix(".txt").exists(),
+            "Probe .txt sidecar must be removed even when the retry succeeds.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_ffprobe_timeout.py
+++ b/backend/tests/test_ffprobe_timeout.py
@@ -1,0 +1,130 @@
+"""
+Regression test: ffprobe invocations must time out instead of hanging forever.
+
+Bug: _get_duration and _select_best_av_map_args awaited process.communicate()
+with no timeout. A corrupt or truncated input file can make ffprobe block
+indefinitely, which stalls the whole post-processing pipeline for that download
+forever (the post-processing slot is never released).
+
+Fix: both helpers wrap communicate() in asyncio.wait_for with
+FFPROBE_TIMEOUT_SECONDS (60s default), kill the ffprobe process on timeout, and
+fall back cleanly (duration 0 / primary stream map args).
+"""
+import asyncio
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_ffprobe_timeout_test", MODULE_PATH)
+PP_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PP_MODULE)
+
+PostProcessor = PP_MODULE.PostProcessor
+
+
+class HangingProcess:
+    """Fake subprocess whose communicate() never returns until terminated."""
+
+    def __init__(self):
+        self.returncode = None
+        self.terminate_called = False
+        self.kill_called = False
+
+    async def communicate(self):
+        await asyncio.sleep(3600)
+
+    def terminate(self):
+        self.terminate_called = True
+        self.returncode = -15
+
+    def kill(self):
+        self.kill_called = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+class FfprobeTimeoutTests(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.processor = PostProcessor()
+        # Short timeout so the test runs fast; production default is 60s.
+        self.processor.FFPROBE_TIMEOUT_SECONDS = 0.1
+
+    async def test_get_duration_times_out_and_kills_ffprobe(self):
+        """_get_duration must return 0 and kill ffprobe when it hangs."""
+        proc = HangingProcess()
+        with patch.object(self.processor, "_resolve_ffprobe_path",
+                          return_value="/usr/bin/ffprobe"), \
+             patch("asyncio.create_subprocess_exec",
+                   new=AsyncMock(return_value=proc)):
+            try:
+                duration = await asyncio.wait_for(
+                    self.processor._get_duration("/tmp/corrupt.ts"), timeout=2.0
+                )
+            except asyncio.TimeoutError:
+                self.fail(
+                    "_get_duration hung on a stalled ffprobe; it must enforce "
+                    "its own timeout and return a fallback duration."
+                )
+
+        self.assertEqual(duration, 0, "Timed-out probe must report duration 0.")
+        self.assertTrue(
+            proc.terminate_called or proc.kill_called,
+            "The hung ffprobe process must be terminated on timeout.",
+        )
+
+    async def test_select_best_av_map_args_times_out_and_kills_ffprobe(self):
+        """_select_best_av_map_args must fall back to primary streams on hang."""
+        proc = HangingProcess()
+        with patch.object(self.processor, "_resolve_ffprobe_path",
+                          return_value="/usr/bin/ffprobe"), \
+             patch("asyncio.create_subprocess_exec",
+                   new=AsyncMock(return_value=proc)):
+            try:
+                map_args = await asyncio.wait_for(
+                    self.processor._select_best_av_map_args("/tmp/corrupt.ts"),
+                    timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                self.fail(
+                    "_select_best_av_map_args hung on a stalled ffprobe; it must "
+                    "enforce its own timeout and fall back to primary streams."
+                )
+
+        self.assertEqual(
+            map_args,
+            self.processor._primary_av_map_args(),
+            "Timed-out stream probe must fall back to primary stream mapping.",
+        )
+        self.assertTrue(
+            proc.terminate_called or proc.kill_called,
+            "The hung ffprobe process must be terminated on timeout.",
+        )
+
+    async def test_get_duration_kills_ffprobe_on_task_cancel(self):
+        """Cancelling the surrounding task must not leave ffprobe running."""
+        proc = HangingProcess()
+        self.processor.FFPROBE_TIMEOUT_SECONDS = 3600
+        with patch.object(self.processor, "_resolve_ffprobe_path",
+                          return_value="/usr/bin/ffprobe"), \
+             patch("asyncio.create_subprocess_exec",
+                   new=AsyncMock(return_value=proc)):
+            task = asyncio.create_task(self.processor._get_duration("/tmp/corrupt.ts"))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertTrue(
+            proc.terminate_called or proc.kill_called,
+            "The ffprobe process must be terminated when the task is cancelled.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_move_to_completed_prunes_empty_dirs.py
+++ b/backend/tests/test_move_to_completed_prunes_empty_dirs.py
@@ -1,0 +1,114 @@
+"""
+Regression test: empty Show/Season directories must be removed from the
+download folder after a series episode is moved to the completed folder.
+
+Bug: series episodes are written to Show/Season subfolders of the download
+(working) folder. _move_to_completed moved the file out (preserving the
+relative path under the completed folder) but left the now-empty Show/Season
+directories behind, so the download folder accumulated empty directory trees
+over time.
+
+Fix: after a successful move, _move_to_completed removes empty parent
+directories up to — but never including — the configured download folder.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+class MoveToCompletedPrunesEmptyDirsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = DownloadManager()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.download_dir = Path(self.tmp) / "downloads"
+        self.completed_dir = Path(self.tmp) / "completed"
+        self.download_dir.mkdir()
+        self.completed_dir.mkdir()
+
+    def _make_episode(self, *parts: str) -> Path:
+        path = self.download_dir.joinpath(*parts)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x47" * 188)
+        return path
+
+    def test_empty_show_and_season_dirs_removed_after_move(self):
+        episode = self._make_episode("My Show", "Season 01", "My Show S01E01.ts")
+
+        dest = self.manager._move_to_completed(
+            str(episode), str(self.completed_dir), str(self.download_dir)
+        )
+
+        self.assertTrue(os.path.isfile(dest), "Episode must be moved to completed folder.")
+        self.assertEqual(
+            dest,
+            str(self.completed_dir / "My Show" / "Season 01" / "My Show S01E01.ts"),
+            "Relative Show/Season structure must be preserved in completed folder.",
+        )
+        self.assertFalse(
+            (self.download_dir / "My Show" / "Season 01").exists(),
+            "Empty Season directory must be removed from the download folder.",
+        )
+        self.assertFalse(
+            (self.download_dir / "My Show").exists(),
+            "Empty Show directory must be removed from the download folder.",
+        )
+        self.assertTrue(
+            self.download_dir.exists(),
+            "The configured download folder itself must never be removed.",
+        )
+
+    def test_non_empty_dirs_are_kept(self):
+        episode = self._make_episode("My Show", "Season 01", "My Show S01E01.ts")
+        sibling = self._make_episode("My Show", "Season 01", "My Show S01E02.ts")
+
+        self.manager._move_to_completed(
+            str(episode), str(self.completed_dir), str(self.download_dir)
+        )
+
+        self.assertTrue(sibling.exists(), "Sibling episode must not be touched.")
+        self.assertTrue(
+            (self.download_dir / "My Show" / "Season 01").exists(),
+            "A Season directory that still has files must be kept.",
+        )
+
+    def test_file_directly_in_download_folder_keeps_root(self):
+        episode = self._make_episode("Movie.ts")
+
+        self.manager._move_to_completed(
+            str(episode), str(self.completed_dir), str(self.download_dir)
+        )
+
+        self.assertTrue(
+            self.download_dir.exists(),
+            "The download folder must survive moving a file that lives directly in it.",
+        )
+
+    def test_path_outside_download_folder_prunes_nothing(self):
+        outside_dir = Path(self.tmp) / "elsewhere" / "nested"
+        outside_dir.mkdir(parents=True)
+        episode = outside_dir / "Movie.ts"
+        episode.write_bytes(b"\x47" * 188)
+
+        self.manager._move_to_completed(
+            str(episode), str(self.completed_dir), str(self.download_dir)
+        )
+
+        self.assertTrue(
+            outside_dir.exists(),
+            "Directories outside the download folder must never be pruned.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_post_process_crash_after_move.py
+++ b/backend/tests/test_post_process_crash_after_move.py
@@ -1,0 +1,148 @@
+"""
+Regression test: a post-processing crash after _move_to_completed must not
+mark the download FAILED.
+
+In _execute_post_process, once the output file has been moved to the completed
+folder, any exception (working-file cleanup, schedule sync, the final DB
+commit) previously fell into the generic except Exception handler, which
+marked the download FAILED with output_path already pointing at the completed
+file. The recording looked failed even though the file was fine -- and a retry
+of that "failed" download would have streamed straight over the completed file
+(then deleted it if the retry failed).
+
+Fix: _execute_post_process tracks the moved path and finalizes the download as
+COMPLETED (with a warning in error_message) when the file already survived in
+the completed folder.
+"""
+import contextlib
+import sys
+import tempfile
+import shutil
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class PostProcessCrashAfterMoveTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed_processing_download(self, output_path: str) -> int:
+        async with self.session_factory() as session:
+            dl = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=50.0,
+            )
+            session.add(dl)
+            await session.commit()
+            await session.refresh(dl)
+            return dl.id
+
+    async def test_crash_after_move_finalizes_completed_not_failed(self):
+        """Crash between the move and the final commit must end COMPLETED."""
+        downloads_dir = Path(self.tmpdir) / "downloads"
+        downloads_dir.mkdir()
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+
+        source_path = downloads_dir / "show.ts"
+        source_path.write_bytes(b"x" * 1024)
+        completed_path = completed_dir / "show.ts"
+
+        async with self.session_factory() as session:
+            session.add(AppSettings(
+                download_folder=str(downloads_dir),
+                completed_folder=str(completed_dir),
+                transcode_enabled=True,
+                comskip_enabled=False,
+            ))
+            await session.commit()
+
+        download_id = await self._seed_processing_download(str(source_path))
+
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        try:
+            with (
+                patch("services.download_manager.async_session_maker", patched_session_maker),
+                patch.object(self.manager, "_post_process", new_callable=AsyncMock,
+                             return_value=(str(source_path), [])),
+                # First call after the real _move_to_completed: simulate a crash
+                # in the post-move stretch of the success path.
+                patch.object(self.manager, "_cleanup_working_files",
+                             side_effect=RuntimeError("simulated crash after move")),
+                patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+                patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+                patch.object(self.manager, "_trigger_plex_refresh", new_callable=AsyncMock),
+            ):
+                await self.manager._execute_post_process(download_id)
+        except Exception:
+            pass
+
+        self.assertTrue(
+            completed_path.exists(),
+            "The moved file must still exist in the completed folder.",
+        )
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.COMPLETED.value,
+            "A post-processing crash after the file reached the completed "
+            "folder must finalize the download as COMPLETED. Before the fix "
+            "it was marked FAILED with output_path pointing at the completed "
+            "file, so a retry would overwrite or delete the good recording.",
+        )
+        self.assertEqual(
+            dl.output_path,
+            str(completed_path),
+            "output_path must point at the surviving completed file.",
+        )
+        self.assertIn(
+            "Completed with warnings",
+            dl.error_message or "",
+            "The post-move error should be surfaced as a warning, not a failure.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_post_process_failure_cancel_cleanup.py
+++ b/backend/tests/test_post_process_failure_cancel_cleanup.py
@@ -1,0 +1,187 @@
+"""
+Regression test: Comskip artifacts and partial transcode outputs must be
+cleaned up when a post-processing task fails or is cancelled.
+
+Bug: _execute_post_process only called _cleanup_working_files on the success
+path. When post-processing raised (e.g. "ComSkip failed: ...") or the task was
+cancelled mid-run, all working files created so far — .edl/.txt sidecars,
+_seg*.ts extraction temps, and the partially-written .mkv/.mp4 transcode
+output — were orphaned in the download folder forever.
+
+Fix: the CancelledError and Exception handlers now call
+_cleanup_working_files with delete_original=False, so the temp files are
+removed while the raw recording stays in the download folder (failures keep
+the .log/ffmpeg logs for debugging).
+"""
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class PostProcessFailureCancelCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.download_dir = tempfile.mkdtemp()
+        self.completed_dir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.download_dir, ignore_errors=True)
+        shutil.rmtree(self.completed_dir, ignore_errors=True)
+
+    async def _seed_db(self) -> tuple[int, str]:
+        ts_path = os.path.join(self.download_dir, "Show.ts")
+        Path(ts_path).write_bytes(b"\x47" * 188)
+
+        async with self.session_factory() as session:
+            settings = AppSettings(
+                comskip_enabled=True,
+                transcode_enabled=True,
+                transcode_format="mkv",
+                remux_only=False,
+                download_folder=self.download_dir,
+                completed_folder=self.completed_dir,
+                delete_original_after_transcode=False,
+                min_free_space_gb=0,
+            )
+            session.add(settings)
+            await session.flush()
+
+            download = Download(
+                account_id=1,
+                channel_id="100",
+                channel_name="Test Channel",
+                program_title="Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/timeshift/1.ts",
+                output_path=ts_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=0.0,
+                is_vod=False,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id, ts_path
+
+    def _run_with_patches(self, mock_pp):
+        return [
+            patch("services.post_processor.post_processor", mock_pp),
+            patch("services.download_manager.async_session_maker",
+                  side_effect=lambda: self.session_factory()),
+            patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+            patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+        ]
+
+    async def _get_download(self, download_id):
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            return result.scalar_one_or_none()
+
+    async def test_failure_cleans_comskip_artifacts_and_partial_output(self):
+        """A ComSkip pipeline failure must not orphan working files."""
+        download_id, ts_path = await self._seed_db()
+        ts_file = Path(ts_path)
+        edl = ts_file.with_suffix(".edl")
+        txt = ts_file.with_suffix(".txt")
+        log = ts_file.with_suffix(".log")
+        partial_mkv = ts_file.with_suffix(".mkv")
+        seg = ts_file.with_stem("Show_seg0")
+
+        async def fake_detect(*args, **kwargs):
+            edl.write_text("60.0 120.0 0\n")
+            txt.write_text("comskip output")
+            log.write_text("comskip log")
+            return str(edl)
+
+        async def fake_remove_commercials(*args, **kwargs):
+            seg.write_bytes(b"\x47" * 188)
+            partial_mkv.write_bytes(b"\x00" * 512)
+            raise RuntimeError("ffmpeg concat failed")
+
+        mock_pp = MagicMock()
+        mock_pp.comskip_available = True
+        mock_pp.ffmpeg_available = True
+        mock_pp.get_ffmpeg_path.return_value = "/usr/bin/ffmpeg"
+        mock_pp.detect_commercials = AsyncMock(side_effect=fake_detect)
+        mock_pp.remove_commercials = AsyncMock(side_effect=fake_remove_commercials)
+        mock_pp.transcode = AsyncMock()
+
+        p = self._run_with_patches(mock_pp)
+        with p[0], p[1], p[2], p[3]:
+            await self.manager._execute_post_process(download_id)
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(dl.status, DownloadStatus.FAILED.value)
+        self.assertTrue(ts_file.exists(), "Raw recording must stay in the download folder.")
+        self.assertFalse(edl.exists(), ".edl must be cleaned up after failure.")
+        self.assertFalse(txt.exists(), ".txt must be cleaned up after failure.")
+        self.assertFalse(seg.exists(), "_seg*.ts must be cleaned up after failure.")
+        self.assertFalse(partial_mkv.exists(), "Partial .mkv must be cleaned up after failure.")
+        self.assertTrue(log.exists(), ".log is kept on failure for debugging.")
+
+    async def test_cancel_cleans_comskip_artifacts_and_partial_output(self):
+        """Cancelling mid post-processing must not orphan working files."""
+        download_id, ts_path = await self._seed_db()
+        ts_file = Path(ts_path)
+        edl = ts_file.with_suffix(".edl")
+        txt = ts_file.with_suffix(".txt")
+        partial_mkv = ts_file.with_suffix(".mkv")
+
+        async def fake_detect(*args, **kwargs):
+            edl.write_text("60.0 120.0 0\n")
+            txt.write_text("comskip output")
+            partial_mkv.write_bytes(b"\x00" * 512)
+            raise asyncio.CancelledError()
+
+        mock_pp = MagicMock()
+        mock_pp.comskip_available = True
+        mock_pp.ffmpeg_available = True
+        mock_pp.get_ffmpeg_path.return_value = "/usr/bin/ffmpeg"
+        mock_pp.detect_commercials = AsyncMock(side_effect=fake_detect)
+        mock_pp.remove_commercials = AsyncMock()
+        mock_pp.transcode = AsyncMock()
+
+        p = self._run_with_patches(mock_pp)
+        with p[0], p[1], p[2], p[3]:
+            try:
+                await self.manager._execute_post_process(download_id)
+            except asyncio.CancelledError:
+                pass
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(dl.status, DownloadStatus.CANCELLED.value)
+        self.assertTrue(ts_file.exists(), "Raw recording must stay in the download folder.")
+        self.assertFalse(edl.exists(), ".edl must be cleaned up after cancel.")
+        self.assertFalse(txt.exists(), ".txt must be cleaned up after cancel.")
+        self.assertFalse(partial_mkv.exists(), "Partial .mkv must be cleaned up after cancel.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_postproc_partial_output_cleanup.py
+++ b/backend/tests/test_postproc_partial_output_cleanup.py
@@ -1,0 +1,153 @@
+"""
+Regression test: partially-written transcode/concat output files must be
+removed by the post-processor itself on failure or cancellation.
+
+Bugs:
+- transcode() raised "ffmpeg failed" leaving the partial {stem}.mkv/.mp4 on
+  disk, and a task cancel during the ffmpeg run also left the partial output.
+- remove_commercials() only removed its partial output in the finally block
+  when same_path_output was True (the _postproc_tmp case). With a different
+  output extension (e.g. .ts -> .mkv) a failed or cancelled concat left the
+  partial {stem}.mkv behind.
+
+Fix: transcode() removes the partial output before raising and on
+CancelledError; the remove_commercials finally block removes work_output_path
+whenever the concat did not succeed.
+"""
+import asyncio
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_partial_cleanup_test", MODULE_PATH)
+PP_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PP_MODULE)
+
+PostProcessor = PP_MODULE.PostProcessor
+OutputFormat = PP_MODULE.OutputFormat
+HardwareAccel = PP_MODULE.HardwareAccel
+
+
+class PartialOutputCleanupTests(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.ts_path = Path(self.tmp) / "Show.ts"
+        self.ts_path.write_bytes(b"\x47" * 188)
+        self.mkv_path = Path(self.tmp) / "Show.mkv"
+        self.processor = PostProcessor()
+        self.processor._ffmpeg_path = "/usr/bin/ffmpeg"
+
+    def _patches(self, run_ffmpeg_side_effect):
+        return [
+            patch.object(
+                type(self.processor), "ffmpeg_available",
+                new_callable=PropertyMock, return_value=True,
+            ),
+            patch.object(
+                self.processor, "_get_duration",
+                new=AsyncMock(return_value=3600.0),
+            ),
+            patch.object(
+                self.processor, "_select_best_av_map_args",
+                new=AsyncMock(return_value=["-map", "0:v:0", "-map", "0:a:0?"]),
+            ),
+            patch.object(
+                self.processor, "_run_ffmpeg_with_progress",
+                side_effect=run_ffmpeg_side_effect,
+            ),
+        ]
+
+    async def test_transcode_failure_removes_partial_output(self):
+        """transcode() must delete the partial .mkv before raising on ffmpeg failure."""
+        async def failing_run(cmd, *args, **kwargs):
+            self.mkv_path.write_bytes(b"\x00" * 512)
+            return 1, b"ffmpeg exploded"
+
+        patches = self._patches(failing_run)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with self.assertRaises(Exception):
+                await self.processor.transcode(
+                    str(self.ts_path),
+                    OutputFormat.MKV,
+                    hw_accel=HardwareAccel.CPU,
+                    remux_only=False,
+                )
+
+        self.assertFalse(
+            self.mkv_path.exists(),
+            "Partial .mkv must be removed when transcode fails.",
+        )
+        self.assertTrue(self.ts_path.exists(), "Input file must not be touched.")
+
+    async def test_transcode_cancel_removes_partial_output(self):
+        """transcode() must delete the partial .mkv when the task is cancelled."""
+        started = asyncio.Event()
+
+        async def hanging_run(cmd, *args, **kwargs):
+            self.mkv_path.write_bytes(b"\x00" * 512)
+            started.set()
+            await asyncio.sleep(3600)
+
+        patches = self._patches(hanging_run)
+        with patches[0], patches[1], patches[2], patches[3]:
+            task = asyncio.create_task(self.processor.transcode(
+                str(self.ts_path),
+                OutputFormat.MKV,
+                hw_accel=HardwareAccel.CPU,
+                remux_only=False,
+            ))
+            await asyncio.wait_for(started.wait(), timeout=5.0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertFalse(
+            self.mkv_path.exists(),
+            "Partial .mkv must be removed when transcode is cancelled.",
+        )
+        self.assertTrue(self.ts_path.exists(), "Input file must not be touched.")
+
+    async def test_remove_commercials_concat_failure_removes_partial_mkv(self):
+        """A failed concat with a different output extension must not orphan the partial .mkv."""
+        edl_path = Path(self.tmp) / "Show.edl"
+        edl_path.write_text("60.0 120.0 0\n")
+
+        async def failing_concat(cmd, *args, **kwargs):
+            self.mkv_path.write_bytes(b"\x00" * 512)
+            return 1, b"concat failed"
+
+        seg_proc = MagicMock()
+        seg_proc.returncode = 0
+        seg_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        patches = self._patches(failing_concat)
+        with patches[0], patches[1], patches[2], patches[3], patch(
+            "asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=seg_proc),
+        ):
+            with self.assertRaises(Exception):
+                await self.processor.remove_commercials(
+                    str(self.ts_path),
+                    str(edl_path),
+                    output_format=OutputFormat.MKV,
+                    hw_accel=HardwareAccel.CPU,
+                    remux_only=False,
+                )
+
+        self.assertFalse(
+            self.mkv_path.exists(),
+            "Partial .mkv from a failed concat must be removed even when the "
+            "output path differs from the input path (not the _postproc_tmp case).",
+        )
+        self.assertTrue(self.ts_path.exists(), "Input file must not be touched.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_segment_extract_cancel_kill.py
+++ b/backend/tests/test_segment_extract_cancel_kill.py
@@ -1,0 +1,108 @@
+"""
+Regression test: cancelling a download during segment extraction in
+remove_commercials must kill the FFmpeg subprocess.
+
+Bug: the per-segment FFmpeg copy in remove_commercials was awaited via
+communicate() with no CancelledError handling. Cancelling the post-processing
+task left the FFmpeg process running and writing the _segN.ts file, while the
+finally block simultaneously tried to delete it — the process survived the
+cancel and could re-create the file after cleanup.
+
+Fix: communicate() is wrapped so CancelledError terminates the subprocess
+before the cancellation propagates (same pattern as _run_ffmpeg_with_progress).
+"""
+import asyncio
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, PropertyMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "post_processor.py"
+SPEC = importlib.util.spec_from_file_location("post_processor_seg_cancel_test", MODULE_PATH)
+PP_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(PP_MODULE)
+
+PostProcessor = PP_MODULE.PostProcessor
+OutputFormat = PP_MODULE.OutputFormat
+HardwareAccel = PP_MODULE.HardwareAccel
+
+
+class HangingSegmentProcess:
+    """Fake segment-extraction FFmpeg whose communicate() blocks until killed."""
+
+    def __init__(self):
+        self.returncode = None
+        self.terminate_called = False
+        self.kill_called = False
+        self.started = asyncio.Event()
+
+    async def communicate(self):
+        self.started.set()
+        await asyncio.sleep(3600)
+
+    def terminate(self):
+        self.terminate_called = True
+        self.returncode = -15
+
+    def kill(self):
+        self.kill_called = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+class SegmentExtractCancelKillTests(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    async def test_cancel_during_segment_extraction_kills_ffmpeg(self):
+        ts_path = Path(self.tmp) / "Show.ts"
+        ts_path.write_bytes(b"\x47" * 188)
+        edl_path = Path(self.tmp) / "Show.edl"
+        edl_path.write_text("60.0 120.0 0\n")
+
+        processor = PostProcessor()
+        processor._ffmpeg_path = "/usr/bin/ffmpeg"
+
+        seg_proc = HangingSegmentProcess()
+
+        with patch.object(
+            type(processor), "ffmpeg_available",
+            new_callable=PropertyMock, return_value=True,
+        ), patch.object(
+            processor, "_get_duration",
+            new=AsyncMock(return_value=3600.0),
+        ), patch.object(
+            processor, "_select_best_av_map_args",
+            new=AsyncMock(return_value=["-map", "0:v:0", "-map", "0:a:0?"]),
+        ), patch(
+            "asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=seg_proc),
+        ):
+            task = asyncio.create_task(processor.remove_commercials(
+                str(ts_path),
+                str(edl_path),
+                output_format=OutputFormat.MKV,
+                hw_accel=HardwareAccel.CPU,
+            ))
+            await asyncio.wait_for(seg_proc.started.wait(), timeout=5.0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertTrue(
+            seg_proc.terminate_called or seg_proc.kill_called,
+            "The segment-extraction FFmpeg subprocess must be terminated when "
+            "the post-processing task is cancelled; otherwise it keeps running "
+            "and writing segment files after cleanup.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_transcode_disk_space_preflight.py
+++ b/backend/tests/test_transcode_disk_space_preflight.py
@@ -1,0 +1,167 @@
+"""
+Regression test: post-processing must check free disk space before starting a
+transcode.
+
+Bug: downloads have a disk-space preflight, but post-processing had none.
+Transcoding writes a full second copy of the recording next to the original;
+when the disk was already below the configured minimum, ffmpeg would run until
+ENOSPC, fail mid-write, and leave a partial output file orphaned in the
+download folder.
+
+Fix: _post_process calls disk_space.get_free_space_shortfall on the download
+folder before any transcode/commercial-removal work. When free space is below
+min_free_space_gb the download fails cleanly with a clear error, no ffmpeg is
+started, and no partial output is written.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class TranscodeDiskSpacePreflightTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.download_dir = tempfile.mkdtemp()
+        self.completed_dir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.download_dir, ignore_errors=True)
+        shutil.rmtree(self.completed_dir, ignore_errors=True)
+
+    async def _seed_db(self, min_free_space_gb: int) -> tuple[int, str]:
+        ts_path = os.path.join(self.download_dir, "Show.ts")
+        Path(ts_path).write_bytes(b"\x47" * 188)
+
+        async with self.session_factory() as session:
+            settings = AppSettings(
+                transcode_enabled=True,
+                comskip_enabled=False,
+                transcode_format="mkv",
+                download_folder=self.download_dir,
+                completed_folder=self.completed_dir,
+                delete_original_after_transcode=False,
+                remux_only=False,
+                min_free_space_gb=min_free_space_gb,
+            )
+            session.add(settings)
+            await session.flush()
+
+            download = Download(
+                account_id=1,
+                channel_id="100",
+                channel_name="Test Channel",
+                program_title="Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/timeshift/1.ts",
+                output_path=ts_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=0.0,
+                is_vod=False,
+            )
+            session.add(download)
+            await session.commit()
+            await session.refresh(download)
+            return download.id, ts_path
+
+    def _make_mock_pp(self):
+        mock_pp = MagicMock()
+        mock_pp.comskip_available = False
+        mock_pp.ffmpeg_available = True
+        mock_pp.get_ffmpeg_path.return_value = "/usr/bin/ffmpeg"
+        mock_pp.transcode = AsyncMock(return_value="unused.mkv")
+        mock_pp.detect_commercials = AsyncMock()
+        mock_pp.remove_commercials = AsyncMock()
+        return mock_pp
+
+    async def test_low_disk_space_fails_before_transcode_starts(self):
+        """With free space below the minimum, the download fails cleanly and ffmpeg never runs."""
+        # An absurdly high minimum guarantees the preflight trips on any machine.
+        download_id, ts_path = await self._seed_db(min_free_space_gb=10 ** 9)
+        mock_pp = self._make_mock_pp()
+
+        with patch("services.post_processor.post_processor", mock_pp), \
+             patch("services.download_manager.async_session_maker",
+                   side_effect=lambda: self.session_factory()), \
+             patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+             patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock):
+            await self.manager._execute_post_process(download_id)
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.FAILED.value,
+            "Post-processing must fail cleanly when disk space is below minimum.",
+        )
+        self.assertIn(
+            "disk space",
+            (dl.error_message or "").lower(),
+            "The error must clearly say the failure is about disk space.",
+        )
+        mock_pp.transcode.assert_not_called()
+        mock_pp.remove_commercials.assert_not_called()
+        self.assertTrue(Path(ts_path).exists(), "Raw recording must stay in the download folder.")
+        self.assertFalse(
+            Path(ts_path).with_suffix(".mkv").exists(),
+            "No partial transcode output may exist after the preflight failure.",
+        )
+
+    async def test_preflight_disabled_when_min_free_space_is_zero(self):
+        """min_free_space_gb=0 disables the preflight and transcode proceeds."""
+        download_id, ts_path = await self._seed_db(min_free_space_gb=0)
+        mock_pp = self._make_mock_pp()
+        transcoded = Path(ts_path).with_suffix(".mkv")
+
+        async def fake_transcode(input_path, *args, **kwargs):
+            transcoded.write_bytes(b"\x00" * 64)
+            return str(transcoded)
+
+        mock_pp.transcode = AsyncMock(side_effect=fake_transcode)
+
+        with patch("services.post_processor.post_processor", mock_pp), \
+             patch("services.download_manager.async_session_maker",
+                   side_effect=lambda: self.session_factory()), \
+             patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock), \
+             patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock):
+            await self.manager._execute_post_process(download_id)
+
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            dl = result.scalar_one()
+
+        self.assertEqual(dl.status, DownloadStatus.COMPLETED.value)
+        mock_pp.transcode.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_transcode_partial_output_orphan.py
+++ b/backend/tests/test_transcode_partial_output_orphan.py
@@ -61,6 +61,7 @@ class PartialTranscodeOutputOrphanTests(unittest.IsolatedAsyncioTestCase):
                 completed_folder=self.completed_dir,
                 delete_original_after_transcode=False,
                 remux_only=True,
+                min_free_space_gb=0,
             )
             session.add(settings)
             await session.flush()


### PR DESCRIPTION
## Summary
Combined audit batches B1 (download lifecycle data-loss) + B3 (post-processor orphans) — same code paths, one coherent review.

**Data loss (4):**
1. Cancel landing after the final byte no longer deletes a fully-downloaded recording — it finalizes COMPLETED and moves the file.
2. Same race no longer leaves the record CANCELLED with the data complete.
3. DB commit failure after the move no longer loses the recording: finalize retries on a fresh session (handles PendingRollbackError); the file is never touched.
4. Post-process crash after the file reached the completed folder finalizes COMPLETED ("Completed with warnings") instead of FAILED — a FAILED row pointing at the completed file would let retry/cleanup destroy a good recording.

**Orphans / leaks (7 + hang fix):**
5. Comskip artifacts + partial transcode outputs cleaned on every exit path (success/failure/cancel); raw recording always kept on failure.
6. Comskip prep FFmpeg terminated on cancel; `_comskip_input.mkv` removed.
7. Segment-extraction FFmpeg terminated on cancel in remove_commercials.
8. Comskip retry probe sidecars (.txt/.log/.logo/.csv/.vdr/.xml) cleaned up.
9. Empty Show/Season dirs pruned after series episode moves to completed (never past the configured download folder).
10. Disk-space preflight before transcode/commercial-removal — clean error instead of ENOSPC mid-write.
11. ffprobe calls get a 60s timeout + kill (corrupt input no longer hangs the pipeline forever).

One audit claim (partial transcode output orphaned on warning-path) was already fixed; this adds defense-in-depth in `transcode()`.

## Steps to test
```
cd backend && python -m unittest discover -s tests
```
22 new regression tests across 11 files, each verified to fail pre-fix. Full suite green.

Backend only. CHANGELOG entries included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)