### PR TITLE
design: distinguish subscription expired from unreachable on account cards

### DIFF
--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -206,7 +206,9 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
         )}
         {account.expiration_date && (
           <Badge variant="outline" size="sm" color={isExpired ? 'red' : 'yellow'}>
-            {isExpired ? 'Expired' : `Expires ${dayjs(account.expiration_date).format('MMM D, YYYY')}`}
+            {isExpired
+              ? `Expired ${dayjs(account.expiration_date).format('MMM D, YYYY')}`
+              : `Expires ${dayjs(account.expiration_date).format('MMM D, YYYY')}`}
           </Badge>
         )}
       </Group>
@@ -240,16 +242,20 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
             {account.last_connection_ok === true
               ? 'Connected'
               : account.last_connection_ok === false
-              ? 'Unreachable'
+              ? isExpired
+                ? 'Subscription Expired'
+                : 'Unreachable'
               : 'Not checked yet'}
             {account.last_connection_checked_at
               ? ` · ${timeAgo(account.last_connection_checked_at)}`
               : ''}
           </Text>
         </Group>
-        {account.last_connection_ok === false && account.last_connection_error && (
+        {account.last_connection_ok === false && (
           <Text size="xs" c="dimmed" ml={14}>
-            {account.last_connection_error}
+            {isExpired
+              ? 'Subscription has expired. Renew with your IPTV provider to continue.'
+              : account.last_connection_error || 'Cannot reach provider.'}
           </Text>
         )}
         {account.last_connection_ok === false && (


### PR DESCRIPTION
## What changed

When a provider's subscription has expired, the Accounts page now clearly tells the user their subscription has expired, instead of showing the same generic "Cannot reach provider" message they would see for a server being down.

**Before:** An expired account showed a red "EXPIRED" badge (no date), then "Unreachable" as status, then "Cannot reach provider. Check the server URL." - sending the user to check a server URL that is not the problem.

**After:** An expired account shows "EXPIRED Jun 4, 2026" (date included), "Subscription Expired" as status, and "Subscription has expired. Renew with your IPTV provider to continue." Accounts that are simply unreachable (server down, wrong URL) continue to show the original message.

## What a user would notice

On the Accounts page, a card for an expired subscription now shows "Subscription Expired" and a clear renewal message rather than pointing the user at their server URL. Accounts that are down for other reasons are unchanged.

## Changes

One file: `frontend/src/components/settings/AccountsSection.jsx`
- Expired badge now includes the date (`Expired Jun 4, 2026` vs `Expired`)
- Status text shows "Subscription Expired" instead of "Unreachable" when expired
- Error message shows renewal guidance when expired; generic error text otherwise

## Evidence

Screenshots posted in #design.

To verify manually: set `expiration_date` on an account row to a past date and reload the Accounts page.