### PR TITLE
fix: epg_channel_id case mismatch silently drops all EPG for affected channels

### DIFF
--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -622,7 +622,7 @@ class EPGIngestManager:
             for _, elem in ET.iterparse(sanitized, events=("end",)):
                 local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
                 if local_tag == "channel":
-                    xmltv_id = elem.get("id")
+                    xmltv_id = (elem.get("id") or "").lower() or None
                     display_name = self._extract_text(elem, "display-name")
                     if xmltv_id and xmltv_id not in xmltv_to_stream:
                         if xmltv_id in stream_info:
@@ -670,7 +670,7 @@ class EPGIngestManager:
             for _, elem in ET.iterparse(io.BytesIO(xmltv_bytes), events=("end",)):
                 local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
                 if local_tag == "channel":
-                    xmltv_id = elem.get("id")
+                    xmltv_id = (elem.get("id") or "").lower() or None
                     display_name = self._extract_text(elem, "display-name")
                     if xmltv_id and xmltv_id not in xmltv_to_stream:
                         if xmltv_id in stream_info:
@@ -686,7 +686,7 @@ class EPGIngestManager:
                 if local_tag != "programme":
                     continue
 
-                xmltv_id = elem.get("channel")
+                xmltv_id = (elem.get("channel") or "").lower() or None
                 if not xmltv_id:
                     elem.clear()
                     continue
@@ -876,7 +876,7 @@ class EPGIngestManager:
         for key in ("epg_channel_id", "tvg_id", "tvgid", "tvg_name", "tvg-id"):
             value = channel.get(key)
             if value:
-                return str(value).strip()
+                return str(value).strip().lower()
         return None
 
     def _normalize_name(self, name: str) -> str:

--- a/backend/tests/test_epg_channel_id_case_insensitive.py
+++ b/backend/tests/test_epg_channel_id_case_insensitive.py
@@ -8,7 +8,7 @@ name-based fallback also fails.  _iter_programs must map the programme to the
 correct stream despite the case difference.
 
 Currently FAILS because stream_by_xmltv_id stores "BBC.ONE" but xmltv_to_stream
-lookup uses the raw XMLTV value "bbc.one" — a case-sensitive miss.
+lookup uses the raw XMLTV value "bbc.one", a case-sensitive miss.
 """
 import sys
 import textwrap

--- a/backend/tests/test_epg_channel_id_case_insensitive.py
+++ b/backend/tests/test_epg_channel_id_case_insensitive.py
@@ -1,0 +1,114 @@
+"""
+Regression test: epg_channel_id case mismatch silently drops all programmes.
+
+Provider stream has  epg_channel_id = "BBC.ONE" (uppercase).
+XMLTV feed has       <channel id="bbc.one"> (lowercase).
+The display-name in the XMLTV does NOT match the provider channel name, so the
+name-based fallback also fails.  _iter_programs must map the programme to the
+correct stream despite the case difference.
+
+Currently FAILS because stream_by_xmltv_id stores "BBC.ONE" but xmltv_to_stream
+lookup uses the raw XMLTV value "bbc.one" — a case-sensitive miss.
+"""
+import sys
+import textwrap
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+_XMLTV_TEMPLATE = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <tv>
+      <channel id="{channel_id}">
+        <display-name>{display_name}</display-name>
+      </channel>
+      <programme channel="{channel_id}" start="20240101120000 +0000" stop="20240101130000 +0000">
+        <title>News at Noon</title>
+      </programme>
+    </tv>
+""")
+
+
+class EpgChannelIdCaseInsensitiveTests(unittest.TestCase):
+    def setUp(self):
+        self._mgr = EPGIngestManager()
+        self._now = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def _build_maps(self, epg_channel_id, provider_name):
+        channel = {
+            "stream_id": "12345",
+            "name": provider_name,
+            "epg_channel_id": epg_channel_id,
+            "tv_archive": "1",
+            "tv_archive_duration": "7",
+        }
+        return self._mgr._build_channel_maps([channel])
+
+    def _programmes(self, xmltv_bytes, channel_maps):
+        return list(self._mgr._iter_programs(xmltv_bytes, channel_maps, self._now))
+
+    def test_exact_case_match_yields_programme(self):
+        """Sanity check: identical case always works."""
+        maps = self._build_maps("bbc.one", "BBC One")
+        xmltv = _XMLTV_TEMPLATE.format(
+            channel_id="bbc.one", display_name="BBC One"
+        ).encode()
+        progs = self._programmes(xmltv, maps)
+        self.assertEqual(len(progs), 1)
+        self.assertEqual(progs[0]["channel_id"], "12345")
+
+    def test_uppercase_provider_id_lowercase_xmltv_id(self):
+        """Provider epg_channel_id uppercase; XMLTV channel id lowercase.
+        Display-name differs from provider name so name fallback also misses.
+        Programmes must still be returned."""
+        maps = self._build_maps("BBC.ONE", "BBC One HD")
+        # XMLTV uses lowercase id; display-name "BBC One" != provider name "BBC One HD"
+        xmltv = _XMLTV_TEMPLATE.format(
+            channel_id="bbc.one", display_name="BBC One"
+        ).encode()
+        progs = self._programmes(xmltv, maps)
+        self.assertEqual(
+            len(progs),
+            1,
+            "Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id",
+        )
+        self.assertEqual(progs[0]["channel_id"], "12345")
+
+    def test_lowercase_provider_id_uppercase_xmltv_id(self):
+        """Provider epg_channel_id lowercase; XMLTV channel id uppercase.
+        Display-name differs from provider name so name fallback also misses."""
+        maps = self._build_maps("bbc.one", "BBC One HD")
+        xmltv = _XMLTV_TEMPLATE.format(
+            channel_id="BBC.ONE", display_name="BBC One"
+        ).encode()
+        progs = self._programmes(xmltv, maps)
+        self.assertEqual(
+            len(progs),
+            1,
+            "Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id",
+        )
+        self.assertEqual(progs[0]["channel_id"], "12345")
+
+    def test_mixed_case_provider_id_vs_xmltv_id(self):
+        """Provider uses Title-Case; XMLTV uses kebab-lower."""
+        maps = self._build_maps("BBC.One.UK", "BBC One UK")
+        xmltv = _XMLTV_TEMPLATE.format(
+            channel_id="bbc.one.uk", display_name="BBC 1 UK"
+        ).encode()
+        progs = self._programmes(xmltv, maps)
+        self.assertEqual(
+            len(progs),
+            1,
+            "Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What a user would notice

Some channels would show a completely empty guide, with no error message. This happened when the provider labeled a channel with an id like `BBC.ONE` but the XMLTV guide file used `bbc.one` (different capitalization). Every programme for that channel was silently skipped.

## Root cause

`_build_channel_maps` stored the channel id exactly as the provider sent it (e.g. `"BBC.ONE"`). The XMLTV parser then looked up the channel id from the guide file (e.g. `"bbc.one"`) in that map, and the case-sensitive Python dict lookup missed every time. No error, no log: the guide just came back empty.

## Fix

Lowercase at both ends:
- `_extract_xmltv_id` now returns `.lower()`, so provider ids are stored in lowercase.
- `_scan_channel_map` and `_iter_programs` now lowercase the `<channel id>` and `<programme channel>` attributes read from the XMLTV document before any map lookup.

The diff is 4 one-line changes in `epg_ingest_manager.py`.

## Before

Running the regression tests on unpatched main:

```
FAIL: test_uppercase_provider_id_lowercase_xmltv_id
AssertionError: 0 != 1 : Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id

FAIL: test_lowercase_provider_id_uppercase_xmltv_id
AssertionError: 0 != 1 : Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id

FAIL: test_mixed_case_provider_id_vs_xmltv_id
AssertionError: 0 != 1 : Programme silently dropped due to case mismatch in epg_channel_id vs XMLTV channel id

Ran 4 tests in 0.002s
FAILED (failures=3)
```

## After

```
test_exact_case_match_yields_programme ... ok
test_lowercase_provider_id_uppercase_xmltv_id ... ok
test_mixed_case_provider_id_vs_xmltv_id ... ok
test_uppercase_provider_id_lowercase_xmltv_id ... ok

Ran 4 tests in 0.002s
OK
```

Full suite: 885 tests, all pass.

## Regression test

`backend/tests/test_epg_channel_id_case_insensitive.py` covers 4 scenarios: exact match (sanity), provider uppercase/XMLTV lowercase, provider lowercase/XMLTV uppercase, and mixed case.

Closes #1514029710609350696 (task: epg_channel_id case mismatch silently drops all EPG for affected channels)