### PR TITLE
feat: starred channels and live/catchup preview in Browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Added: Star your favorite channels and preview programs before downloading in Browse
+
+**What you would notice:** Two additions to the Browse page. First, every channel in the channel list now has a star button — starred channels jump to the top of the list so the channels you record from most are always one click away. Stars are personal: each signed-in user (including download-only users) keeps their own favorites, and they are remembered across sessions and devices. Second, programs in the channel guide that can still be downloaded — and the program airing right now — show a small "Preview" button. Clicking it opens a player so you can check you have the right program (or watch the live channel) before queueing a download. Whether the preview actually plays depends on your browser's support for the provider's broadcast format; if it stays black, downloads are unaffected. To keep your provider connection limits safe, at most two previews can run at the same time.
+
+**What changed:** Stars are stored server-side in a new `starred_channels` table keyed per user, with a toggle endpoint and a `starred` flag in the channel list response; the list sorts starred channels first while keeping the provider's order otherwise. Previews are relayed through a new authenticated backend endpoint that opens the live or timeshift stream on the server and proxies the bytes to the browser, so the provider URL — which contains your account credentials — never reaches the page. The proxy caps concurrent previews at two, limits each preview to five minutes, and closes the provider connection as soon as the preview window is closed.
+
+---
+
 ### Added: Account cards warn before your subscription expires and show what each provider supports
 
 **What you would notice:** On the Accounts page, each account card now shows a yellow "Expires in N days" warning badge during the last week of your subscription (hover over it to see the exact date), so a renewal doesn't sneak up on you. Each card also shows a compact summary of what the provider actually offers: how many channels have catchup, the longest archive window seen (for example "Catchup: 1,234 channels · up to 7 days"), and whether the provider has a VOD (movies/series) library. These summaries come from data Mustarrd already collects during its regular guide refresh, so the Accounts page no longer asks your provider for the full channel list every time you open it — the page loads faster and puts less load on your provider. The summaries appear after the first guide refresh following this update.

--- a/backend/api/channels.py
+++ b/backend/api/channels.py
@@ -1,12 +1,13 @@
+import logging
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from typing import Optional
-import logging
 
 from auth import require_admin_or_download_user, AuthContext
 from database import get_session
-from models import XtreamAccount
+from models import StarredChannel, XtreamAccount
 from services.epg_service import epg_service, NoCatchupSupportError
 from services.account_credentials import resolve_account_password_with_migration
 from services.xtream_client import XtreamClient
@@ -48,7 +49,7 @@ async def get_channels(
     account_id: int,
     category_id: Optional[str] = Query(None),
     catchup_only: bool = Query(True, description="Only show channels with catchup/timeshift support"),
-    _admin: None = Depends(require_admin_or_download_user),
+    auth: AuthContext = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session)
 ):
     """Get channels for an account, optionally filtered by category."""
@@ -61,6 +62,14 @@ async def get_channels(
         raise HTTPException(status_code=404, detail="Account not found")
 
     try:
+        starred_result = await session.execute(
+            select(StarredChannel.channel_id).where(
+                StarredChannel.user_id == auth.user_id,
+                StarredChannel.account_id == account_id,
+            )
+        )
+        starred_ids = set(starred_result.scalars().all())
+
         password = await resolve_account_password_with_migration(session, account)
         client = XtreamClient(account.server_url, account.username, password)
         try:
@@ -73,9 +82,13 @@ async def get_channels(
                     if _channel_has_tv_archive(ch) and epg_service.archive_days_for_channel(ch) > 0
                 ]
 
-            # Add archive duration info
+            # Add archive duration info and the per-user starred flag
             for ch in channels:
                 ch["tv_archive_duration"] = epg_service.archive_days_for_channel(ch)
+                ch["starred"] = str(ch.get("stream_id")) in starred_ids
+
+            # Starred channels float to the top; provider order is kept otherwise
+            channels.sort(key=lambda ch: not ch["starred"])
 
             return channels
         finally:
@@ -88,6 +101,48 @@ async def get_channels(
             category_id,
         )
         raise HTTPException(status_code=400, detail="Failed to load channels from provider")
+
+
+@router.post("/accounts/{account_id}/channels/{channel_id}/star")
+async def toggle_channel_star(
+    account_id: int,
+    channel_id: str,
+    auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Toggle the requesting user's star on a channel."""
+    result = await session.execute(
+        select(XtreamAccount).where(XtreamAccount.id == account_id)
+    )
+    account = result.scalar_one_or_none()
+
+    if not account:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    channel_key = str(channel_id)
+    existing_result = await session.execute(
+        select(StarredChannel).where(
+            StarredChannel.user_id == auth.user_id,
+            StarredChannel.account_id == account_id,
+            StarredChannel.channel_id == channel_key,
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+
+    if existing:
+        await session.delete(existing)
+        await session.commit()
+        return {"starred": False}
+
+    session.add(
+        StarredChannel(
+            user_id=auth.user_id,
+            account_id=account_id,
+            channel_id=channel_key,
+        )
+    )
+    await session.commit()
+    return {"starred": True}
 
 
 @router.get("/accounts/{account_id}/channels/{channel_id}/epg")

--- a/backend/api/channels.py
+++ b/backend/api/channels.py
@@ -1,13 +1,19 @@
+import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
+import aiohttp
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from starlette.background import BackgroundTask
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from auth import require_admin_or_download_user, AuthContext
 from database import get_session
 from models import StarredChannel, XtreamAccount
+from services.download_builder import _normalize_provider_start_token
 from services.epg_service import epg_service, NoCatchupSupportError
 from services.account_credentials import resolve_account_password_with_migration
 from services.xtream_client import XtreamClient
@@ -15,6 +21,30 @@ from services.xtream_client import XtreamClient
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+# Stream-preview proxy limits: previews relay provider bytes through the
+# backend so credentials embedded in provider URLs never reach the browser.
+PREVIEW_MAX_CONCURRENT = 2
+PREVIEW_MAX_SECONDS = 300
+PREVIEW_CHUNK_SIZE = 64 * 1024
+PREVIEW_TIMEOUT = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=60)
+
+_active_preview_count = 0
+
+
+def _release_preview_slot() -> None:
+    global _active_preview_count
+    _active_preview_count = max(0, _active_preview_count - 1)
+
+
+async def _close_preview_connection(provider_response, http_session) -> None:
+    """Close the provider response and its session, tolerating partial setup."""
+    try:
+        if provider_response is not None:
+            provider_response.close()
+    finally:
+        if http_session is not None and not http_session.closed:
+            await http_session.close()
 
 
 def _channel_has_tv_archive(ch: dict) -> bool:
@@ -228,6 +258,132 @@ async def get_catchup_programs(
             channel_id,
         )
         raise HTTPException(status_code=500, detail="Failed to load catchup programs")
+
+
+@router.get("/accounts/{account_id}/channels/{channel_id}/preview")
+async def preview_channel_stream(
+    account_id: int,
+    channel_id: str,
+    mode: str = Query("live", pattern="^(live|catchup)$"),
+    start_timestamp: Optional[int] = Query(None, ge=0),
+    stop_timestamp: Optional[int] = Query(None, ge=0),
+    provider_start: Optional[str] = Query(None, max_length=64),
+    _auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Relay a short-lived preview of a live or catchup stream.
+
+    The provider URL embeds account credentials, so it never leaves the
+    backend: the stream is opened server-side and bytes are proxied to the
+    authenticated browser session.
+    """
+    global _active_preview_count
+
+    result = await session.execute(
+        select(XtreamAccount).where(XtreamAccount.id == account_id)
+    )
+    account = result.scalar_one_or_none()
+
+    if not account:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    password = await resolve_account_password_with_migration(session, account)
+    client = XtreamClient(account.server_url, account.username, password)
+
+    if mode == "catchup":
+        if not start_timestamp or not stop_timestamp or stop_timestamp <= start_timestamp:
+            raise HTTPException(
+                status_code=400,
+                detail="Catchup preview requires valid start and stop timestamps",
+            )
+        try:
+            start_utc = datetime.fromtimestamp(start_timestamp, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            raise HTTPException(status_code=400, detail="Invalid start timestamp")
+        duration_minutes = max(1, (stop_timestamp - start_timestamp) // 60)
+        normalized_start = (
+            _normalize_provider_start_token(provider_start, 0) if provider_start else None
+        )
+        stream_url = client.build_timeshift_url(
+            channel_id,
+            start_utc,
+            duration_minutes,
+            provider_start=normalized_start,
+        )
+    else:
+        stream_url = client.build_stream_url(channel_id, "ts")
+
+    if _active_preview_count >= PREVIEW_MAX_CONCURRENT:
+        raise HTTPException(
+            status_code=429,
+            detail="Preview limit reached. Close another preview and try again.",
+        )
+    _active_preview_count += 1
+
+    http_session = None
+    provider_response = None
+    try:
+        http_session = aiohttp.ClientSession(timeout=PREVIEW_TIMEOUT)
+        provider_response = await http_session.get(stream_url)
+        if provider_response.status != 200:
+            # Never echo the provider URL: it carries credentials.
+            raise HTTPException(
+                status_code=502,
+                detail=f"Provider refused the preview stream (HTTP {provider_response.status})",
+            )
+    except HTTPException:
+        await _close_preview_connection(provider_response, http_session)
+        _release_preview_slot()
+        raise
+    except Exception:
+        await _close_preview_connection(provider_response, http_session)
+        _release_preview_slot()
+        logger.exception(
+            "Preview stream failed account_id=%s channel_id=%s mode=%s",
+            account_id,
+            channel_id,
+            mode,
+        )
+        raise HTTPException(status_code=502, detail="Could not connect to the provider for preview")
+
+    cleanup_done = False
+
+    async def cleanup():
+        # Idempotent: invoked from the generator's finally and from the
+        # response background task, whichever runs first wins.
+        nonlocal cleanup_done
+        if cleanup_done:
+            return
+        cleanup_done = True
+        await _close_preview_connection(provider_response, http_session)
+        _release_preview_slot()
+
+    async def relay():
+        try:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + PREVIEW_MAX_SECONDS
+            async for chunk in provider_response.content.iter_chunked(PREVIEW_CHUNK_SIZE):
+                yield chunk
+                if loop.time() >= deadline:
+                    break
+        finally:
+            # Runs on normal completion, the deadline break, and client
+            # disconnect (generator aclose), so the provider connection
+            # never outlives the preview.
+            await cleanup()
+
+    return StreamingResponse(
+        relay(),
+        media_type="video/mp2t",
+        headers={
+            "Cache-Control": "no-store",
+            "X-Accel-Buffering": "no",
+        },
+        # Safety net for a disconnect before the first byte is sent: closing
+        # a never-started generator skips its finally block, but Starlette
+        # still runs the background task after the response ends.
+        background=BackgroundTask(cleanup),
+    )
 
 
 @router.get("/accounts/{account_id}/channels/{channel_id}")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,6 +3,7 @@ from .download import Download, DownloadStatus
 from .epg_program import EPGProgram
 from .settings import AppSettings
 from .scheduled_recording import ScheduledRecording, ScheduledStatus
+from .starred_channel import StarredChannel
 from .user import User, UserIdentity, UserSetupToken, PlexServer
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "AppSettings",
     "ScheduledRecording",
     "ScheduledStatus",
+    "StarredChannel",
     "User",
     "UserIdentity",
     "UserSetupToken",

--- a/backend/models/starred_channel.py
+++ b/backend/models/starred_channel.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from sqlalchemy import String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from database import Base
+
+
+class StarredChannel(Base):
+    """A channel a user starred so it floats to the top of the Browse list."""
+
+    __tablename__ = "starred_channels"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "account_id",
+            "channel_id",
+            name="ux_starred_channels_user_account_channel",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    account_id: Mapped[int] = mapped_column(ForeignKey("xtream_accounts.id"), index=True)
+    channel_id: Mapped[str] = mapped_column(String(64), index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "account_id": self.account_id,
+            "channel_id": self.channel_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/backend/tests/test_channel_preview.py
+++ b/backend/tests/test_channel_preview.py
@@ -1,0 +1,333 @@
+"""
+Tests for the Browse EPG stream-preview proxy endpoint.
+
+GET /accounts/{account_id}/channels/{channel_id}/preview relays a live or
+catchup stream through the backend so the provider URL — which embeds the
+account username and password — never reaches the browser. The endpoint must:
+
+- require authentication (admin or download_only),
+- never leak credentials in any response field (error detail, headers),
+- close the provider connection when the client disconnects,
+- enforce the concurrent-preview cap with HTTP 429.
+"""
+import inspect
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import api.channels as channels_api
+from api.channels import preview_channel_stream
+from auth import AuthContext, require_admin_or_download_user
+from database import Base
+from models import XtreamAccount
+
+SECRET_PASSWORD = "sup3r-secret-pw"
+SECRET_USERNAME = "secret-user"
+SERVER_URL = "http://provider.example:8080"
+
+
+def _make_account():
+    return XtreamAccount(
+        name="Provider",
+        server_url=SERVER_URL,
+        username=SECRET_USERNAME,
+        password="",
+        password_encrypted="enc",
+    )
+
+
+def _make_auth():
+    return AuthContext(authenticated=True, role="download_only", user_id=1, is_admin=False)
+
+
+def _make_provider_response(status=200, chunks=(b"\x47" * 188,)):
+    response = MagicMock()
+    response.status = status
+    response.close = MagicMock()
+
+    async def iter_chunked(_size):
+        for chunk in chunks:
+            yield chunk
+
+    response.content.iter_chunked = iter_chunked
+    return response
+
+
+def _make_http_session(response):
+    session = MagicMock()
+    session.get = AsyncMock(return_value=response)
+    session.closed = False
+    session.close = AsyncMock()
+    return session
+
+
+class ChannelPreviewTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        channels_api._active_preview_count = 0
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with self.session_factory() as session:
+            account = _make_account()
+            session.add(account)
+            await session.commit()
+            await session.refresh(account)
+            self.account_id = account.id
+
+    async def asyncTearDown(self):
+        channels_api._active_preview_count = 0
+        await self.engine.dispose()
+
+    async def _call_preview(self, http_session, mode="live", **kwargs):
+        with (
+            patch("api.channels.aiohttp.ClientSession", return_value=http_session),
+            patch(
+                "api.channels.resolve_account_password_with_migration",
+                AsyncMock(return_value=SECRET_PASSWORD),
+            ),
+        ):
+            async with self.session_factory() as session:
+                return await preview_channel_stream(
+                    account_id=kwargs.pop("account_id", self.account_id),
+                    channel_id=kwargs.pop("channel_id", "55"),
+                    mode=mode,
+                    start_timestamp=kwargs.pop("start_timestamp", None),
+                    stop_timestamp=kwargs.pop("stop_timestamp", None),
+                    provider_start=kwargs.pop("provider_start", None),
+                    _auth=_make_auth(),
+                    session=session,
+                )
+
+    # ------------------------------------------------------------------
+    # auth wiring
+    # ------------------------------------------------------------------
+
+    def test_preview_requires_authentication(self):
+        """preview_channel_stream must declare require_admin_or_download_user."""
+        sig = inspect.signature(preview_channel_stream)
+        auth_param = sig.parameters.get("_auth")
+        self.assertIsNotNone(auth_param, "_auth parameter missing from handler")
+        self.assertEqual(auth_param.default.dependency, require_admin_or_download_user)
+
+    # ------------------------------------------------------------------
+    # validation
+    # ------------------------------------------------------------------
+
+    async def test_unknown_account_404(self):
+        response = _make_provider_response()
+        with self.assertRaises(HTTPException) as ctx:
+            await self._call_preview(_make_http_session(response), account_id=9999)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    async def test_catchup_without_timestamps_400(self):
+        response = _make_provider_response()
+        with self.assertRaises(HTTPException) as ctx:
+            await self._call_preview(_make_http_session(response), mode="catchup")
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(channels_api._active_preview_count, 0)
+
+    async def test_catchup_builds_timeshift_url(self):
+        """Catchup mode must hit the provider's timeshift URL with the program duration."""
+        start = int(datetime(2026, 6, 8, 20, 0, tzinfo=timezone.utc).timestamp())
+        stop = start + 3600
+        response = _make_provider_response()
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(
+            http_session, mode="catchup", start_timestamp=start, stop_timestamp=stop
+        )
+        try:
+            requested_url = http_session.get.call_args[0][0]
+            self.assertIn("/timeshift/", requested_url)
+            self.assertIn("/60/", requested_url, "Duration must be 60 minutes for a 1-hour program.")
+            self.assertIn("2026-06-08:20-00", requested_url)
+        finally:
+            await result.body_iterator.aclose()
+
+    async def test_live_mode_builds_live_url(self):
+        response = _make_provider_response()
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session, mode="live")
+        try:
+            requested_url = http_session.get.call_args[0][0]
+            self.assertIn("/live/", requested_url)
+            self.assertTrue(requested_url.endswith("/55.ts"))
+        finally:
+            await result.body_iterator.aclose()
+
+    # ------------------------------------------------------------------
+    # credential leakage
+    # ------------------------------------------------------------------
+
+    async def test_provider_error_detail_has_no_credentials(self):
+        """A provider failure must not echo the URL, username, or password."""
+        response = _make_provider_response(status=404)
+        http_session = _make_http_session(response)
+
+        with self.assertRaises(HTTPException) as ctx:
+            await self._call_preview(http_session)
+
+        self.assertEqual(ctx.exception.status_code, 502)
+        detail = str(ctx.exception.detail)
+        self.assertNotIn(SECRET_PASSWORD, detail)
+        self.assertNotIn(SECRET_USERNAME, detail)
+        self.assertNotIn("provider.example", detail)
+        # Provider connection must be torn down and the slot released
+        response.close.assert_called_once()
+        http_session.close.assert_awaited()
+        self.assertEqual(channels_api._active_preview_count, 0)
+
+    async def test_success_response_has_no_credentials(self):
+        """Headers of a successful preview must not carry the provider URL."""
+        response = _make_provider_response()
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session)
+        try:
+            self.assertEqual(result.media_type, "video/mp2t")
+            for name, value in result.headers.items():
+                self.assertNotIn(SECRET_PASSWORD, value, f"Credential leaked in header {name}")
+                self.assertNotIn(SECRET_USERNAME, value, f"Credential leaked in header {name}")
+                self.assertNotIn("provider.example", value, f"Provider URL leaked in header {name}")
+        finally:
+            await result.body_iterator.aclose()
+
+    # ------------------------------------------------------------------
+    # disconnect handling
+    # ------------------------------------------------------------------
+
+    async def test_client_disconnect_closes_provider_connection(self):
+        """Closing the response generator (client disconnect) must close the provider stream."""
+        chunk = b"\x47" * 188
+        response = _make_provider_response(chunks=(chunk, chunk, chunk))
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session)
+        first = await result.body_iterator.__anext__()
+        self.assertEqual(first, chunk)
+        self.assertEqual(channels_api._active_preview_count, 1)
+
+        # Starlette calls aclose() on the body iterator when the client goes away
+        await result.body_iterator.aclose()
+
+        response.close.assert_called_once()
+        http_session.close.assert_awaited()
+        self.assertEqual(
+            channels_api._active_preview_count,
+            0,
+            "Preview slot must be released on client disconnect.",
+        )
+
+    async def test_stream_end_releases_slot(self):
+        """Draining the stream to its natural end must also release the slot."""
+        response = _make_provider_response(chunks=(b"a", b"b"))
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session)
+        received = [chunk async for chunk in result.body_iterator]
+
+        self.assertEqual(received, [b"a", b"b"])
+        response.close.assert_called_once()
+        http_session.close.assert_awaited()
+        self.assertEqual(channels_api._active_preview_count, 0)
+
+    # ------------------------------------------------------------------
+    # concurrency cap
+    # ------------------------------------------------------------------
+
+    async def test_preview_limit_returns_429(self):
+        """When the concurrent-preview cap is reached, new previews get HTTP 429."""
+        channels_api._active_preview_count = channels_api.PREVIEW_MAX_CONCURRENT
+
+        response = _make_provider_response()
+        http_session = _make_http_session(response)
+        with self.assertRaises(HTTPException) as ctx:
+            await self._call_preview(http_session)
+
+        self.assertEqual(ctx.exception.status_code, 429)
+        http_session.get.assert_not_awaited()
+        self.assertEqual(
+            channels_api._active_preview_count,
+            channels_api.PREVIEW_MAX_CONCURRENT,
+            "A rejected preview must not consume or release a slot.",
+        )
+
+    async def test_slot_freed_after_close_allows_new_preview(self):
+        """Closing an active preview frees its slot for the next request."""
+        channels_api._active_preview_count = channels_api.PREVIEW_MAX_CONCURRENT - 1
+
+        first_response = _make_provider_response()
+        first_session = _make_http_session(first_response)
+        first = await self._call_preview(first_session)
+        self.assertEqual(channels_api._active_preview_count, channels_api.PREVIEW_MAX_CONCURRENT)
+
+        await first.body_iterator.__anext__()
+        await first.body_iterator.aclose()
+        self.assertEqual(
+            channels_api._active_preview_count,
+            channels_api.PREVIEW_MAX_CONCURRENT - 1,
+        )
+
+        second_response = _make_provider_response()
+        second_session = _make_http_session(second_response)
+        second = await self._call_preview(second_session)
+        try:
+            self.assertEqual(second.media_type, "video/mp2t")
+        finally:
+            await second.body_iterator.aclose()
+
+    async def test_disconnect_before_first_byte_releases_via_background(self):
+        """
+        Closing a never-started generator skips its finally block (PEP 525),
+        so the response's background task must release the provider connection
+        and the preview slot. Starlette runs it after the response ends.
+        """
+        response = _make_provider_response()
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session)
+        # Client goes away before the first chunk: Starlette closes the
+        # unstarted body iterator (no-op for cleanup) then runs background.
+        await result.body_iterator.aclose()
+        self.assertIsNotNone(result.background, "Preview response must carry a cleanup background task.")
+        await result.background()
+
+        response.close.assert_called_once()
+        http_session.close.assert_awaited()
+        self.assertEqual(channels_api._active_preview_count, 0)
+
+    async def test_cleanup_is_idempotent(self):
+        """Generator finally plus background task must not double-release the slot."""
+        channels_api._active_preview_count = 1  # an unrelated active preview
+
+        response = _make_provider_response(chunks=(b"a",))
+        http_session = _make_http_session(response)
+
+        result = await self._call_preview(http_session)
+        async for _chunk in result.body_iterator:
+            pass
+        await result.background()  # Starlette always runs background afterwards
+
+        self.assertEqual(
+            channels_api._active_preview_count,
+            1,
+            "Cleanup ran twice: the unrelated preview's slot was stolen.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_starred_channels.py
+++ b/backend/tests/test_starred_channels.py
@@ -1,0 +1,252 @@
+"""
+Tests for per-user starred channels in the Browse channel list.
+
+Feature: users can star channels via POST
+/accounts/{account_id}/channels/{channel_id}/star. Stars are stored per user
+in the starred_channels table, the channel list response carries a `starred`
+flag for the requesting user, and starred channels sort to the top of the
+list while the provider's order is preserved for everything else.
+"""
+import inspect
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from api.channels import get_channels, toggle_channel_star
+from auth import AuthContext, require_admin_or_download_user
+from database import Base
+from models import StarredChannel, User, XtreamAccount
+
+
+def _make_account(name="Provider"):
+    return XtreamAccount(
+        name=name,
+        server_url="http://provider.example:8080",
+        username="user",
+        password="",
+        password_encrypted="enc",
+    )
+
+
+def _make_user(display_name, role="download_only"):
+    return User(
+        role=role,
+        status="active",
+        display_name=display_name,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _make_auth(user_id, is_admin=False):
+    return AuthContext(
+        authenticated=True,
+        role="admin" if is_admin else "download_only",
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+def _fake_channels():
+    return [
+        {"stream_id": 101, "name": "Alpha", "tv_archive": 1, "tv_archive_duration": 7},
+        {"stream_id": 102, "name": "Bravo", "tv_archive": 1, "tv_archive_duration": 7},
+        {"stream_id": 103, "name": "Charlie", "tv_archive": 1, "tv_archive_duration": 7},
+    ]
+
+
+def _make_xtream_client(channels):
+    client = MagicMock()
+    client.get_live_streams = AsyncMock(return_value=channels)
+    client.close = AsyncMock()
+    return client
+
+
+class StarredChannelDBTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with self.session_factory() as session:
+            account = _make_account()
+            user_a = _make_user("User A")
+            user_b = _make_user("User B")
+            session.add_all([account, user_a, user_b])
+            await session.commit()
+            await session.refresh(account)
+            await session.refresh(user_a)
+            await session.refresh(user_b)
+            self.account_id = account.id
+            self.user_a_id = user_a.id
+            self.user_b_id = user_b.id
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _count_stars(self, user_id):
+        async with self.session_factory() as session:
+            result = await session.execute(
+                select(StarredChannel).where(StarredChannel.user_id == user_id)
+            )
+            return len(result.scalars().all())
+
+    async def _get_channels(self, user_id):
+        client = _make_xtream_client(_fake_channels())
+        with (
+            patch("api.channels.XtreamClient", return_value=client),
+            patch(
+                "api.channels.resolve_account_password_with_migration",
+                AsyncMock(return_value="pw"),
+            ),
+        ):
+            async with self.session_factory() as session:
+                return await get_channels(
+                    account_id=self.account_id,
+                    category_id=None,
+                    catchup_only=False,
+                    auth=_make_auth(user_id),
+                    session=session,
+                )
+
+    # ------------------------------------------------------------------
+    # toggle endpoint
+    # ------------------------------------------------------------------
+
+    async def test_toggle_star_creates_then_removes(self):
+        """First toggle stars the channel, second toggle removes the star."""
+        async with self.session_factory() as session:
+            result = await toggle_channel_star(
+                account_id=self.account_id,
+                channel_id="103",
+                auth=_make_auth(self.user_a_id),
+                session=session,
+            )
+        self.assertEqual(result, {"starred": True})
+        self.assertEqual(await self._count_stars(self.user_a_id), 1)
+
+        async with self.session_factory() as session:
+            result = await toggle_channel_star(
+                account_id=self.account_id,
+                channel_id="103",
+                auth=_make_auth(self.user_a_id),
+                session=session,
+            )
+        self.assertEqual(result, {"starred": False})
+        self.assertEqual(await self._count_stars(self.user_a_id), 0)
+
+    async def test_toggle_star_unknown_account_404(self):
+        async with self.session_factory() as session:
+            with self.assertRaises(HTTPException) as ctx:
+                await toggle_channel_star(
+                    account_id=9999,
+                    channel_id="103",
+                    auth=_make_auth(self.user_a_id),
+                    session=session,
+                )
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    # ------------------------------------------------------------------
+    # per-user isolation
+    # ------------------------------------------------------------------
+
+    async def test_star_is_isolated_per_user(self):
+        """User A's star must not appear in user B's channel list."""
+        async with self.session_factory() as session:
+            await toggle_channel_star(
+                account_id=self.account_id,
+                channel_id="102",
+                auth=_make_auth(self.user_a_id),
+                session=session,
+            )
+
+        channels_a = await self._get_channels(self.user_a_id)
+        channels_b = await self._get_channels(self.user_b_id)
+
+        starred_a = {ch["stream_id"] for ch in channels_a if ch["starred"]}
+        starred_b = {ch["stream_id"] for ch in channels_b if ch["starred"]}
+        self.assertEqual(starred_a, {102}, "User A must see their starred channel flagged.")
+        self.assertEqual(starred_b, set(), "User B must not inherit user A's star.")
+
+    async def test_unstar_does_not_touch_other_users_star(self):
+        """Both users star the same channel; unstarring as A keeps B's star."""
+        for user_id in (self.user_a_id, self.user_b_id):
+            async with self.session_factory() as session:
+                await toggle_channel_star(
+                    account_id=self.account_id,
+                    channel_id="101",
+                    auth=_make_auth(user_id),
+                    session=session,
+                )
+
+        async with self.session_factory() as session:
+            await toggle_channel_star(
+                account_id=self.account_id,
+                channel_id="101",
+                auth=_make_auth(self.user_a_id),
+                session=session,
+            )
+
+        self.assertEqual(await self._count_stars(self.user_a_id), 0)
+        self.assertEqual(await self._count_stars(self.user_b_id), 1)
+
+    # ------------------------------------------------------------------
+    # ordering
+    # ------------------------------------------------------------------
+
+    async def test_starred_channels_sort_first(self):
+        """A starred channel floats to the top; the rest keep provider order."""
+        async with self.session_factory() as session:
+            await toggle_channel_star(
+                account_id=self.account_id,
+                channel_id="103",
+                auth=_make_auth(self.user_a_id),
+                session=session,
+            )
+
+        channels = await self._get_channels(self.user_a_id)
+        self.assertEqual(
+            [ch["stream_id"] for ch in channels],
+            [103, 101, 102],
+            "Starred channel must sort first; unstarred channels keep provider order.",
+        )
+        self.assertTrue(channels[0]["starred"])
+
+    async def test_no_stars_keeps_provider_order(self):
+        channels = await self._get_channels(self.user_b_id)
+        self.assertEqual([ch["stream_id"] for ch in channels], [101, 102, 103])
+        self.assertTrue(all(ch["starred"] is False for ch in channels))
+
+
+class StarredChannelWiringTests(unittest.TestCase):
+
+    def test_toggle_star_requires_authenticated_user(self):
+        """toggle_channel_star must use require_admin_or_download_user (download_only users can star)."""
+        sig = inspect.signature(toggle_channel_star)
+        auth_param = sig.parameters.get("auth")
+        self.assertIsNotNone(auth_param, "auth parameter missing from handler")
+        self.assertEqual(auth_param.default.dependency, require_admin_or_download_user)
+
+    def test_get_channels_receives_auth_context(self):
+        """get_channels must depend on require_admin_or_download_user to resolve the user's stars."""
+        sig = inspect.signature(get_channels)
+        auth_param = sig.parameters.get("auth")
+        self.assertIsNotNone(auth_param, "auth parameter missing from handler")
+        self.assertEqual(auth_param.default.dependency, require_admin_or_download_user)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -98,6 +98,8 @@ export const channelsApi = {
     return request(`/accounts/${accountId}/channels?${params}`)
   },
   getChannel: (accountId, channelId) => request(`/accounts/${accountId}/channels/${channelId}`),
+  toggleStar: (accountId, channelId) =>
+    request(`/accounts/${accountId}/channels/${channelId}/star`, { method: 'POST' }),
   getEpg: (accountId, channelId, daysBack = 7, fresh = false) =>
     request(
       `/accounts/${accountId}/channels/${channelId}/epg?days_back=${daysBack}&fresh=${fresh ? 'true' : 'false'}`

--- a/frontend/src/components/EPGGrid.jsx
+++ b/frontend/src/components/EPGGrid.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useEffect } from 'react'
-import { Stack, Text, Group, Badge, ScrollArea, Box, Divider, Tooltip } from '@mantine/core'
+import { Stack, Text, Group, Badge, Button, ScrollArea, Box, Divider, Tooltip } from '@mantine/core'
 import { useMediaQuery } from '@mantine/hooks'
-import { IconClock, IconDownload, IconCalendar } from '@tabler/icons-react'
+import { IconClock, IconDownload, IconCalendar, IconPlayerPlay } from '@tabler/icons-react'
 import {
   getChannelDisplayTime,
   getGuideOffsetHours,
@@ -47,6 +47,9 @@ function ProgramBlock({
   const isClickable = isDownloadable || isSchedulable
   const actionIcon = isDownloadable ? IconDownload : isSchedulable ? IconCalendar : null
   const ActionIcon = actionIcon
+  // Live preview: currently airing programs stream live, past programs still
+  // inside the catchup window stream via timeshift.
+  const canPreview = isCurrent || isDownloadable
 
   return (
     <Box
@@ -113,6 +116,20 @@ function ProgramBlock({
           <Badge size="xs" variant="light" color={isCurrent ? 'green' : isPast ? 'gray' : 'yellow'}>
             {program.duration_minutes}m
           </Badge>
+          {canPreview && (
+            <Button
+              size="compact-xs"
+              variant="light"
+              color="gray"
+              leftSection={<IconPlayerPlay size={12} />}
+              onClick={(e) => {
+                e.stopPropagation()
+                onClick(program, { action: 'preview', mode: isCurrent ? 'live' : 'catchup' })
+              }}
+            >
+              Preview
+            </Button>
+          )}
           {isExpired && (
             <Tooltip label="No longer available — outside this channel's catchup window" withArrow>
               <Badge size="xs" variant="light" color="gray">

--- a/frontend/src/components/PreviewModal.jsx
+++ b/frontend/src/components/PreviewModal.jsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react'
+import { Alert, Badge, Group, Modal, Stack, Text } from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
+
+export default function PreviewModal({ opened, onClose, program, channel, accountId, mode = 'catchup' }) {
+  const previewUrl = useMemo(() => {
+    if (!opened || !program || !accountId) return null
+    const channelId = channel?.stream_id ?? program.channel_id
+    if (channelId == null) return null
+
+    const params = new URLSearchParams({ mode })
+    if (mode === 'catchup') {
+      if (!program.start_timestamp || !program.stop_timestamp) return null
+      params.set('start_timestamp', String(program.start_timestamp))
+      params.set('stop_timestamp', String(program.stop_timestamp))
+      if (program.provider_start) {
+        params.set('provider_start', program.provider_start)
+      }
+    }
+    return `/api/accounts/${accountId}/channels/${encodeURIComponent(channelId)}/preview?${params.toString()}`
+  }, [opened, program, channel, accountId, mode])
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Preview" size="lg" returnFocus={false}>
+      <Stack gap="sm">
+        <Group gap="xs" wrap="nowrap">
+          <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+            <Text fw={600} truncate>
+              {program?.title || 'Program'}
+            </Text>
+            {channel?.name && (
+              <Text size="sm" c="dimmed" truncate>
+                {channel.name}
+              </Text>
+            )}
+          </Stack>
+          <Badge variant="light" color={mode === 'live' ? 'red' : 'yellow'} style={{ flexShrink: 0 }}>
+            {mode === 'live' ? 'Live' : 'Catchup'}
+          </Badge>
+        </Group>
+
+        {previewUrl ? (
+          <video
+            controls
+            autoPlay
+            preload="none"
+            style={{ width: '100%', maxHeight: '60vh', background: '#000', borderRadius: 8 }}
+            src={previewUrl}
+          />
+        ) : (
+          <Alert color="red" icon={<IconAlertCircle size={16} />}>
+            Preview is not available for this program.
+          </Alert>
+        )}
+
+        <Text size="xs" c="dimmed">
+          Previews stream in the original broadcast format, so playback depends on your browser&apos;s
+          codec support. If it stays black, downloading still works normally.
+        </Text>
+      </Stack>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -8,6 +8,7 @@ import {
   Stack,
   TextInput,
   ScrollArea,
+  ActionIcon,
   Badge,
   Loader,
   Box,
@@ -26,6 +27,8 @@ import {
   IconClock,
   IconPlayerPlay,
   IconChevronLeft,
+  IconStar,
+  IconStarFilled,
 } from '@tabler/icons-react'
 import dayjs from 'dayjs'
 
@@ -43,14 +46,16 @@ import {
   getNowUtc,
 } from '../utils/channelTime'
 
-function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, isError, isAdmin }) {
+function ChannelList({ channels, selectedChannel, onSelectChannel, onToggleStar, isLoading, isError, isAdmin }) {
   const [search, setSearch] = useState('')
 
   const filteredChannels = useMemo(() => {
     if (!channels) return []
-    if (!search) return channels
+    // Starred channels float to the top; provider order is kept otherwise
+    const sorted = [...channels].sort((a, b) => (b.starred ? 1 : 0) - (a.starred ? 1 : 0))
+    if (!search) return sorted
     const searchLower = search.toLowerCase()
-    return channels.filter((ch) => ch.name?.toLowerCase().includes(searchLower))
+    return sorted.filter((ch) => ch.name?.toLowerCase().includes(searchLower))
   }, [channels, search])
 
   if (isLoading) {
@@ -133,6 +138,19 @@ function ChannelList({ channels, selectedChannel, onSelectChannel, isLoading, is
                     </Text>
                   )}
                 </Stack>
+                <ActionIcon
+                  variant="subtle"
+                  color={channel.starred ? 'yellow' : 'gray'}
+                  size="sm"
+                  aria-label={channel.starred ? 'Unstar channel' : 'Star channel'}
+                  title={channel.starred ? 'Unstar channel' : 'Star channel'}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onToggleStar?.(channel)
+                  }}
+                >
+                  {channel.starred ? <IconStarFilled size={16} /> : <IconStar size={16} />}
+                </ActionIcon>
               </Group>
             </Card>
           ))}
@@ -416,6 +434,27 @@ export default function Browse() {
     enabled: !!selectedAccountId,
     retry: false,
   })
+
+  const toggleStarMutation = useMutation({
+    mutationFn: (channel) => channelsApi.toggleStar(selectedAccountId, channel.stream_id),
+    onSuccess: (data, channel) => {
+      queryClient.setQueryData(['channels', selectedAccountId], (old) =>
+        old?.map((ch) =>
+          ch.stream_id?.toString() === channel.stream_id?.toString()
+            ? { ...ch, starred: data.starred }
+            : ch
+        )
+      )
+    },
+  })
+
+  const handleToggleStar = useCallback(
+    (channel) => {
+      if (!selectedAccountId || toggleStarMutation.isPending) return
+      toggleStarMutation.mutate(channel)
+    },
+    [selectedAccountId, toggleStarMutation]
+  )
 
   // Fetch EPG for selected channel, going back as far as its catchup archive allows
   const selectedChannelArchiveDays = getChannelArchiveDays(selectedChannel)
@@ -957,6 +996,7 @@ export default function Browse() {
                     channels={channels}
                     selectedChannel={selectedChannel}
                     onSelectChannel={handleSelectChannel}
+                    onToggleStar={handleToggleStar}
                     isLoading={channelsLoading}
                     isError={channelsIsError}
                     isAdmin={authStatus?.is_admin}
@@ -990,6 +1030,7 @@ export default function Browse() {
                     channels={channels}
                     selectedChannel={selectedChannel}
                     onSelectChannel={handleSelectChannel}
+                    onToggleStar={handleToggleStar}
                     isLoading={channelsLoading}
                     isError={channelsIsError}
                     isAdmin={authStatus?.is_admin}

--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -35,6 +35,7 @@ import dayjs from 'dayjs'
 import { accountsApi, authApi, channelsApi, downloadsApi, epgApi, settingsApi, vodApi } from '../api'
 import EPGGrid from '../components/EPGGrid'
 import DownloadModal from '../components/DownloadModal'
+import PreviewModal from '../components/PreviewModal'
 import ScheduleModal from '../components/ScheduleModal'
 import MovieModal from '../components/VodMovieModal'
 import SeriesModal from '../components/VodSeriesModal'
@@ -388,6 +389,7 @@ export default function Browse() {
   const [selectedChannel, setSelectedChannel] = useState(null)
   const [downloadProgram, setDownloadProgram] = useState(null)
   const [scheduleProgram, setScheduleProgram] = useState(null)
+  const [previewTarget, setPreviewTarget] = useState(null)
   const [programSearch, setProgramSearch] = useState('')
   const [globalSearch, setGlobalSearch] = useState('')
   const [debouncedGlobalSearch] = useDebouncedValue(globalSearch, 400)
@@ -712,6 +714,10 @@ export default function Browse() {
   }, [browseTab, vodTab, isMobile, viewportHeight])
 
   const handleProgramClick = (program, meta = {}) => {
+    if (meta.action === 'preview') {
+      setPreviewTarget({ program, mode: meta.mode || 'catchup' })
+      return
+    }
     if (meta.action === 'schedule') {
       setScheduleProgram(program)
       return
@@ -1472,6 +1478,14 @@ export default function Browse() {
         channel={selectedChannel}
         accountId={selectedAccountId}
         guideOffsetHours={selectedGuideOffsetHours}
+      />
+      <PreviewModal
+        opened={!!previewTarget}
+        onClose={() => setPreviewTarget(null)}
+        program={previewTarget?.program}
+        channel={selectedChannel}
+        accountId={selectedAccountId}
+        mode={previewTarget?.mode || 'catchup'}
       />
       <MovieModal
         opened={!!selectedMovie}


### PR DESCRIPTION
## Summary
Audit batch B13 — two Browse-page features:

1. **Starred channels** — star icon on each channel row; starred channels float to the top of the list. Per-user persistence (new `starred_channels` table, unique per user+account+channel; download-only users can star too). Toggle endpoint + `starred` flag in the channel list response; React Query cache updated in place for instant feedback.
2. **Preview before download** — a Preview button on currently-airing programs (live stream) and in-window past programs (timeshift stream), playing in an HTML5 video modal. The backend proxies the stream (auth required) so the credential-bearing provider URL never reaches the browser — verified by tests on every response field including errors. Caps: 2 concurrent previews (429), 5-minute max; provider connection torn down on modal close/client disconnect, including the disconnect-before-first-byte edge via a Starlette BackgroundTask.

## Steps to test
```
cd backend && python -m unittest discover -s tests   # 934 green
cd frontend && npm run build                          # passes
```
21 new regression tests (`test_starred_channels.py`, `test_channel_preview.py`) — auth, per-user isolation, ordering, credential leakage, slot release, disconnect cleanup. Note: TS-in-<video> playback varies by browser; stream teardown is exercised regardless.

CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)