### PR TITLE
Wire FoldersStatus card into Settings Recording section

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -51,6 +51,7 @@ import {
 import { adminPlexApi, adminUsersApi, authApi, epgApi, settingsApi } from '../api'
 import AccountsSection from '../components/settings/AccountsSection'
 import LogsSection from '../components/settings/LogsSection'
+import FoldersStatus from '../components/settings/FoldersStatus'
 
 function isPlexNotConnectedError(message) {
   return (message || '').toLowerCase().includes('plex account is not connected')
@@ -755,6 +756,7 @@ export default function Settings() {
           styles={{ input: { textOverflow: 'ellipsis' } }}
           title={formData.completed_folder}
         />
+        <FoldersStatus />
       </Stack>
 
       <Divider variant="dashed" />


### PR DESCRIPTION
## Summary
Follow-up to #360: the FoldersStatus component (recordings folder paths + write-test badges) was built but left unwired to avoid clashing with in-progress Settings.jsx work. This adds the import and renders `<FoldersStatus />` under the Storage folder inputs in the Recording section — two lines.

## Steps to test
Open Settings → Recording: below the folder inputs, a card shows each resolved folder path with a Writable / Not writable / Missing badge and failure reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)