### PR TITLE
fix: catchup window correctness — hour-based archive durations, days_back cap, expired programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: Catchup windows are now calculated correctly, and Browse EPG shows exactly what your provider can still serve
+
+**What you would notice:** Three related problems around how far back you can record are fixed. First, if your provider reports its archive length in hours (for example 168 for a 7-day archive), Mustarrd treated that number as days and advertised weeks of catchup that always failed to download; those channels now show the correct window (168 becomes 7 days). Second, channels with archives longer than 14 days were silently cut off at 14 in Browse EPG; the guide now goes back as far as the channel's actual archive allows. Third, programs that have aged out of the provider's archive no longer look downloadable: they appear greyed out with an "Expired" badge and a tooltip explaining they are outside the channel's catchup window, instead of queuing downloads that are guaranteed to fail.
+
+**What changed:** The shared archive-duration helper now treats `tv_archive_duration` values above 30 as hours and converts them to days, and every consumer (EPG ingest, channel listing, EPG and catchup endpoints, the scheduler) goes through that helper. The `days_back` validation cap on the channel EPG and catchup endpoints was raised from 14 to 365, with the channel's real archive duration still applied as the effective limit. The Browse EPG page now requests the channel's full archive window and greys out past programs that ended before the window began.
+
+---
+
 ### Fixed: Recordings are no longer lost when a cancel or an error arrives just as a download finishes
 
 **What you would notice:** Pressing Cancel at the exact moment a recording finished downloading could delete the fully-downloaded file and mark the recording as cancelled, even though every byte was already on disk. Similarly, a hiccup at the very end of a download or during post-processing — for example the database briefly failing while saving the final status, or a crash right after the file was moved into your completed folder — could leave the recording stuck, marked as failed, or queued for a full re-download even though the finished file was sitting safely in the completed folder (and retrying such a "failed" recording could overwrite or delete the good file). After this fix, once the last byte has been written, the recording is always kept: it is moved to the completed folder and shown as completed, regardless of late cancels, database errors, or post-processing crashes.

--- a/backend/api/channels.py
+++ b/backend/api/channels.py
@@ -94,7 +94,7 @@ async def get_channels(
 async def get_channel_epg(
     account_id: int,
     channel_id: str,
-    days_back: int = Query(7, ge=1, le=14),
+    days_back: int = Query(7, ge=1, le=365),
     fresh: bool = Query(False, description="Fetch live channel EPG before falling back to stored guide data"),
     _admin: None = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session)
@@ -136,7 +136,7 @@ async def get_channel_epg(
 async def get_catchup_programs(
     account_id: int,
     channel_id: str,
-    days_back: int = Query(7, ge=1, le=14),
+    days_back: int = Query(7, ge=1, le=365),
     _admin: None = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session)
 ):

--- a/backend/services/epg_service.py
+++ b/backend/services/epg_service.py
@@ -53,10 +53,18 @@ class EPGService:
     def archive_days_for_channel(channel: dict) -> int:
         value = channel.get("tv_archive_duration")
         try:
-            days = int(value)
+            duration = int(value)
         except (TypeError, ValueError):
             return 0
-        return max(0, min(days, 365))
+        if duration <= 0:
+            return 0
+        if duration > 30:
+            # Most providers report tv_archive_duration in days, but some send
+            # hours (e.g. 168 for a 7-day archive). No provider offers more
+            # than a 30-day archive, while hour-based providers send >= 24,
+            # so anything above 30 is treated as hours.
+            duration = max(1, duration // 24)
+        return min(duration, 365)
 
     async def get_channel_archive_days(
         self,

--- a/backend/tests/test_archive_duration_hours.py
+++ b/backend/tests/test_archive_duration_hours.py
@@ -1,0 +1,73 @@
+"""
+Regression tests: tv_archive_duration reported in hours must not inflate the
+catchup window 24x.
+
+Most Xtream providers report tv_archive_duration in days (e.g. 7), but some
+send hours (e.g. 168 for a 7-day archive). The old code treated the value as
+days unconditionally, so an hours-provider produced a 168-day window: EPG
+ingest kept months of stale programs, the channel list advertised "168 days
+catchup", and the scheduler dispatched downloads that 404'd at the provider.
+
+The shared helper EPGService.archive_days_for_channel now treats values above
+30 as hours (no provider offers a >30-day archive, while hour-based providers
+send >= 24). Every consumer (EPG ingest, channel listing, EPG/catchup API
+endpoints, scheduler) goes through this helper.
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_service import EPGService
+
+
+class ArchiveDurationHoursHeuristicTests(unittest.TestCase):
+    """archive_days_for_channel converts hour-based values to days."""
+
+    def test_168_hours_becomes_7_days(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 168}), 7)
+
+    def test_240_hours_becomes_10_days(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 240}), 10)
+
+    def test_720_hours_becomes_30_days(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 720}), 30)
+
+    def test_numeric_string_hours_converted(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": "168"}), 7)
+
+    def test_day_values_up_to_30_unchanged(self):
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 7}), 7)
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 14}), 14)
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 30}), 30)
+
+    def test_hours_just_above_threshold_never_round_to_zero(self):
+        # 31 is treated as hours; integer division would give 0 days without a floor.
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 31}), 1)
+
+
+class GetChannelArchiveDaysHoursTests(unittest.IsolatedAsyncioTestCase):
+    """The provider-list lookup used by the API endpoints and scheduler applies the heuristic."""
+
+    async def test_hours_provider_returns_days(self):
+        service = EPGService()
+
+        async def fake_get_live_streams():
+            return [{"stream_id": 1, "name": "Sports HD", "tv_archive": 1, "tv_archive_duration": 168}]
+
+        mock_client = MagicMock()
+        mock_client.get_live_streams = AsyncMock(side_effect=fake_get_live_streams)
+        mock_client.close = AsyncMock()
+
+        with patch.object(service, "_get_client", return_value=mock_client):
+            days = await service.get_channel_archive_days(MagicMock(), account_id=1, channel_id="1")
+
+        self.assertEqual(days, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_epg_archive_duration_missing.py
+++ b/backend/tests/test_epg_archive_duration_missing.py
@@ -40,8 +40,9 @@ class ArchiveDaysForChannelTests(unittest.TestCase):
     def test_negative_duration_clamped_to_zero(self):
         self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": -5}), 0)
 
-    def test_over_365_clamped(self):
-        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 999}), 365)
+    def test_over_365_days_after_hours_conversion_clamped(self):
+        # 10000 is read as hours (416 days) and then clamped to 365.
+        self.assertEqual(EPGService.archive_days_for_channel({"tv_archive_duration": 10000}), 365)
 
 
 class IterProgramsArchiveUnknownTests(unittest.TestCase):

--- a/backend/tests/test_epg_days_back_cap.py
+++ b/backend/tests/test_epg_days_back_cap.py
@@ -1,0 +1,50 @@
+"""
+Regression tests: Browse EPG must not hard-cap days_back at 14.
+
+The /channels/{id}/epg and /channels/{id}/catchup endpoints declared
+days_back with Query(..., le=14), silently truncating channels whose
+provider archive window is longer (e.g. 30 days). The validation cap is
+now 365; the real limit is still the channel's own archive duration via
+actual_days = min(days_back, channel_archive_days) inside each handler.
+"""
+import inspect
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from api.channels import get_channel_epg, get_catchup_programs
+
+
+def _days_back_bounds(handler):
+    sig = inspect.signature(handler)
+    default = sig.parameters["days_back"].default
+    ge = le = None
+    for constraint in getattr(default, "metadata", []):
+        if getattr(constraint, "ge", None) is not None:
+            ge = constraint.ge
+        if getattr(constraint, "le", None) is not None:
+            le = constraint.le
+    return ge, le
+
+
+class DaysBackCapTests(unittest.TestCase):
+
+    def test_channel_epg_days_back_allows_long_archives(self):
+        ge, le = _days_back_bounds(get_channel_epg)
+        self.assertEqual(ge, 1)
+        self.assertIsNotNone(le)
+        self.assertGreaterEqual(le, 30, "days_back cap truncates archives longer than 14 days")
+
+    def test_catchup_days_back_allows_long_archives(self):
+        ge, le = _days_back_bounds(get_catchup_programs)
+        self.assertEqual(ge, 1)
+        self.assertIsNotNone(le)
+        self.assertGreaterEqual(le, 30, "days_back cap truncates archives longer than 14 days")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/EPGGrid.jsx
+++ b/frontend/src/components/EPGGrid.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useEffect } from 'react'
-import { Stack, Text, Group, Badge, ScrollArea, Box, Divider } from '@mantine/core'
+import { Stack, Text, Group, Badge, ScrollArea, Box, Divider, Tooltip } from '@mantine/core'
 import { useMediaQuery } from '@mantine/hooks'
 import { IconClock, IconDownload, IconCalendar } from '@tabler/icons-react'
 import {
@@ -25,6 +25,7 @@ function ProgramBlock({
   isCurrent,
   isDownloadable,
   isSchedulable,
+  isExpired,
   elementId,
   previousDownload,
   guideOffsetHours,
@@ -37,7 +38,7 @@ function ProgramBlock({
 
   const backgroundColor = isCurrent
     ? 'var(--mantine-color-green-light)'
-    : isPast && program.has_archive
+    : isPast && program.has_archive && !isExpired
     ? 'rgba(245, 159, 0, 0.1)'
     : isPast
     ? 'var(--mantine-color-dark-5)'
@@ -63,7 +64,7 @@ function ProgramBlock({
           : isSchedulable
           ? '3px solid var(--mantine-color-teal-6)'
           : '3px solid transparent',
-        opacity: isPast && !program.has_archive ? 0.5 : 1,
+        opacity: isPast && (!program.has_archive || isExpired) ? 0.5 : 1,
         transition: 'box-shadow 0.15s, background-color 0.15s',
       }}
       onClick={() => isClickable && onClick(program, { action: isDownloadable ? 'download' : 'schedule' })}
@@ -112,6 +113,13 @@ function ProgramBlock({
           <Badge size="xs" variant="light" color={isCurrent ? 'green' : isPast ? 'gray' : 'yellow'}>
             {program.duration_minutes}m
           </Badge>
+          {isExpired && (
+            <Tooltip label="No longer available — outside this channel's catchup window" withArrow>
+              <Badge size="xs" variant="light" color="gray">
+                Expired
+              </Badge>
+            </Tooltip>
+          )}
           {previousMeta && (
             <Badge size="xs" variant="light" color={previousMeta.color}>
               {previousMeta.label}
@@ -129,7 +137,7 @@ function ProgramBlock({
   )
 }
 
-function DaySection({ date, programs, onProgramClick, getProgramPreviousDownload, guideOffsetHours }) {
+function DaySection({ date, programs, onProgramClick, getProgramPreviousDownload, guideOffsetHours, archiveCutoff }) {
   const now = getNowUtc()
   const displayNow = now.add(getGuideOffsetHours(guideOffsetHours), 'hour')
   const isToday = date.isSame(displayNow, 'day')
@@ -170,7 +178,10 @@ function DaySection({ date, programs, onProgramClick, getProgramPreviousDownload
           const end = getProgramInstant(program, 'end')
           const isPast = Boolean(end?.isBefore(now))
           const isCurrent = Boolean(start?.isBefore(now) && end?.isAfter(now))
-          const isDownloadable = isPast && program.has_archive
+          const isExpired = Boolean(
+            isPast && program.has_archive && archiveCutoff && end?.isBefore(archiveCutoff)
+          )
+          const isDownloadable = isPast && program.has_archive && !isExpired
           const isSchedulable = !isPast
           const elementId = `epg-program-${program.epg_id || program.id || idx}`
           const previousDownload = getProgramPreviousDownload
@@ -186,6 +197,7 @@ function DaySection({ date, programs, onProgramClick, getProgramPreviousDownload
               isCurrent={isCurrent}
               isDownloadable={isDownloadable}
               isSchedulable={isSchedulable}
+              isExpired={isExpired}
               elementId={elementId}
               previousDownload={previousDownload}
               guideOffsetHours={guideOffsetHours}
@@ -203,11 +215,20 @@ export default function EPGGrid({
   showFuture = false,
   getProgramPreviousDownload = null,
   guideOffsetHours = 0,
+  archiveDays = null,
 }) {
   const scrollAreaRef = useRef(null)
   const didAutoScrollRef = useRef(false)
   const normalizedGuideOffsetHours = getGuideOffsetHours(guideOffsetHours)
   const now = useMemo(() => getNowUtc(), [epgData, showFuture])
+
+  // Programs that ended before this instant are outside the provider's
+  // catchup window and would 404 if queued for download.
+  const archiveCutoff = useMemo(() => {
+    const parsed = Number(archiveDays)
+    if (!Number.isFinite(parsed) || parsed <= 0) return null
+    return now.subtract(parsed, 'day')
+  }, [archiveDays, now])
 
   const visiblePrograms = useMemo(() => {
     if (!epgData) return epgData
@@ -296,9 +317,11 @@ export default function EPGGrid({
     )
   }
 
-  const downloadableCount = visiblePrograms.filter(
-    (p) => p.has_archive && getProgramInstant(p, 'end')?.isBefore(now)
-  ).length
+  const downloadableCount = visiblePrograms.filter((p) => {
+    const end = getProgramInstant(p, 'end')
+    if (!p.has_archive || !end?.isBefore(now)) return false
+    return !(archiveCutoff && end.isBefore(archiveCutoff))
+  }).length
   const schedulableCount = visiblePrograms.filter(
     (p) => getProgramInstant(p, 'end')?.isAfter(now)
   ).length
@@ -329,6 +352,7 @@ export default function EPGGrid({
                 onProgramClick={onProgramClick}
                 getProgramPreviousDownload={getProgramPreviousDownload}
                 guideOffsetHours={normalizedGuideOffsetHours}
+                archiveCutoff={archiveCutoff}
               />
             </Box>
           ))}

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -318,6 +318,14 @@ function formatArchiveDuration(days) {
   return `${Math.floor(parsed)} days`
 }
 
+function getChannelArchiveDays(channel) {
+  const parsed = Number(channel?.tv_archive_duration)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null
+  }
+  return Math.min(365, Math.max(1, Math.trunc(parsed)))
+}
+
 const previousDownloadStatusMeta = {
   pending: { label: 'Queued', color: 'yellow' },
   downloading: { label: 'Downloading', color: 'yellow' },
@@ -409,10 +417,12 @@ export default function Browse() {
     retry: false,
   })
 
-  // Fetch EPG for selected channel
+  // Fetch EPG for selected channel, going back as far as its catchup archive allows
+  const selectedChannelArchiveDays = getChannelArchiveDays(selectedChannel)
   const { data: epgData, isLoading: epgLoading } = useQuery({
-    queryKey: ['epg', selectedAccountId, selectedChannel?.stream_id],
-    queryFn: () => channelsApi.getEpg(selectedAccountId, selectedChannel.stream_id, 7, true),
+    queryKey: ['epg', selectedAccountId, selectedChannel?.stream_id, selectedChannelArchiveDays],
+    queryFn: () =>
+      channelsApi.getEpg(selectedAccountId, selectedChannel.stream_id, selectedChannelArchiveDays || 7, true),
     enabled: !!selectedAccountId && !!selectedChannel,
     staleTime: 0,
     refetchOnWindowFocus: false,

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -924,6 +924,7 @@ export default function Browse() {
                               getProgramPreviousDownload(program, selectedChannel?.stream_id)
                             }
                             guideOffsetHours={selectedGuideOffsetHours}
+                            archiveDays={selectedChannelArchiveDays}
                           />
                         ) : (
                           <Text c="dimmed" ta="center" py="xl">
@@ -1046,6 +1047,7 @@ export default function Browse() {
                             getProgramPreviousDownload(program, selectedChannel?.stream_id)
                           }
                           guideOffsetHours={selectedGuideOffsetHours}
+                          archiveDays={selectedChannelArchiveDays}
                         />
                       ) : (
                         <Text c="dimmed" ta="center" py="xl">


### PR DESCRIPTION
## Summary
Audit batch B6 — three catchup-window correctness issues:

1. **Hour-based `tv_archive_duration` no longer inflates the window 24x** — some providers report hours (168) instead of days (7). The shared `archive_days_for_channel` helper now treats values > 30 as hours (no provider offers a >30-day archive; hour-based providers send >= 24). All consumers (channel listing, EPG endpoints, scheduler via get_channel_archive_days, ingest cutoff) go through this one helper, consistent with #339.
2. **Browse EPG no longer hard-caps history at 14 days** — `days_back` validation raised to 365; the effective limit stays `min(days_back, channel_archive_days)` in the handlers. Browse now requests the channel's full archive window.
3. **Out-of-window programs are greyed out instead of failing on download** — programs older than the channel's archive window show a gray "Expired" badge with a tooltip and are not clickable, so users can't queue guaranteed-404 downloads.

## Steps to test
```
cd backend && python -m unittest discover -s tests   # 820 tests green
cd frontend && npm run build                          # passes
```
9 new regression tests (`test_archive_duration_hours.py`, `test_epg_days_back_cap.py`). UI change is the Expired badge/grey-out in Browse EPG.

CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)