### PR TITLE
fix: reject application/json error bodies in content-type guard

### DIFF
--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1747,7 +1747,10 @@ class DownloadManager:
                     raise Exception(f"HTTP {response.status}: {response.reason}")
 
                 content_type = response.headers.get("Content-Type", "")
-                if not needs_restart and content_type.lower().startswith("text/"):
+                _ct_lower = content_type.lower()
+                if not needs_restart and (
+                    _ct_lower.startswith("text/") or _ct_lower.startswith("application/json")
+                ):
                     raise Exception(
                         f"Provider returned an error page (Content-Type: {content_type}). "
                         "The catchup window may have expired or be unavailable."
@@ -1847,7 +1850,8 @@ class DownloadManager:
                 if response.status not in (200, 206):
                     raise Exception(f"HTTP {response.status}: {response.reason}")
                 restart_ct = response.headers.get("Content-Type", "")
-                if restart_ct.lower().startswith("text/"):
+                _rct_lower = restart_ct.lower()
+                if _rct_lower.startswith("text/") or _rct_lower.startswith("application/json"):
                     raise Exception(
                         f"Provider returned an error page (Content-Type: {restart_ct}). "
                         "The catchup window may have expired or be unavailable."

--- a/backend/tests/test_download_json_body.py
+++ b/backend/tests/test_download_json_body.py
@@ -1,0 +1,130 @@
+"""
+Regression test: provider returns HTTP 200 with an application/json body (error).
+
+Some Xtream Codes providers return JSON error messages with HTTP 200 instead of
+an HTTP error status. For example:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    {"error": "Stream unavailable", "code": "403"}
+
+Before the fix, _download_file passes the text/* guard (application/json does not
+start with "text/"), writes the small JSON body to the output file, and marks the
+download COMPLETED. The user ends up with a corrupt recording that Plex/Jellyfin
+cannot play.
+
+After the fix, _download_file raises as soon as it sees application/json so the
+download is marked FAILED with a clear message.
+
+This test currently FAILS: no exception is raised for application/json bodies.
+"""
+
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.download_manager import DownloadManager
+
+
+def _make_response(status, content_type, chunks):
+    response = MagicMock()
+    response.status = status
+    response.reason = "OK"
+    response.content_length = None
+    response.headers = {"Content-Type": content_type}
+
+    async def iter_chunked(_size):
+        for chunk in chunks:
+            yield chunk
+
+    response.content.iter_chunked = iter_chunked
+    return response
+
+
+def _make_client_session(response):
+    get_cm = MagicMock()
+    get_cm.__aenter__ = AsyncMock(return_value=response)
+    get_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = get_cm
+
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    return client_cm
+
+
+class JsonBodyRejectionTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_json_200_raises_exception(self):
+        """HTTP 200 with application/json body must raise, not write JSON to disk.
+
+        Providers that return JSON error messages with HTTP 200 and
+        Content-Type: application/json bypass the existing text/* guard.
+        The JSON body gets written to the output .ts file and the download
+        is silently marked COMPLETED with a corrupt, non-playable file.
+        """
+        json_body = b'{"error": "Stream unavailable", "code": "403"}'
+        response = _make_response(200, "application/json", [json_body])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    with self.assertRaises(Exception) as ctx:
+                        await manager._download_file(
+                            "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts",
+                            tmp_path,
+                            1,
+                            db_session,
+                            offset=0,
+                        )
+
+        self.assertIn(
+            "error",
+            str(ctx.exception).lower(),
+            "Exception message must indicate the response was not a valid stream.",
+        )
+
+    async def test_json_200_session_limit_raises_exception(self):
+        """HTTP 200 with application/json session-limit error must raise."""
+        json_body = b'{"message": "maximum connections reached", "status": "error"}'
+        response = _make_response(200, "application/json; charset=utf-8", [json_body])
+        client_cm = _make_client_session(response)
+
+        manager = DownloadManager()
+        db_session = AsyncMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as f:
+            tmp_path = f.name
+
+        with patch("services.download_manager.aiohttp.ClientSession", return_value=client_cm):
+            with patch.object(manager, "_broadcast_log", AsyncMock()):
+                with patch.object(manager, "_broadcast_progress", AsyncMock()):
+                    with self.assertRaises(Exception):
+                        await manager._download_file(
+                            "http://provider/timeshift/user/pass/60/2026-06-06:00-00/1.ts",
+                            tmp_path,
+                            1,
+                            db_session,
+                            offset=0,
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Some IPTV providers return JSON error messages (like "maximum connections reached" or "auth failed") with HTTP 200 instead of an error status code. The download manager already rejects responses with `Content-Type: text/*` (HTML/plain error pages), but `application/json` does not start with `text/`, so it slipped through.

**Before:** Provider returns HTTP 200 with `Content-Type: application/json` body `{"error": "Stream unavailable"}`. The JSON body (~40 bytes) is written to the `.ts` file. `downloaded_bytes` is non-zero so the empty-body guard also misses. Download is marked COMPLETED. User ends up with a corrupt, non-playable recording in Plex/Jellyfin (shows as 0:00 duration).

**After:** Both content-type guards (initial request and the restart path) now also reject `application/json`. Download is immediately marked FAILED with the message "Provider returned an error page (Content-Type: application/json)."

## Files changed

- `backend/services/download_manager.py`: extend content-type guard at both check points (initial request path and needs_restart path)
- `backend/tests/test_download_json_body.py`: regression tests covering a plain JSON error body and a session-limit error with `; charset=utf-8` suffix

## Test run

Before fix:
```
FAIL: test_json_200_raises_exception - Exception not raised
FAIL: test_json_200_session_limit_raises_exception - Exception not raised
```

After fix:
```
Ran 2 tests in 0.005s
OK

Ran 996 tests in 8.808s
OK
```

## Related

- Regression test PR: #356 (approved, tests were confirmed red on main)
- Task thread: 1514041003672076308