### PR TITLE
fix: cap series download episode list at 200 per request

### DIFF
--- a/backend/api/vod.py
+++ b/backend/api/vod.py
@@ -1,9 +1,9 @@
 from collections import Counter
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from typing import Optional
+from typing import Annotated, Optional
 import logging
 import os
 
@@ -44,7 +44,7 @@ class SeriesDownloadRequest(BaseModel):
     account_id: int
     series_id: str
     series_name: str
-    episodes: list[EpisodeItem]
+    episodes: Annotated[list[EpisodeItem], Field(max_length=200)]
 
 
 async def _get_client(session: AsyncSession, account: XtreamAccount) -> XtreamClient:

--- a/backend/tests/test_series_episode_limit.py
+++ b/backend/tests/test_series_episode_limit.py
@@ -1,0 +1,67 @@
+"""
+Regression test: SeriesDownloadRequest.episodes must reject requests with more
+than 200 episodes.
+
+Before fix: no upper bound, an authenticated user could send 5000+ episodes and
+trigger thousands of DB queries in a single request, stalling all other requests
+on a Raspberry Pi or low-spec Unraid box.
+
+After fix: Pydantic rejects the payload at validation time with a 422 response.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from pydantic import ValidationError
+
+from api.vod import SeriesDownloadRequest, EpisodeItem
+
+
+def _episode(n: int) -> dict:
+    return {
+        "id": f"ep{n}",
+        "season": 1,
+        "episode_num": n,
+        "container_extension": "mp4",
+    }
+
+
+class SeriesEpisodeLimitTests(unittest.TestCase):
+
+    def test_201_episodes_rejected(self):
+        """A request with 201 episodes must raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            SeriesDownloadRequest(
+                account_id=1,
+                series_id="s1",
+                series_name="Test Show",
+                episodes=[EpisodeItem(**_episode(i)) for i in range(201)],
+            )
+
+    def test_200_episodes_accepted(self):
+        """A request with exactly 200 episodes must be valid."""
+        req = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Test Show",
+            episodes=[EpisodeItem(**_episode(i)) for i in range(200)],
+        )
+        self.assertEqual(len(req.episodes), 200)
+
+    def test_empty_episodes_accepted(self):
+        """An empty episode list must be valid (no episodes to queue)."""
+        req = SeriesDownloadRequest(
+            account_id=1,
+            series_id="s1",
+            series_name="Test Show",
+            episodes=[],
+        )
+        self.assertEqual(len(req.episodes), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What you would notice

Before this fix, if you selected hundreds of TV episodes and clicked Download, the server would silently accept the full list and run a database query and download task for every single episode, back to back. On a Raspberry Pi or a low-spec Unraid box, a 500-episode request could stall the app for several seconds, blocking all other users from downloading or browsing.

## What changed

`POST /api/vod/series/download` now rejects any request with more than 200 episodes at the validation stage, before any database work begins. The response is HTTP 422 with a validation error. Requests with 200 or fewer episodes are unchanged.

The limit is enforced by adding `Field(max_length=200)` to the `episodes` field in `SeriesDownloadRequest` (one line in `backend/api/vod.py`).

## How it was tested

Three new regression tests in `backend/tests/test_series_episode_limit.py`:
- A 201-episode request raises `ValidationError` (was silently accepted before)
- A 200-episode request is accepted
- An empty episode list is accepted

```
Ran 1017 tests in 8.644s
OK
```

Before fix: `SeriesDownloadRequest(episodes=[...201 items...])` succeeds.
After fix: `pydantic_core._pydantic_core.ValidationError: 1 validation error for SeriesDownloadRequest — episodes: List should have at most 200 items after validation, not 201`