### PR TITLE
fix: restart recovery no longer skips post-processing when download and completed folders match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: Commercial skip and transcoding no longer get skipped after a restart when the download and completed folders are the same
+
+**What you would notice:** If you point the download folder and the completed folder at the same directory, restarting Mustarrd while a recording was waiting for (or in the middle of) commercial detection or transcoding used to mark that recording as completed without ever processing it — you would end up with the raw recording, commercials and all. After this fix, the recording is picked up again after the restart and goes through commercial skip and transcoding as configured. Saving Settings with both folders set to the same path now also logs a warning so the setup is easy to spot in the Logs page.
+
+**What changed:** The restart-recovery check that treated "the file is already in the completed folder" as proof that post-processing had finished is no longer trusted when the download and completed folders resolve to the same directory — in that case the raw file lives there before processing has run, so the recording is re-queued for post-processing instead. Moving a finished file "to the completed folder" was already a no-op when both folders match, so nothing else changes. Backend only, no user settings or configuration were changed.
+
+---
+
 ### Fixed: First-run setup stays local-only behind a reverse proxy, and provider download links are checked more strictly
 
 **What you would notice:** Two security tighten-ups. First, if you run Mustarrd behind a reverse proxy in Docker (for example Unraid with Nginx Proxy Manager) and expose it to the internet, the initial "set admin password" screen was reachable by anyone on the internet before you finished setup — the app saw every proxied visitor as the proxy's local address and waved them through the "local network only" restriction. Now the app looks at the real visitor address reported by the proxy, so only visitors on your local/private network can complete first-run setup (unless you explicitly enable remote setup with `CATCHUP_ALLOW_REMOTE_SETUP`). Direct local access without a proxy works exactly as before. Second, when your IPTV provider supplies a direct download link for a movie or episode, Mustarrd only trusts it if it points back at your provider's server — that check now requires the port to match too, not just the server name, so a link to a different service on the same machine is no longer trusted.

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from typing import Literal, Optional
+import logging
 import os
 
 from auth import require_admin, require_authenticated, AuthContext
@@ -23,6 +24,8 @@ from services.post_processor import post_processor
 
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 
 def _paths_match(path_a: Optional[str], path_b: Optional[str]) -> bool:
@@ -235,6 +238,13 @@ async def update_settings(
     # is the valid "fast remux + skip commercials" profile written by onboarding.
     if settings.comskip_enabled:
         settings.transcode_enabled = True
+
+    if _paths_match(settings.download_folder, settings.completed_folder):
+        logger.warning(
+            "Download folder and completed folder are set to the same path (%s). "
+            "Finished recordings will stay in place instead of being moved.",
+            settings.download_folder,
+        )
 
     await session.commit()
     await session.refresh(settings)

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -330,6 +330,15 @@ class DownloadManager:
         except Exception:
             return False
 
+    def _folders_equal(self, folder_a: str, folder_b: str) -> bool:
+        try:
+            return (
+                os.path.realpath(os.path.abspath(folder_a))
+                == os.path.realpath(os.path.abspath(folder_b))
+            )
+        except Exception:
+            return False
+
     async def process_queue(self):
         """Main loop for processing download queue."""
         self._running = True
@@ -467,6 +476,10 @@ class DownloadManager:
                         pass
             completed_folder = self._resolve_completed_folder(settings)
             download_folder = self._resolve_download_folder(settings)
+            # When both folders are the same directory, "the file is under the
+            # completed folder" says nothing about whether post-processing ran:
+            # the raw downloaded input lives there too.
+            folders_equal = self._folders_equal(download_folder, completed_folder)
 
             result = await session.execute(
                 select(Download).where(
@@ -557,7 +570,15 @@ class DownloadManager:
                     continue
 
                 if download.status == DownloadStatus.PROCESSING.value:
-                    if input_file.is_file() and self._path_is_under(str(input_file), completed_folder):
+                    # Only trust "file already in the completed folder" as proof
+                    # that post-processing finished when the completed folder is
+                    # distinct from the download folder. With equal folders the
+                    # raw input sits there before processing has run.
+                    if (
+                        input_file.is_file()
+                        and self._path_is_under(str(input_file), completed_folder)
+                        and not (folders_equal and self._needs_post_processing(download, settings))
+                    ):
                         download.status = DownloadStatus.COMPLETED.value
                         download.progress = 100.0
                         if not download.completed_at:

--- a/backend/tests/test_recover_equal_folders_postprocess.py
+++ b/backend/tests/test_recover_equal_folders_postprocess.py
@@ -1,0 +1,178 @@
+"""
+Regression test: restart recovery must not skip post-processing when the
+download folder and the completed folder are configured to the same path.
+
+recover_incomplete_downloads treats "the file is under the completed folder"
+as proof that post-processing already finished and marks the download
+COMPLETED. When both folders point at the same directory, the raw downloaded
+.ts file sits "under the completed folder" before any Comskip/transcode work
+has run, so a restart mid-processing silently finalized the unprocessed file.
+
+Fix: the completed-folder shortcut is only trusted when the two folders are
+distinct; with equal folders the download is requeued for post-processing.
+"""
+import contextlib
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import AppSettings, Download, DownloadStatus
+from services.download_manager import DownloadManager
+
+
+class RecoverEqualFoldersPostProcessTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
+        self.manager = DownloadManager()
+        self.tmpdir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    async def _seed(self, download_folder: str, completed_folder: str,
+                    output_path: str, transcode_enabled: bool) -> int:
+        async with self.session_factory() as session:
+            session.add(AppSettings(
+                download_folder=download_folder,
+                completed_folder=completed_folder,
+                transcode_enabled=transcode_enabled,
+                comskip_enabled=False,
+            ))
+            dl = Download(
+                account_id=1,
+                channel_id="1",
+                channel_name="Test Channel",
+                program_title="Test Show",
+                program_start=datetime(2024, 1, 1, 20, 0, 0),
+                program_end=datetime(2024, 1, 1, 21, 0, 0),
+                duration_minutes=60,
+                source_url="http://provider.test/ts",
+                output_path=output_path,
+                status=DownloadStatus.PROCESSING.value,
+                progress=50.0,
+            )
+            session.add(dl)
+            await session.commit()
+            await session.refresh(dl)
+            return dl.id
+
+    async def _recover(self) -> None:
+        @contextlib.asynccontextmanager
+        async def patched_session_maker():
+            async with self.session_factory() as real_session:
+                yield real_session
+
+        with (
+            patch("services.download_manager.async_session_maker", patched_session_maker),
+            patch.object(self.manager, "_broadcast_progress", new_callable=AsyncMock),
+            patch.object(self.manager, "_broadcast_log", new_callable=AsyncMock),
+        ):
+            await self.manager.recover_incomplete_downloads()
+
+    async def _get_download(self, download_id: int) -> Download:
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(Download).where(Download.id == download_id)
+            )
+            return result.scalar_one()
+
+    async def test_equal_folders_processing_requeues_post_processing(self):
+        """Equal folders + post-processing enabled: requeue, don't finalize."""
+        media_dir = Path(self.tmpdir) / "media"
+        media_dir.mkdir()
+        raw_path = media_dir / "show.ts"
+        raw_path.write_bytes(b"x" * 1024)
+
+        download_id = await self._seed(
+            download_folder=str(media_dir),
+            completed_folder=str(media_dir),
+            output_path=str(raw_path),
+            transcode_enabled=True,
+        )
+
+        await self._recover()
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.PROCESSING.value,
+            "With download folder == completed folder, a PROCESSING download "
+            "must be requeued for post-processing on restart. Before the fix "
+            "the raw .ts was 'under the completed folder' and got marked "
+            "COMPLETED without Comskip/transcode ever running.",
+        )
+        self.assertEqual(
+            self.manager._post_queue.qsize(), 1,
+            "The download must be put back on the post-processing queue.",
+        )
+        self.assertEqual(self.manager._post_queue.get_nowait(), download_id)
+
+    async def test_equal_folders_without_post_processing_marks_completed(self):
+        """Equal folders + post-processing disabled: finalizing is correct."""
+        media_dir = Path(self.tmpdir) / "media"
+        media_dir.mkdir()
+        raw_path = media_dir / "show.ts"
+        raw_path.write_bytes(b"x" * 1024)
+
+        download_id = await self._seed(
+            download_folder=str(media_dir),
+            completed_folder=str(media_dir),
+            output_path=str(raw_path),
+            transcode_enabled=False,
+        )
+
+        await self._recover()
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(dl.status, DownloadStatus.COMPLETED.value)
+        self.assertEqual(dl.output_path, str(raw_path))
+        self.assertTrue(raw_path.exists(), "Move-to-completed must be a no-op.")
+        self.assertEqual(self.manager._post_queue.qsize(), 0)
+
+    async def test_distinct_folders_file_in_completed_still_finalizes(self):
+        """Distinct folders: a file already in completed is still finalized."""
+        downloads_dir = Path(self.tmpdir) / "downloads"
+        downloads_dir.mkdir()
+        completed_dir = Path(self.tmpdir) / "completed"
+        completed_dir.mkdir()
+        moved_path = completed_dir / "show.mkv"
+        moved_path.write_bytes(b"x" * 1024)
+
+        download_id = await self._seed(
+            download_folder=str(downloads_dir),
+            completed_folder=str(completed_dir),
+            output_path=str(moved_path),
+            transcode_enabled=True,
+        )
+
+        await self._recover()
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(
+            dl.status,
+            DownloadStatus.COMPLETED.value,
+            "With distinct folders, a PROCESSING download whose file already "
+            "sits in the completed folder must still be finalized as COMPLETED.",
+        )
+        self.assertEqual(self.manager._post_queue.qsize(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Audit batch B9. When the download folder and completed folder are configured to the same path, restart recovery treated the raw unprocessed recording as "already in the completed folder" and marked it COMPLETED — Comskip/transcode never ran. Recovery now only takes that shortcut when the folders are distinct (or no post-processing is needed); equal folders fall through to the existing requeue-for-post-processing branch. Settings updates log a warning when both paths resolve to the same directory.

The audit's other claim (multi-byte names exceeding NAME_MAX) was already fixed in PR #236 — both namers cap at 200 UTF-8 bytes on character boundaries with CJK regression tests; verified worst-case component lengths incl. pipeline suffixes stay under 255 bytes. No change.

## Steps to test
```
cd backend && python -m unittest discover -s tests   # 3 new tests in test_recover_equal_folders_postprocess.py
```
Backend only. CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)