### PR TITLE
Add GPU encoding via jellyfin-ffmpeg and hardware-accel status in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Added: GPU-accelerated encoding in Docker, with a plain-language GPU status panel in Settings
+
+**What you would notice:** The Docker image can now encode recordings on your GPU. If your server has an Intel, AMD, or NVIDIA GPU visible to the container, re-encoding finished recordings is much faster and uses far less CPU. The Settings page tells you where you stand in plain language: a green "GPU encoding ready" badge with the detected vendor when everything works, a note when the driver was set manually, and a clear explanation when no GPU is available (for example, Docker Desktop on macOS and Windows does not share the host GPU with containers, so encoding falls back to the CPU; slower, but everything still works).
+
+**What changed:** The Docker image now installs `jellyfin-ffmpeg7` from the Jellyfin apt repository (bundles VAAPI, QSV, NVENC, and AMF encoder builds) instead of copying ffmpeg binaries out of the LinuxServer ffmpeg image. Compatibility symlinks keep `/usr/local/bin/ffmpeg` and `ffprobe` working, and `CATCHUP_FFMPEG_PATH`, `CATCHUP_FFPROBE_PATH`, `LIBVA_DRIVERS_PATH`, and `LD_LIBRARY_PATH` point at the bundled tools and drivers. The Settings frontend renders the VAAPI diagnostics the backend already exposes via `/api/settings/tools` as a status badge, mapping the kernel driver or PCI vendor id to a friendly vendor name and explaining each detection state (auto-detected, manual override, device missing, sysfs unavailable).
+
+---
+
 ### Added: Back up your scheduled recordings, and let failed downloads retry themselves
 
 **What you would notice:** Two additions around scheduled recordings. First, the Scheduled Recordings page has new Export and Import buttons: Export saves your schedules to a JSON file, and Import restores them later — handy before reinstalling, when moving to another machine, or simply as a backup. Importing runs each entry through the same checks as scheduling normally does, so programs that are already scheduled, have already ended, or belong to an IPTV account this server does not have are skipped — and the result tells you exactly how many schedules were created and what was skipped and why. Admins export everyone's schedules; other users export and restore only their own. Second, admins get a small "Auto-retry failed downloads" switch on the same page (off by default). With it on, a catchup download that fails — for example because your provider hiccuped — is retried automatically: up to 3 times, at least 10 minutes apart, and only while the program is still inside the channel's catchup window, so Mustarrd never wastes attempts on programs that have aged out. Recordings you cancelled are never retried behind your back.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,13 +33,11 @@ RUN npm ci
 COPY frontend ./
 RUN npm run build
 
-FROM lscr.io/linuxserver/ffmpeg:latest AS lsffmpeg
-
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble
 
 WORKDIR /app/backend
 
-# Runtime deps
+# Runtime deps + jellyfin-ffmpeg (bundles nvenc/qsv/vaapi/amf builds)
 RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list \
   && sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list \
   && apt-get update -o Acquire::Retries=3 \
@@ -47,53 +45,37 @@ RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubun
     python3 \
     python3-venv \
     python3-pip \
+    ca-certificates \
+    curl \
+    gnupg \
+    gosu \
+    libargtable2-0 \
     libavcodec60 \
     libavformat60 \
     libavutil58 \
     libswscale7 \
-    libswresample4 \
     libpostproc57 \
-    libargtable2-0 \
-    libedit2 \
-    libelf1 \
-    libexpat1 \
-    libglib2.0-0 \
-    libgomp1 \
-    libpciaccess0 \
-    libv4l-0 \
-    libwayland-client0 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb-dri2-0 \
-    libxcb-dri3-0 \
-    libxcb-present0 \
-    libxcb-randr0 \
-    libxcb-shape0 \
-    libxcb-shm0 \
-    libxcb-sync1 \
-    libxcb-xfixes0 \
-    libxcb1 \
-    libxext6 \
-    libxfixes3 \
-    libxshmfence1 \
-    libxml2 \
-    ocl-icd-libopencl1 \
-    gosu \
-  && for pkg in vainfo libva2 libva-drm2 libdrm2 libasound2t64 libasound2 libllvm18; do \
-       apt-get install -y --no-install-recommends -o Acquire::Retries=3 "$pkg" || true; \
-     done \
+  && install -d -m 0755 /etc/apt/keyrings \
+  && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg \
+  && . /etc/os-release \
+  && echo "deb [signed-by=/etc/apt/keyrings/jellyfin.gpg] https://repo.jellyfin.org/${ID} ${VERSION_CODENAME} main" \
+       > /etc/apt/sources.list.d/jellyfin.list \
+  && apt-get update -o Acquire::Retries=3 \
+  && apt-get install -y --no-install-recommends jellyfin-ffmpeg7 \
   && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-       for pkg in mesa-va-drivers i965-va-driver intel-media-va-driver libigdgmm12; do \
+       for pkg in mesa-va-drivers intel-media-va-driver i965-va-driver; do \
          apt-get install -y --no-install-recommends -o Acquire::Retries=3 "$pkg" || true; \
        done; \
      fi \
   && rm -rf /var/lib/apt/lists/*
 
 ENV \
-    LIBVA_DRIVERS_PATH="/usr/local/lib/x86_64-linux-gnu/dri:/usr/local/lib/aarch64-linux-gnu/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/aarch64-linux-gnu/dri" \
-    LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib/x86_64-linux-gnu:/usr/local/lib/aarch64-linux-gnu" \
-    CATCHUP_FFMPEG_PATH="/usr/local/bin/ffmpeg" \
-    CATCHUP_FRONTEND_DIST="/app/frontend/dist"
+    CATCHUP_FFMPEG_PATH="/usr/lib/jellyfin-ffmpeg/ffmpeg" \
+    CATCHUP_FFPROBE_PATH="/usr/lib/jellyfin-ffmpeg/ffprobe" \
+    CATCHUP_FRONTEND_DIST="/app/frontend/dist" \
+    LIBVA_DRIVERS_PATH="/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/aarch64-linux-gnu/dri" \
+    LD_LIBRARY_PATH="/usr/lib/jellyfin-ffmpeg/lib"
 
 # Install dependencies in a venv (PEP 668 safe)
 ENV VENV_PATH="/opt/venv"
@@ -115,11 +97,9 @@ COPY comskip.ini /app/comskip.ini
 COPY --from=comskip-builder /tmp/comskip/comskip /usr/local/bin/comskip
 RUN chmod +x /usr/local/bin/comskip
 
-# Copy ffmpeg + drivers from LinuxServer ffmpeg image
-COPY --from=lsffmpeg /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
-COPY --from=lsffmpeg /usr/local/bin/ffprobe /usr/local/bin/ffprobe
-COPY --from=lsffmpeg /usr/local/lib/ /usr/local/lib/
-COPY --from=lsffmpeg /usr/local/share/ /usr/local/share/
+# Symlink jellyfin-ffmpeg so callers expecting /usr/local/bin/ffmpeg keep working
+RUN ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
+  && ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe
 
 # Ensure repo-provided tools are executable if present
 RUN chmod +x /app/tools/bin/*/ffmpeg /app/tools/bin/*/ffprobe /app/tools/bin/*/comskip 2>/dev/null || true

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -57,6 +57,74 @@ function isPlexNotConnectedError(message) {
   return (message || '').toLowerCase().includes('plex account is not connected')
 }
 
+const VAAPI_VENDOR_NAMES = {
+  '0x8086': 'Intel',
+  '0x1002': 'AMD',
+  '0x10de': 'NVIDIA',
+}
+
+const VAAPI_KERNEL_LABELS = {
+  amdgpu: 'AMD',
+  radeon: 'AMD (legacy)',
+  i915: 'Intel',
+  xe: 'Intel (Xe)',
+  nouveau: 'NVIDIA (open driver)',
+  nvidia: 'NVIDIA',
+}
+
+function describeHardwareAccel(vaapi) {
+  if (!vaapi || !vaapi.enabled) {
+    return null
+  }
+  const vendorLabel =
+    VAAPI_KERNEL_LABELS[(vaapi.kernel_driver || '').toLowerCase()] ||
+    VAAPI_VENDOR_NAMES[(vaapi.vendor || '').toLowerCase()] ||
+    null
+
+  switch (vaapi.source) {
+    case 'auto-detected':
+      return {
+        color: 'green',
+        icon: <IconCheck size={12} />,
+        label: `GPU encoding ready${vendorLabel ? ` — ${vendorLabel}` : ''}`,
+        detail: `Recordings will be encoded on your ${vendorLabel || 'GPU'} (driver: ${vaapi.driver}).`,
+      }
+    case 'env':
+      return {
+        color: 'green',
+        icon: <IconCheck size={12} />,
+        label: 'GPU encoding ready (manual)',
+        detail: `Using driver "${vaapi.driver}" from the LIBVA_DRIVER_NAME environment variable.`,
+      }
+    case 'device-missing':
+      return {
+        color: 'gray',
+        icon: <IconAlertCircle size={12} />,
+        label: 'GPU encoding unavailable',
+        detail:
+          'No GPU is visible to the app. This is expected on macOS and Windows — Docker Desktop doesn\'t share the host GPU with containers. Recordings will be encoded on the CPU, which works fine but is slower.',
+      }
+    case 'sysfs-unavailable':
+      return {
+        color: 'yellow',
+        icon: <IconAlertCircle size={12} />,
+        label: 'GPU found, details unknown',
+        detail:
+          'A GPU device was found but the app couldn\'t identify it. Hardware acceleration may still work — try selecting VA-API and running a test transcode.',
+      }
+    case 'auto':
+    default:
+      return {
+        color: 'yellow',
+        icon: <IconAlertCircle size={12} />,
+        label: vendorLabel ? `GPU found — ${vendorLabel}` : 'GPU found',
+        detail: vendorLabel
+          ? `Detected a ${vendorLabel} GPU but couldn\'t auto-pick a driver. Set LIBVA_DRIVER_NAME manually if encoding fails.`
+          : 'Detected a GPU but couldn\'t identify a matching driver. Set LIBVA_DRIVER_NAME manually if encoding fails.',
+      }
+  }
+}
+
 function TemplateSection({ label, template, variables, example, renderedExample, onChange }) {
   const inputRef = useRef(null)
 
@@ -846,13 +914,18 @@ export default function Settings() {
             {toolsStatus.comskip?.error && (
               <Text size="xs" c="dimmed">Comskip error: {toolsStatus.comskip.error}</Text>
             )}
-            {toolsStatus.vaapi?.enabled && (
-              <Text size="xs" c="dimmed">
-                VA-API driver: {toolsStatus.vaapi.driver || 'auto/unset'}
-                {toolsStatus.vaapi.source ? ` (${toolsStatus.vaapi.source})` : ''}
-                {toolsStatus.vaapi.kernel_driver ? `, kernel: ${toolsStatus.vaapi.kernel_driver}` : ''}
-              </Text>
-            )}
+            {(() => {
+              const hwStatus = describeHardwareAccel(toolsStatus.vaapi)
+              if (!hwStatus) return null
+              return (
+                <Stack gap={4}>
+                  <Badge color={hwStatus.color} variant="light" leftSection={hwStatus.icon} style={{ alignSelf: 'flex-start' }}>
+                    {hwStatus.label}
+                  </Badge>
+                  <Text size="xs" c="dimmed">{hwStatus.detail}</Text>
+                </Stack>
+              )
+            })()}
           </Stack>
         )}
 
@@ -936,12 +1009,16 @@ export default function Settings() {
             />
           )}
 
-          {toolsStatus?.vaapi?.enabled && formData.hw_accel === 'vaapi' && isFullTranscode && (
-            <Text size="xs" c="dimmed">
-              Active VA-API driver: {toolsStatus.vaapi.driver || 'auto/unset'}.
-              {toolsStatus.vaapi.source ? ` Source: ${toolsStatus.vaapi.source}.` : ''}
-            </Text>
-          )}
+          {toolsStatus?.vaapi?.enabled && formData.hw_accel === 'vaapi' && isFullTranscode && (() => {
+            const hwStatus = describeHardwareAccel(toolsStatus.vaapi)
+            if (!hwStatus) return null
+            return (
+              <Alert color={hwStatus.color === 'green' ? 'green' : hwStatus.color === 'gray' ? 'blue' : 'yellow'} variant="light" icon={hwStatus.icon}>
+                <Text size="sm" fw={500}>{hwStatus.label}</Text>
+                <Text size="xs" c="dimmed" mt={4}>{hwStatus.detail}</Text>
+              </Alert>
+            )
+          })()}
 
           {isTranscoding && (
             <SettingRow


### PR DESCRIPTION
## Summary

Lands the owner's WIP for GPU-accelerated encoding (backend VAAPI diagnostics already merged; this adds the missing surface):

- **Dockerfile**: installs `jellyfin-ffmpeg7` from the Jellyfin apt repository (bundles VAAPI/QSV/NVENC/AMF encoder builds) instead of copying binaries from the LinuxServer ffmpeg image. Compatibility symlinks keep `/usr/local/bin/ffmpeg`/`ffprobe` working; `CATCHUP_FFMPEG_PATH`, `CATCHUP_FFPROBE_PATH` (read in `post_processor.py`), `LIBVA_DRIVERS_PATH`, `LD_LIBRARY_PATH` point at the bundled tools/drivers.
- **Settings.jsx**: renders the VAAPI diagnostics from `/api/settings/tools` as a hardware-accel status badge. Vendor name mapped from kernel driver (`amdgpu`/`i915`/`xe`/…) or PCI vendor id, with plain-language detail per detection state (auto-detected, env override, device missing, sysfs unavailable).
- CHANGELOG entry included (no em dashes, per the style rule #364 enforces).

## Steps to test

- `cd frontend && npm test` (46 passing) and `npm run build` (passes)
- `docker compose build` then on a host with a GPU: Settings → tools section shows "GPU encoding ready" with the vendor; on Docker Desktop (macOS/Windows): grey "GPU encoding unavailable" badge with explanation
- Note: Docker image not built in this environment; the Dockerfile change needs a CI/host build to verify. No screenshots (no live browser in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)