### PR TITLE
design: fix Browse EPG right panel wording when provider unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1060,7 +1060,7 @@ export default function Browse() {
                       <IconVideo size={48} opacity={0.3} />
                       <Text c="dimmed" ta="center">
                         {channelsIsError
-                          ? 'Channel guide will appear here once your provider is connected.'
+                          ? 'Channel guide will appear here once your provider connection is restored.'
                           : 'Select a channel to view its program guide.'}
                       </Text>
                     </Stack>


### PR DESCRIPTION
## What a user would notice

When their IPTV provider is temporarily unreachable, the Browse EPG page now says **"Channel guide will appear here once your provider connection is restored"** instead of "once your provider is connected." The new wording makes it clear this is a temporary issue, not a missing setup step.

## What changed

One line in `frontend/src/pages/Browse.jsx`. No logic changes, no backend changes.

When the channels panel shows an error (provider unreachable), the right-hand guide panel previously said "once your provider is **connected**." The word "connected" implies a first-time setup task. A non-technical user who already added their provider account would read this and think they had forgotten to do something during setup, not that their connection is temporarily down.

Changed to "once your provider **connection is restored**" - this correctly frames the situation as a known, temporary connectivity problem that will resolve on its own.

## Before / After

**BEFORE (desktop):** Right panel says "once your provider is connected" - implies setup task.

**AFTER (desktop):** Right panel says "once your provider connection is restored" - implies temporary issue.

Screenshots posted in #design.

## How it was tested

- Started app locally (backend port 4177, frontend port 4178)
- Both providers in dev DB are unreachable (example URLs), so the error state is always visible
- Playwright screenshot confirmed before and after wording on desktop (1280x800) and mobile (390x844)
- On mobile, the right panel is hidden (single-column layout), so no visible change there - correct behavior