### PR TITLE
Update CLAUDE.md: tests, security, VOD/Plex, config docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Mustarrd is an IPTV catchup DVR web app. It connects to Xtream Codes IPTV servers, browses past EPG programs, and downloads catchup/timeshift streams with smart filename templating, commercial skip (Comskip), and GPU/CPU re-encoding (FFmpeg).
+Mustarrd is an IPTV catchup DVR web app. It connects to Xtream Codes IPTV servers, browses past EPG programs, and downloads catchup/timeshift streams with smart filename templating, commercial skip (Comskip), and GPU/CPU re-encoding (FFmpeg). It also downloads provider VOD (movies/series) and integrates with Plex (Plex-login users, push recordings to a Plex library).
 
 ## Development Commands
 
@@ -23,44 +23,67 @@ npm install
 npm run dev
 ```
 
-**Docker** (full stack):
+**Tests** (backend: stdlib `unittest`, no pytest; frontend: Vitest + React Testing Library):
+```bash
+cd backend
+python -m unittest discover -s tests          # full suite, ~1000 tests, runs in seconds
+python -m unittest tests.test_disk_full       # single module
+
+cd frontend
+npm test                                      # Vitest single run (test:watch for watch mode)
+```
+CI runs both suites on every PR (`.github/workflows/tests.yml`). Bug-fix PRs are expected to add a regression test in `backend/tests/`.
+
+**Docker** (single container, backend serves the built frontend on 4177):
 ```bash
 docker-compose up -d
-# backend: 4177, frontend: 4178
 ```
-
-No automated test suite exists. If adding tests: `backend/tests/` or `frontend/src/__tests__/`.
 
 ## Architecture
 
 ### Download Pipeline
 1. User picks a channel+EPG program → frontend calls `POST /api/downloads/`
-2. `download_manager` (service) picks up the queued record and fetches the Xtream catchup URL
-3. FFmpeg downloads the TS stream; `post_processor` handles Comskip and/or transcoding
-4. Finished file moves to the completed folder
+2. `download_manager` (service) picks up the queued record and builds the Xtream catchup URL (`download_builder`)
+3. The TS stream downloads; `post_processor` handles Comskip and/or FFmpeg transcode/remux
+4. Finished file moves to the completed folder (named via `file_namer` / `vod_namer` templates)
 5. Real-time progress flows over WebSocket at `/api/downloads/ws`
 
-### Background Managers (started in `backend/main.py` lifespan)
-- `download_manager` — concurrent download queue; resumes in-progress tasks on restart
-- `post_processor` — Comskip + FFmpeg re-encode/remux pipeline
-- `epg_ingest_manager` — periodically refreshes EPG from Xtream for all accounts
-- `scheduled_manager` — fires scheduled recordings as their time arrives
+Disk-space preflight (`services/disk_space.py`) blocks downloads when space is low.
+
+### Background Tasks (started in `backend/main.py` lifespan)
+- `download_manager.process_queue()` — concurrent download queue; recovers in-progress tasks on restart
+- `download_manager.process_post_queue()` — drives post-processing (the `post_processor` service does Comskip + FFmpeg work)
+- `scheduled_manager.process_queue()` — fires scheduled recordings as their time arrives
+- `epg_ingest_manager.process_queue()` — periodically refreshes EPG from Xtream for all accounts
+- `server_log_bridge` — streams server logs to the frontend Logs page
+
+### API Routers (`backend/api/`)
+`auth`, `accounts`, `channels`, `downloads`, `schedules`, `vod`, `settings`, `epg`, `logs`, `onboarding`, `admin_users` (download-only user management), `admin_plex` (Plex server linking).
 
 ### Database & Migrations
-SQLite via async SQLAlchemy. Schema is created and migrated on every startup in `backend/database.py` using lightweight `ALTER TABLE` checks — no migration framework. `app_settings` table holds global config (padding defaults, transcode flags, etc.).
+SQLite via async SQLAlchemy. Schema is created and migrated on every startup in `backend/database.py` using lightweight `ALTER TABLE` checks — no migration framework. `app_settings` table holds global config (padding defaults, transcode flags, etc.). Account/Plex secrets are encrypted at rest with AES-GCM (`services/credential_crypto.py`).
 
 Key constraint: enabling Comskip forces `transcode_enabled = true`; enabling commercial removal forces `remux_only = false`.
 
-### Authentication (current branch: `codex/authentication`)
-Session-based auth implemented in `backend/auth.py` and `backend/api/auth.py`. Optional/progressive: first run requires no password; once an admin password is set via `/auth/setup`, protected endpoints require login. Frontend uses `ProtectedRoute` in `App.jsx` and checks `/api/auth/status` on load.
+### Authentication & Security
+Session-based auth in `backend/auth.py` and `backend/api/auth.py`. Two roles on the `users` table: `admin` and `download_only`. Download-only users can browse/schedule/download but not touch Settings; they sign in with username/password or via Plex OAuth PIN flow (`services/plex_service.py`, identities in `user_identities`).
+
+- First run: `SetupLockdownMiddleware` returns 423 for all API routes until an admin password is set via `/api/auth/setup` (frontend Onboarding page)
+- CSRF: unsafe methods require the token from `/api/auth/csrf` in a header, plus Origin validation (`backend/security.py`, `CSRFMiddleware` in `main.py`)
+- Login/setup/Plex endpoints are rate-limited (`_enforce_rate_limit` in `api/auth.py`)
+- Session cookie auto-sets `Secure` for HTTPS/forwarded-HTTPS; session secret auto-generated and persisted to the config dir
+- Frontend: `ProtectedRoute` in `App.jsx`, checks `/api/auth/status` on load; `get_auth_context` re-verifies the role against the DB on every request
 
 ### Configuration
 All settings use the `CATCHUP_` env prefix (see `backend/config.py`). A `.env` file in `backend/` is supported. Key vars:
-- `CATCHUP_DATABASE_URL` — defaults to SQLite in `/app/config/` (Docker) or `data/` (local)
+- `CATCHUP_DATABASE_URL` — defaults to SQLite in `/app/config/` (Docker) or `data/` (local); `CATCHUP_DATA_ROOT` moves the local data dir
 - `CATCHUP_DEFAULT_DOWNLOAD_FOLDER` / `CATCHUP_DEFAULT_COMPLETED_FOLDER`
 - `CATCHUP_MAX_CONCURRENT_DOWNLOADS` (default: 2)
-- `CATCHUP_FFMPEG_PATH`, `CATCHUP_COMSKIP_PATH` — override auto-detected tool paths
-- `CATCHUP_TIMEZONE`, `CATCHUP_DEBUG`
+- `CATCHUP_FFMPEG_PATH`, `CATCHUP_COMSKIP_PATH` — override auto-detected tool paths (read in `post_processor.py`, not `config.py`)
+- `CATCHUP_SESSION_SECRET`, `CATCHUP_CORS_ORIGINS`, `CATCHUP_DEBUG`
+- `CATCHUP_DESKTOP_MODE=1` — desktop packaging mode (`desktop_server.py`, binds 127.0.0.1, downloads to `~/Downloads`)
+
+Environment detection: Docker paths activate via `CATCHUP_DOCKER=1` or container runtime markers.
 
 ## Code Style
 - Python: 4-space indentation; async throughout (FastAPI + SQLAlchemy AsyncIO)
@@ -70,4 +93,5 @@ All settings use the `CATCHUP_` env prefix (see `backend/config.py`). A `.env` f
 
 ## Commits & PRs
 - Short imperative commit messages (e.g., `Fix missing Path import`)
-- PRs need: concise summary, steps to test, screenshots for UI changes
+- PRs need: concise summary, steps to test, screenshots for UI changes (convention: `.github/pr-screenshots/`)
+- User-facing changes get a `CHANGELOG.md` entry written in plain English ("What you would notice" / "What changed"), newest at top


### PR DESCRIPTION
## Summary

Lands the owner's WIP CLAUDE.md refresh. The committed version was stale (still said "no automated test suite exists" and referenced the long-merged `codex/authentication` branch). Updates:

- Tests section: backend unittest commands (~1000 tests) **and** the new frontend Vitest suite from #366; CI runs both
- Project overview now mentions VOD downloads and Plex integration
- Download pipeline: `download_builder`, `file_namer`/`vod_namer`, disk-space preflight
- Background tasks list matches `main.py` lifespan (post queue, `server_log_bridge`)
- New sections: API routers, Authentication & Security (roles, setup lockdown, CSRF, rate limits)
- Config: `CATCHUP_DATA_ROOT`, `CATCHUP_SESSION_SECRET`, `CATCHUP_CORS_ORIGINS`, desktop mode, Docker detection
- Commits & PRs: screenshots convention, CHANGELOG convention

Docs only; no code change, no CHANGELOG entry.

## Steps to test

Read the diff; verify claims against the code (test count: `cd backend && python -m unittest discover -s tests` reports 998).

🤖 Generated with [Claude Code](https://claude.com/claude-code)