### PR TITLE
fix: ISO XMLTV timestamps with named TZ abbreviations silently drop programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Fixed: Guides using ISO timestamps with timezone names (EST, CET, MSK) no longer come up empty
+
+**What you would notice:** With some providers, certain channels (or the whole guide) showed no programs at all, with no error anywhere. This happened when the provider's guide file wrote program times in ISO format with a named timezone, for example "2024-01-15 20:00:00 EST" instead of a numeric offset. Mustarrd could not parse those times and silently skipped every affected program. These guides now load correctly, with program times converted from the named timezone.
+
+**What changed:** `_parse_xmltv_time` resolved named timezone abbreviations only in the compact XMLTV format path; the ISO format path fed the abbreviation to `datetime.fromisoformat`, which rejected it, and the parser returned None. The ISO path now strips a trailing named timezone, looks it up in the existing offset table, and applies it to the parsed time. Unknown abbreviations fall back to UTC, the same behavior as the compact path. 14 regression tests cover the affected formats.
+
+---
+
 ### Added: GPU-accelerated encoding in Docker, with a plain-language GPU status panel in Settings
 
 **What you would notice:** The Docker image can now encode recordings on your GPU. If your server has an Intel, AMD, or NVIDIA GPU visible to the container, re-encoding finished recordings is much faster and uses far less CPU. The Settings page tells you where you stand in plain language: a green "GPU encoding ready" badge with the detected vendor when everything works, a note when the driver was set manually, and a clear explanation when no GPU is available (for example, Docker Desktop on macOS and Windows does not share the host GPU with containers, so encoding falls back to the CPU; slower, but everything still works).

--- a/backend/services/epg_ingest_manager.py
+++ b/backend/services/epg_ingest_manager.py
@@ -845,6 +845,18 @@ class EPGIngestManager:
         if "-" in first_chunk[:10] or "T" in first_chunk:
             try:
                 parts = value.split()
+                # Named TZ suffix ("2024-01-15 20:00:00 EST"): fromisoformat
+                # rejects it, so resolve it via _NAMED_TZ_OFFSETS up front and
+                # parse the rest as a naive ISO timestamp. Unknown names fall
+                # back to UTC, matching the compact-format path below.
+                named_tz = None
+                if len(parts) >= 2 and parts[-1].isalpha():
+                    upper = parts[-1].upper()
+                    if upper in _NAMED_TZ_OFFSETS:
+                        named_tz = timezone(timedelta(minutes=_NAMED_TZ_OFFSETS[upper]))
+                    else:
+                        named_tz = timezone.utc
+                    parts = parts[:-1]
                 if len(parts) == 3:
                     # "2024-01-15 20:00:00 +0100" -> "2024-01-15T20:00:00+0100"
                     iso_str = parts[0] + "T" + parts[1] + parts[2]
@@ -854,6 +866,8 @@ class EPGIngestManager:
                 elif len(parts) == 2:
                     # "2024-01-15 20:00:00" (no tz)
                     iso_str = parts[0] + "T" + parts[1]
+                elif len(parts) == 1:
+                    iso_str = parts[0]
                 else:
                     iso_str = value
                 if iso_str.endswith("Z"):
@@ -863,7 +877,7 @@ class EPGIngestManager:
                     iso_str = iso_str[:-2] + ":" + iso_str[-2:]
                 dt = datetime.fromisoformat(iso_str)
                 if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
+                    dt = dt.replace(tzinfo=named_tz or timezone.utc)
                 return dt
             except (ValueError, TypeError):
                 return None

--- a/backend/tests/test_epg_xmltv_iso_named_tz.py
+++ b/backend/tests/test_epg_xmltv_iso_named_tz.py
@@ -1,0 +1,167 @@
+"""
+Regression tests for ISO-format XMLTV timestamps with named TZ abbreviations
+silently returning None and dropping all programs.
+
+Bug: _parse_xmltv_time has a named-TZ lookup (_NAMED_TZ_OFFSETS) only in the
+compact-format code path (YYYYMMDDHHmmss + TZ). When the ISO-format path fires
+(date part contains dashes or 'T'), the code constructs an iso_str such as
+"2024-01-15T20:00:00EST" and calls datetime.fromisoformat(), which raises
+ValueError on named TZ abbreviations. The except clause returns None, silently
+dropping every programme whose timestamp uses an ISO date with a named TZ zone.
+
+Common real-world triggers:
+  - North American providers: "2024-01-15 20:00:00 EST"
+  - European providers:       "2024-01-15 20:00:00 CET"
+  - Australian providers:     "2024-01-15 20:00:00 ACST"
+
+Expected: returns a timezone-aware datetime equivalent to the correct UTC time.
+Actual:   returns None, program is silently skipped during EPG ingest.
+
+Fix (maintainer): in the ISO path, when fromisoformat raises ValueError on a
+3-part token where parts[2] is a letter-only string, check parts[2].upper()
+against _NAMED_TZ_OFFSETS and construct the datetime manually.
+"""
+import sys
+import unittest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_ingest_manager import EPGIngestManager
+
+
+class ISOFormatNamedTZTests(unittest.TestCase):
+    def setUp(self):
+        self.mgr = EPGIngestManager.__new__(EPGIngestManager)
+
+    def test_iso_space_separator_est_not_none(self):
+        """'2024-01-15 20:00:00 EST' must not return None.
+
+        Bug: ISO path builds '2024-01-15T20:00:00EST', fromisoformat raises
+        ValueError, except returns None. All programs with EST in ISO format
+        are silently dropped from the guide.
+        """
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 EST")
+        self.assertIsNotNone(
+            result,
+            "'2024-01-15 20:00:00 EST' returned None. ISO path does not apply "
+            "_NAMED_TZ_OFFSETS; fromisoformat raises ValueError on 'EST' suffix "
+            "and the program is silently dropped.",
+        )
+
+    def test_iso_space_separator_est_correct_utc(self):
+        """'2024-01-15 20:00:00 EST' (UTC-5) must equal 01:00 UTC on 2024-01-16."""
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 EST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 1, 16, 1, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            result_utc,
+            expected,
+            f"EST ISO noon should be 2024-01-16 01:00 UTC, got {result_utc.isoformat()}",
+        )
+
+    def test_iso_space_separator_pst_not_none(self):
+        """'2024-01-15 20:00:00 PST' must not return None."""
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 PST")
+        self.assertIsNotNone(
+            result,
+            "'2024-01-15 20:00:00 PST' returned None. Same ISO+named-TZ gap as EST.",
+        )
+
+    def test_iso_space_separator_pst_correct_utc(self):
+        """'2024-01-15 20:00:00 PST' (UTC-8) must equal 04:00 UTC on 2024-01-16."""
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 PST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 1, 16, 4, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected)
+
+    def test_iso_space_separator_cet_not_none(self):
+        """'2024-06-01 12:00:00 CET' must not return None."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 CET")
+        self.assertIsNotNone(
+            result,
+            "'2024-06-01 12:00:00 CET' returned None. European providers using ISO "
+            "format with CET lose their entire guide silently.",
+        )
+
+    def test_iso_space_separator_cet_correct_utc(self):
+        """'2024-06-01 12:00:00 CET' (UTC+1) must equal 11:00 UTC."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 CET")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 6, 1, 11, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected)
+
+    def test_iso_space_separator_acst_not_none(self):
+        """'2024-06-01 12:00:00 ACST' must not return None."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 ACST")
+        self.assertIsNotNone(
+            result,
+            "'2024-06-01 12:00:00 ACST' returned None. Australian Central providers "
+            "using ISO format lose their entire guide.",
+        )
+
+    def test_iso_space_separator_acst_correct_utc(self):
+        """'2024-06-01 12:00:00 ACST' (UTC+9:30) must equal 02:30 UTC."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 ACST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 6, 1, 2, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected)
+
+    def test_iso_t_separator_est_not_none(self):
+        """'2024-01-15T20:00:00 EST' (T-separator with space before TZ) must not return None."""
+        result = self.mgr._parse_xmltv_time("2024-01-15T20:00:00 EST")
+        self.assertIsNotNone(
+            result,
+            "'2024-01-15T20:00:00 EST' returned None. T-separator ISO format with "
+            "named TZ has the same gap: 2 parts where parts[1] is 'EST' not starting "
+            "with +/-, so it is treated as a no-tz ISO string; EST is then silently "
+            "ignored and the time is treated as UTC, shifting all programs by 5 hours.",
+        )
+
+    def test_iso_space_separator_msk_not_none(self):
+        """'2024-06-01 12:00:00 MSK' must not return None."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 MSK")
+        self.assertIsNotNone(
+            result,
+            "'2024-06-01 12:00:00 MSK' returned None. Russian providers using ISO "
+            "format with MSK lose their entire guide.",
+        )
+
+    def test_iso_space_separator_msk_correct_utc(self):
+        """'2024-06-01 12:00:00 MSK' (UTC+3) must equal 09:00 UTC."""
+        result = self.mgr._parse_xmltv_time("2024-06-01 12:00:00 MSK")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected)
+
+    def test_iso_numeric_offset_still_works(self):
+        """Regression: '2024-01-15 20:00:00 +0100' must still work after fix."""
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00 +0100")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.utcoffset().total_seconds(), 3600)
+
+    def test_iso_no_tz_still_works(self):
+        """Regression: '2024-01-15 20:00:00' must still return UTC-stamped datetime."""
+        result = self.mgr._parse_xmltv_time("2024-01-15 20:00:00")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.tzinfo, timezone.utc)
+
+    def test_compact_named_tz_still_works(self):
+        """Regression: '20240115200000 EST' (compact format) must still work."""
+        result = self.mgr._parse_xmltv_time("20240115200000 EST")
+        self.assertIsNotNone(result)
+        result_utc = result.astimezone(timezone.utc)
+        expected = datetime(2024, 1, 16, 1, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result_utc, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR contains

11 failing tests that prove a new bug in `_parse_xmltv_time`. No code changes.

## Bug

`_parse_xmltv_time` has named-TZ support (`_NAMED_TZ_OFFSETS`) only in the compact-format code path (`20240115200000 EST`). When a timestamp looks like ISO format (date part contains dashes or T), the code assembles an `iso_str` and calls `datetime.fromisoformat()`, which raises `ValueError` on named TZ suffixes. The `except` clause returns `None`.

Result: every `<programme>` element whose `start` or `stop` attribute uses an ISO-format date with a named TZ abbreviation is silently dropped from the EPG. The guide goes partially or fully empty with no error or warning.

**Formats that fail:**
- `"2024-01-15 20:00:00 EST"` (3-part space-separated, named TZ)
- `"2024-01-15 20:00:00 CET"`
- `"2024-01-15 20:00:00 ACST"`
- `"2024-01-15 20:00:00 MSK"`
- `"2024-01-15T20:00:00 EST"` (T-separator, space before named TZ)

**How to reproduce:**
1. Build an XMLTV document with `start="2024-01-15 20:00:00 EST"`.
2. Run EPG ingest.
3. All programmes are silently skipped. Guide is empty.

## Fix outline (maintainer)

In the ISO path, when `len(parts) == 3` and `parts[2]` is letters-only (not a numeric offset), look it up in `_NAMED_TZ_OFFSETS` and construct the timezone manually, the same way the compact path does. Same guard needed for the 2-part `T`-separator case where `parts[1]` is a letters-only string.

## Tests

`backend/tests/test_epg_xmltv_iso_named_tz.py` - 11 assertions fail before the fix, 3 regression guards pass.