### PR TITLE
docs: remove duplicate changelog entry, add #375, update README features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+## 2026-06-10
+
+### Fixed: Downloading hundreds of TV episodes at once no longer stalls the app
+
+**What you would notice:** If you selected more than 200 episodes of a TV series and clicked Download, the server would accept all of them and start queuing hundreds of individual download tasks at once, which could freeze the interface for several seconds on lower-powered hardware like a Raspberry Pi or Unraid box. Mustarrd now rejects any batch over 200 episodes before doing any database work, and shows a clear validation error so you can split the request into smaller groups.
+
+**What changed:** The series download endpoint now enforces a hard limit of 200 episodes per request. Requests at or below 200 are unchanged. Three new regression tests cover the limit boundary.
+
+---
+
 ## 2026-06-09
 
 ### Improved: Export and Import buttons on Scheduled Recordings stay together on phone-sized screens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-09
 
+### Improved: Export and Import buttons on Scheduled Recordings stay together on phone-sized screens
+
+**What you would notice:** On a narrow phone screen, the Export and Import buttons on the Scheduled Recordings page now always appear side by side on the same row. Previously, Import could end up stranded alone on a second row while Export stayed next to the Auto-retry toggle on the first, making the two buttons look unrelated.
+
+**What changed:** Export and Import are now kept in a single no-wrap group so they always move together if the header needs to wrap. Desktop layout is unchanged.
+
+---
+
 ### Fixed: Provider error messages can no longer masquerade as completed recordings
 
 **What you would notice:** Occasionally a download would finish instantly and show as Completed, but the resulting file was a few hundred bytes and would not play. This happened when the provider answered the catchup request with an error message (for example "maximum connections reached" or "stream unavailable") sent as JSON or XML with a success status code; Mustarrd saved that message as if it were the recording. These downloads now fail immediately with a clear error ("Provider returned an error page"), so the recording can be retried while the catchup window is still open instead of being discovered broken later.
@@ -35,14 +43,6 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 **What you would notice:** On the Browse EPG page, when your IPTV provider is unreachable, the large right panel now ends with an actionable link instead of a dead-end message. If you are an admin, you see "Check Settings, Accounts." as a clickable link that takes you directly to the Accounts section where you can check your connection. If you are not an admin, you see "Contact your administrator." Previously, the panel gave you nowhere to go.
 
 **What changed:** One block in the Browse page. No backend, no configuration changes.
-
----
-
-### Fixed: Downloads no longer complete silently when your provider returns a JSON error instead of a stream
-
-**What you would notice:** Some IPTV providers send a JSON error message (for example, "maximum connections reached" or "stream unavailable") disguised as a normal HTTP 200 response. Before this fix, Mustarrd wrote that tiny JSON blob to the recording file and marked the download as Completed. You would end up with a corrupt, unplayable recording in Plex or Jellyfin showing 0:00 duration, with no indication anything went wrong. After this fix, Mustarrd detects the JSON content type and immediately marks the download as Failed with a clear reason: "Provider returned an error page (Content-Type: application/json)."
-
-**What changed:** The content-type guard in the download manager, which already rejected HTML and plain-text error pages, now also rejects `application/json` responses. The check applies at both the initial request and the restart path so no code path lets a JSON error body through. Two regression tests cover the affected cases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Mustarrd connects to your IPTV provider and lets you download past programs. Thi
 ## Features
 
 - **Browse past programs:** scroll back through your provider's program guide (EPG) and see what's available to download
+- **Starred channels:** star your favorite channels so they always appear at the top of the list
+- **Program preview:** preview a live channel or catchup program in your browser before queuing a download
 - **Commercial skip:** ComSkip integration removes commercials before saving
 - **Flexible output formats:** save recordings as-is (.ts), remux to MKV or MP4, or re-encode with FFmpeg for smaller files
+- **GPU-accelerated encoding:** if your server has an Intel, AMD, or NVIDIA GPU, re-encoding uses it automatically; the Settings page shows GPU status in plain language
 - **Download from On Demand:** If your provider provides on demand listings, you can grab those too!
-- **Scheduled recordings:** set programs to download automatically when they air
+- **Scheduled recordings:** set programs to download automatically when they air; export and import your schedule as a backup or to move to another machine
 - **Smart file naming:** TV shows, movies, and sports get automatically named in the right format (`Breaking Bad - S01E01 - Pilot.ts`, `The Matrix (1999).ts`, etc.)
 - **Plex Link:** Allow your plex users to request programming by logging in with their Plex creds (or don't) and push recording directly to your TV recording library
 - **Multiple accounts:** connect more than one IPTV provider. Add more users to give them download access


### PR DESCRIPTION
## What changed

Three documentation fixes in one pass.

**1. Duplicate CHANGELOG entry removed**

PRs #373 and #374 both added entries for the content-type guard fix (PR #365, application/json). #373 added a combined JSON+XML entry covering both #365 and #367, which is the correct and complete version. #374 was based on an older branch and re-added a JSON-only entry, creating a duplicate. The redundant JSON-only entry is removed; the combined entry from #373 remains.

**2. CHANGELOG entry added for PR #375**

PR #375 fixed the Export and Import buttons on the Scheduled Recordings page wrapping to separate lines on narrow phone screens. This fix had no changelog entry; one is added now.

**3. README features list updated**

The features section was missing several additions from recent PRs. Added:
- Starred channels (PR #359)
- Program preview (PR #359)
- GPU-accelerated encoding with Settings status panel (PR #370)
- Schedule export/import (PR #362)

Docs only. No backend or frontend code changes.