### PR TITLE
design: add Settings link to Browse right panel when provider unreachable

### DIFF
--- a/frontend/src/pages/Browse.jsx
+++ b/frontend/src/pages/Browse.jsx
@@ -1106,9 +1106,20 @@ export default function Browse() {
                     <Stack align="center" justify="center" style={{ flex: 1, minHeight: 0 }}>
                       <IconVideo size={48} opacity={0.3} />
                       <Text c="dimmed" ta="center">
-                        {channelsIsError
-                          ? 'Channel guide will appear here once your provider connection is restored.'
-                          : 'Select a channel to view its program guide.'}
+                        {channelsIsError ? (
+                          <>
+                            Channel guide will appear here once your provider connection is restored.{' '}
+                            {authStatus?.is_admin ? (
+                              <Link to="/settings?section=accounts" style={{ color: 'var(--mantine-color-orange-5)' }}>
+                                Check Settings → Accounts.
+                              </Link>
+                            ) : (
+                              'Contact your administrator.'
+                            )}
+                          </>
+                        ) : (
+                          'Select a channel to view its program guide.'
+                        )}
                       </Text>
                     </Stack>
                   )}


### PR DESCRIPTION
## What changed

When the IPTV provider cannot be reached, the Browse EPG page shows two areas telling the user something is wrong: a small left panel with "Could not reach your provider" and a large right panel with "Channel guide will appear here once your provider connection is restored."

Before this change, the right panel had no action link. A non-technical user staring at the large empty right panel had no obvious next step.

After this change, the right panel appends a clickable link: admins see "Check Settings → Accounts." and non-admin users see "Contact your administrator."

## Before

The large right panel shows a dead-end message with no link and no next step. Screenshots posted in #design.

## After

The right panel message ends with "Check Settings → Accounts." as an orange link, matching the style already used in the left panel. One click takes the user where they need to go. Screenshots posted in #design.

## What was not changed

No logic, no backend, no other screens. One JSX block in Browse.jsx modified.

## Test plan

- Start the app without a working IPTV provider configured
- Open Browse EPG
- Confirm the right panel message ends with a "Check Settings → Accounts." link
- Click the link and confirm it navigates to Settings, Accounts section
- Log in as a non-admin user and confirm the right panel shows "Contact your administrator." with no link