### PR TITLE
feat: account cards show expiry warning and provider capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Added: Account cards warn before your subscription expires and show what each provider supports
+
+**What you would notice:** On the Accounts page, each account card now shows a yellow "Expires in N days" warning badge during the last week of your subscription (hover over it to see the exact date), so a renewal doesn't sneak up on you. Each card also shows a compact summary of what the provider actually offers: how many channels have catchup, the longest archive window seen (for example "Catchup: 1,234 channels · up to 7 days"), and whether the provider has a VOD (movies/series) library. These summaries come from data Mustarrd already collects during its regular guide refresh, so the Accounts page no longer asks your provider for the full channel list every time you open it — the page loads faster and puts less load on your provider. The summaries appear after the first guide refresh following this update.
+
+**What changed:** The EPG ingest now records a per-account capabilities summary (catchup-enabled channel count, maximum archive days, VOD availability via one category lookup per refresh) on the account row, and the accounts API returns those fields. The frontend reads them from the accounts payload instead of fetching every channel from the provider on each page load, and shows an "expires soon" badge when the cached subscription expiry date is 7 days away or less.
+
+---
+
 ### Fixed: The app no longer freezes during big file moves, guide refreshes, or when a network drive misbehaves — and large providers load reliably
 
 **What you would notice:** Several situations that used to make the whole app momentarily unresponsive — frozen download progress, stalled WebSocket updates, pages not loading — are gone. Moving a finished multi-gigabyte recording into a completed folder on another drive (for example a NAS) no longer freezes everything for the duration of the copy. Refreshing the guide from a provider with a large compressed guide file no longer stalls the app while it unpacks. A slow or hung network drive no longer hangs the scheduler or downloads while free space is checked — the check now gives up after 10 seconds. Two more fixes for network-drive and big-provider setups: if your download folder sits on a drive that is not mounted, scheduled recordings now wait for it to come back (with a clear "folder is missing or unreachable" status) instead of silently recording onto the wrong disk and filling it up; and on providers with very large channel lists, loading channels and the program guide no longer times out after 30 seconds — those requests now get the same 90-second budget that movie/series lists already had. Browsing the guide and catchup lists is also faster, because each page load now asks the provider for its channel list once instead of twice.

--- a/backend/database.py
+++ b/backend/database.py
@@ -102,6 +102,15 @@ async def _apply_lightweight_migrations(conn) -> None:
     if not await _column_exists(conn, "xtream_accounts", "last_connection_error"):
         await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN last_connection_error TEXT"))
 
+    if not await _column_exists(conn, "xtream_accounts", "catchup_channel_count"):
+        await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN catchup_channel_count INTEGER"))
+
+    if not await _column_exists(conn, "xtream_accounts", "catchup_max_archive_days"):
+        await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN catchup_max_archive_days INTEGER"))
+
+    if not await _column_exists(conn, "xtream_accounts", "vod_available"):
+        await conn.execute(text("ALTER TABLE xtream_accounts ADD COLUMN vod_available BOOLEAN"))
+
 
 async def _migrate_legacy_account_passwords() -> None:
     from models import XtreamAccount

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -29,6 +29,11 @@ class XtreamAccount(Base):
     last_connection_checked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_connection_error: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
+    # Provider capabilities summary, refreshed during EPG ingest (None = not yet known)
+    catchup_channel_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    catchup_max_archive_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    vod_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
     def to_dict(self):
         return {
             "id": self.id,
@@ -46,4 +51,7 @@ class XtreamAccount(Base):
             "last_connection_ok": self.last_connection_ok,
             "last_connection_checked_at": self.last_connection_checked_at.isoformat() + "Z" if self.last_connection_checked_at else None,
             "last_connection_error": self.last_connection_error,
+            "catchup_channel_count": self.catchup_channel_count,
+            "catchup_max_archive_days": self.catchup_max_archive_days,
+            "vod_available": self.vod_available,
         }

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -307,6 +307,27 @@ class EPGIngestManager:
                 f"Found {len(catchup_channels)} catchup-enabled channels.",
                 account=account
             )
+
+            max_archive_days = 0
+            for ch in catchup_channels:
+                days = epg_service.archive_days_for_channel(ch)
+                if days > max_archive_days:
+                    max_archive_days = days
+
+            vod_available = None
+            try:
+                vod_categories = await client.get_vod_categories()
+                vod_available = bool(vod_categories)
+            except Exception:
+                logger.debug("VOD category probe failed for account %s", account.id, exc_info=True)
+
+            await self._update_provider_capabilities(
+                account.id,
+                catchup_channel_count=len(catchup_channels),
+                catchup_max_archive_days=max_archive_days,
+                vod_available=vod_available,
+            )
+
             channel_maps = self._build_channel_maps(catchup_channels)
 
             raw_xmltv = await client.get_xmltv()
@@ -532,6 +553,33 @@ class EPGIngestManager:
                     await session.commit()
         except Exception:
             logger.exception("Failed to update connection status for account %s", account_id)
+
+    async def _update_provider_capabilities(
+        self,
+        account_id: int,
+        catchup_channel_count: int,
+        catchup_max_archive_days: int,
+        vod_available: bool | None,
+    ) -> None:
+        """Persist the provider capabilities summary derived during a refresh.
+
+        vod_available=None means the VOD probe failed; the previously stored
+        value is kept so a transient error does not flip the badge.
+        """
+        try:
+            async with async_session_maker() as session:
+                result = await session.execute(
+                    select(XtreamAccount).where(XtreamAccount.id == account_id)
+                )
+                account = result.scalar_one_or_none()
+                if account:
+                    account.catchup_channel_count = catchup_channel_count
+                    account.catchup_max_archive_days = catchup_max_archive_days
+                    if vod_available is not None:
+                        account.vod_available = vod_available
+                    await session.commit()
+        except Exception:
+            logger.exception("Failed to update provider capabilities for account %s", account_id)
 
     def _build_channel_maps(self, channels: list[dict]) -> dict:
         # Maps an XMLTV id to the list of stream ids that claim it. Two provider

--- a/backend/tests/test_account_capabilities.py
+++ b/backend/tests/test_account_capabilities.py
@@ -1,0 +1,240 @@
+"""
+Regression tests: provider capabilities summary on the account row.
+
+The EPG ingest already fetches the full live channel list each refresh, so the
+catchup capabilities (channel count, max archive days) are derived from that
+fetch plus one VOD category lookup, and persisted on the account. The accounts
+API then serves them from the row — no live provider call per page load.
+"""
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models.account import XtreamAccount
+from services.epg_ingest_manager import EPGIngestManager
+
+
+def _make_account(account_id=1):
+    account = MagicMock()
+    account.id = account_id
+    account.name = "Test Provider"
+    account.server_url = "http://provider.example"
+    account.username = "user"
+    return account
+
+
+def _make_session(db_account):
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=db_account))
+    )
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_refresh_session_maker():
+    """Fake async_session_maker for the main _refresh_account transaction."""
+    fake_session = AsyncMock()
+
+    async def fake_execute(stmt, *args, **kwargs):
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        result.all.return_value = []
+        return result
+
+    fake_session.execute = fake_execute
+
+    @asynccontextmanager
+    async def fake_begin():
+        yield
+
+    fake_session.begin = fake_begin
+
+    @asynccontextmanager
+    async def maker():
+        yield fake_session
+
+    return maker
+
+
+class UpdateProviderCapabilitiesTests(unittest.IsolatedAsyncioTestCase):
+    async def test_writes_capabilities_to_account(self):
+        """_update_provider_capabilities persists count, max days and VOD flag."""
+        manager = EPGIngestManager()
+        db_account = MagicMock()
+        session = _make_session(db_account)
+
+        with patch("services.epg_ingest_manager.async_session_maker", return_value=session):
+            await manager._update_provider_capabilities(
+                1,
+                catchup_channel_count=1234,
+                catchup_max_archive_days=7,
+                vod_available=True,
+            )
+
+        self.assertEqual(db_account.catchup_channel_count, 1234)
+        self.assertEqual(db_account.catchup_max_archive_days, 7)
+        self.assertTrue(db_account.vod_available)
+        session.commit.assert_awaited()
+
+    async def test_vod_none_keeps_previous_value(self):
+        """A failed VOD probe (None) must not overwrite the stored flag."""
+        manager = EPGIngestManager()
+        db_account = MagicMock()
+        db_account.vod_available = True
+        session = _make_session(db_account)
+
+        with patch("services.epg_ingest_manager.async_session_maker", return_value=session):
+            await manager._update_provider_capabilities(
+                1,
+                catchup_channel_count=10,
+                catchup_max_archive_days=3,
+                vod_available=None,
+            )
+
+        self.assertTrue(db_account.vod_available)
+        self.assertEqual(db_account.catchup_channel_count, 10)
+
+    async def test_missing_account_does_not_commit(self):
+        """No-op when the account no longer exists."""
+        manager = EPGIngestManager()
+        session = _make_session(None)
+
+        with patch("services.epg_ingest_manager.async_session_maker", return_value=session):
+            await manager._update_provider_capabilities(
+                99,
+                catchup_channel_count=1,
+                catchup_max_archive_days=1,
+                vod_available=False,
+            )
+
+        session.commit.assert_not_called()
+
+
+class RefreshAccountCapabilitiesTests(unittest.IsolatedAsyncioTestCase):
+    def _make_client(self, channels, vod_categories=None, vod_error=None):
+        client = MagicMock()
+        client.get_live_streams = AsyncMock(return_value=channels)
+        client.get_xmltv = AsyncMock(return_value=b"")
+        client.close = AsyncMock()
+        if vod_error is not None:
+            client.get_vod_categories = AsyncMock(side_effect=vod_error)
+        else:
+            client.get_vod_categories = AsyncMock(return_value=vod_categories or [])
+        return client
+
+    async def _run_refresh(self, client):
+        manager = EPGIngestManager()
+        account = _make_account()
+        # Recent backfill keeps the cooldown active so the refresh does not
+        # walk into the per-channel API backfill path.
+        account.last_epg_backfill_at = datetime.now(timezone.utc)
+
+        with (
+            patch("services.epg_ingest_manager.async_session_maker", side_effect=_make_refresh_session_maker()),
+            patch("services.epg_ingest_manager.resolve_account_password", return_value="pass"),
+            patch("services.epg_ingest_manager.XtreamClient", return_value=client),
+            patch.object(manager, "_update_provider_capabilities", new=AsyncMock()) as mock_caps,
+            patch.object(manager, "_log", new=AsyncMock()),
+        ):
+            await manager._refresh_account(account)
+
+        return mock_caps
+
+    async def test_refresh_persists_channel_count_and_max_days(self):
+        """Refresh derives count and max archive days from the live channel list."""
+        channels = [
+            {"stream_id": 1, "name": "A", "tv_archive": 1, "tv_archive_duration": 3},
+            {"stream_id": 2, "name": "B", "tv_archive": 1, "tv_archive_duration": 7},
+            {"stream_id": 3, "name": "C", "tv_archive": 0, "tv_archive_duration": 0},
+        ]
+        client = self._make_client(channels, vod_categories=[{"category_id": "1"}])
+
+        mock_caps = await self._run_refresh(client)
+
+        mock_caps.assert_awaited_once()
+        call = mock_caps.call_args
+        self.assertEqual(call.args[0], 1)
+        self.assertEqual(call.kwargs["catchup_channel_count"], 2)
+        self.assertEqual(call.kwargs["catchup_max_archive_days"], 7)
+        self.assertTrue(call.kwargs["vod_available"])
+
+    async def test_refresh_empty_vod_categories_reports_unavailable(self):
+        """A provider with no VOD categories is recorded as vod_available=False."""
+        channels = [
+            {"stream_id": 1, "name": "A", "tv_archive": 1, "tv_archive_duration": 2},
+        ]
+        client = self._make_client(channels, vod_categories=[])
+
+        mock_caps = await self._run_refresh(client)
+
+        mock_caps.assert_awaited_once()
+        self.assertFalse(mock_caps.call_args.kwargs["vod_available"])
+
+    async def test_refresh_vod_probe_failure_does_not_break_refresh(self):
+        """A failing VOD lookup passes None (keep previous) and the refresh continues."""
+        channels = [
+            {"stream_id": 1, "name": "A", "tv_archive": 1, "tv_archive_duration": 2},
+        ]
+        client = self._make_client(channels, vod_error=Exception("boom"))
+
+        mock_caps = await self._run_refresh(client)
+
+        mock_caps.assert_awaited_once()
+        self.assertIsNone(mock_caps.call_args.kwargs["vod_available"])
+        self.assertEqual(mock_caps.call_args.kwargs["catchup_channel_count"], 1)
+
+
+class AccountToDictCapabilitiesTests(unittest.TestCase):
+    def _make_mock_account(self):
+        account = MagicMock(spec=XtreamAccount)
+        account.id = 1
+        account.name = "Test"
+        account.server_url = "http://example.com"
+        account.username = "user"
+        account.is_active = True
+        account.created_at = datetime(2026, 6, 6, 23, 0, 0)
+        account.last_used = None
+        account.last_epg_backfill_at = None
+        account.max_connections = None
+        account.active_connections = None
+        account.expiration_date = None
+        account.guide_offset_hours = 0
+        account.last_connection_ok = True
+        account.last_connection_checked_at = None
+        account.last_connection_error = None
+        account.catchup_channel_count = 1234
+        account.catchup_max_archive_days = 7
+        account.vod_available = True
+        return account
+
+    def test_to_dict_includes_capability_fields(self):
+        """The accounts payload carries the capabilities so the UI needs no live call."""
+        d = XtreamAccount.to_dict(self._make_mock_account())
+        self.assertEqual(d["catchup_channel_count"], 1234)
+        self.assertEqual(d["catchup_max_archive_days"], 7)
+        self.assertTrue(d["vod_available"])
+
+    def test_to_dict_capability_fields_default_none(self):
+        """Unknown capabilities serialize as None, not 0/False."""
+        account = self._make_mock_account()
+        account.catchup_channel_count = None
+        account.catchup_max_archive_days = None
+        account.vod_available = None
+        d = XtreamAccount.to_dict(account)
+        self.assertIsNone(d["catchup_channel_count"])
+        self.assertIsNone(d["catchup_max_archive_days"])
+        self.assertIsNone(d["vod_available"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/settings/AccountsSection.jsx
+++ b/frontend/src/components/settings/AccountsSection.jsx
@@ -16,10 +16,11 @@ import {
   Alert,
   NumberInput,
   Box,
+  Tooltip,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
-import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   IconPlus,
   IconDotsVertical,
@@ -33,7 +34,7 @@ import {
 } from '@tabler/icons-react'
 import dayjs from 'dayjs'
 
-import { accountsApi, channelsApi, epgApi, settingsApi } from '../../api'
+import { accountsApi, epgApi, settingsApi } from '../../api'
 
 function timeAgo(dateStr) {
   if (!dateStr) return null
@@ -50,6 +51,16 @@ function timeAgo(dateStr) {
 function getGuideOffsetLabel(account) {
   const offset = Number(account?.guide_offset_hours || 0)
   return offset ? `Guide offset: ${offset >= 0 ? '+' : ''}${offset}h` : 'Guide offset: 0h'
+}
+
+function getCatchupLabel(account) {
+  const count = Number(account.catchup_channel_count)
+  if (count <= 0) return 'Catchup: not available'
+  const maxDays = Number(account.catchup_max_archive_days || 0)
+  const channels = `${count.toLocaleString()} channel${count === 1 ? '' : 's'}`
+  return maxDays > 0
+    ? `Catchup: ${channels} · up to ${maxDays} day${maxDays === 1 ? '' : 's'}`
+    : `Catchup: ${channels}`
 }
 
 function AccountForm({ account, onSubmit, onCancel, isLoading }) {
@@ -130,8 +141,12 @@ function AccountForm({ account, onSubmit, onCancel, isLoading }) {
   )
 }
 
-function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTest, catchupSummary, defaultPending }) {
+function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTest, defaultPending }) {
   const isExpired = account.expiration_date && dayjs(account.expiration_date).isBefore(dayjs())
+  const daysUntilExpiry = account.expiration_date
+    ? dayjs(account.expiration_date).diff(dayjs(), 'day')
+    : null
+  const isExpiringSoon = Boolean(account.expiration_date) && !isExpired && daysUntilExpiry <= 7
 
   return (
     <Card shadow="sm" padding="lg" radius="md" withBorder>
@@ -185,15 +200,16 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
       </Text>
 
       <Group mt="md" gap="xs">
-        {catchupSummary?.loading && account.last_connection_ok !== false ? (
+        {account.catchup_channel_count != null && (
           <Badge variant="outline" size="sm" color="blue">
-            Catchup: loading...
+            {getCatchupLabel(account)}
           </Badge>
-        ) : catchupSummary?.maxDays > 0 ? (
-          <Badge variant="outline" size="sm" color="blue">
-            Catchup: up to {catchupSummary.maxDays} days
+        )}
+        {account.vod_available != null && (
+          <Badge variant="outline" size="sm" color={account.vod_available ? 'teal' : 'gray'}>
+            {account.vod_available ? 'VOD ✓' : 'VOD ✗'}
           </Badge>
-        ) : null}
+        )}
         {Number(account?.guide_offset_hours || 0) !== 0 && (
           <Badge variant="light" size="sm" color="grape">
             {getGuideOffsetLabel(account)}
@@ -203,6 +219,15 @@ function AccountCard({ account, isDefault, onSetDefault, onEdit, onDelete, onTes
           <Badge variant="outline" size="sm">
             {account.active_connections || 0}/{account.max_connections} connections
           </Badge>
+        )}
+        {isExpiringSoon && (
+          <Tooltip label={`Subscription expires ${dayjs(account.expiration_date).format('MMM D, YYYY')}`}>
+            <Badge variant="filled" size="sm" color="yellow">
+              {daysUntilExpiry === 0
+                ? 'Expires today'
+                : `Expires in ${daysUntilExpiry} day${daysUntilExpiry === 1 ? '' : 's'}`}
+            </Badge>
+          </Tooltip>
         )}
         {account.expiration_date && (
           <Badge variant="outline" size="sm" color={isExpired ? 'red' : 'yellow'}>
@@ -287,36 +312,6 @@ export default function AccountsSection({ showTitle = true }) {
     queryFn: epgApi.status,
     refetchInterval: 5000,
   })
-
-  const catchupQueries = useQueries({
-    queries: (accounts || []).map((account) => ({
-      queryKey: ['account-catchup-summary', account.id],
-      queryFn: async () => {
-        const channels = await channelsApi.getChannels(account.id, null, false)
-        let maxDays = 0
-        for (const channel of channels || []) {
-          const raw = Number(channel?.tv_archive_duration)
-          const days = Number.isFinite(raw) ? Math.max(0, Math.min(365, Math.trunc(raw))) : 0
-          if (days > maxDays) maxDays = days
-        }
-        return { maxDays }
-      },
-      enabled: Boolean(accounts?.length),
-      staleTime: 5 * 60 * 1000,
-      refetchOnWindowFocus: false,
-    })),
-  })
-
-  const catchupSummaryByAccount = {}
-  if (accounts?.length) {
-    accounts.forEach((account, index) => {
-      const query = catchupQueries[index]
-      catchupSummaryByAccount[account.id] = {
-        loading: Boolean(query?.isLoading),
-        maxDays: query?.data?.maxDays || 0,
-      }
-    })
-  }
 
   const createMutation = useMutation({
     mutationFn: accountsApi.create,
@@ -562,7 +557,6 @@ export default function AccountsSection({ showTitle = true }) {
               onEdit={handleEdit}
               onDelete={handleDelete}
               onTest={handleTest}
-              catchupSummary={catchupSummaryByAccount[account.id]}
               defaultPending={setDefaultAccountMutation.isPending}
             />
           ))}


### PR DESCRIPTION
## Summary
Audit batch B10 — two Accounts-page features:

1. **Subscription expiry warning** — a yellow "Expires in N days" / "Expires today" badge appears on the account card within 7 days of expiry (tooltip shows the date). Uses the `expiration_date` already cached on the account row; frontend only. Designed around open PR #349 (already-expired display) — verified zero-conflict via merge-tree, badges never duplicate.
2. **Provider capabilities summary** — each card shows "Catchup: N channels · up to N days" and "VOD ✓/✗" at a glance. Three nullable columns on `xtream_accounts` (lightweight ALTER TABLE migrations) populated during the regular EPG refresh — zero extra provider calls per page load; this also REMOVES the old per-account full channel fetch the page did on every load. A failed VOD probe preserves the previous value. Badges hide until the first refresh after deploy populates them.

## Steps to test
```
cd backend && python -m unittest discover -s tests   # 911 green
cd frontend && npm run build                          # passes
```
8 new regression tests (`test_account_capabilities.py`). Screenshots: not included (automated change); badges visible on Settings → Accounts after an EPG refresh.

CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)