### PR TITLE
design: show countdown to download start on upcoming recording cards

### DIFF
--- a/frontend/src/pages/Downloads.jsx
+++ b/frontend/src/pages/Downloads.jsx
@@ -44,7 +44,7 @@ import duration from 'dayjs/plugin/duration'
 
 import { accountsApi, authApi, downloadsApi, createDownloadWebSocket } from '../api'
 import ProgressBar from '../components/ProgressBar'
-import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
+import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours, getChannelDisplayTime, getNowUtc } from '../utils/channelTime'
 
 dayjs.extend(duration)
 
@@ -81,6 +81,22 @@ function formatDuration(minutes) {
     return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
   }
   return `${mins}m`
+}
+
+function formatTimeUntil(displayTime, guideOffsetHours = 0) {
+  if (!displayTime) return null
+  const nowDisplay = getNowUtc().add(getGuideOffsetHours(guideOffsetHours), 'hour')
+  const diffMinutes = displayTime.diff(nowDisplay, 'minute')
+  if (diffMinutes <= 0) return null
+  const hours = Math.floor(diffMinutes / 60)
+  const mins = diffMinutes % 60
+  if (hours >= 48) return `in ${Math.floor(hours / 24)}d`
+  if (hours >= 24) {
+    const remHours = hours % 24
+    return remHours > 0 ? `in 1d ${remHours}h` : 'in 1d'
+  }
+  if (hours > 0) return mins > 0 ? `in ${hours}h ${mins}m` : `in ${hours}h`
+  return `in ${mins}m`
 }
 
 function formatRecordedDuration(seconds) {
@@ -730,7 +746,11 @@ export default function Downloads() {
                 const airStart = formatAirDateTime(rec, 'start', guideOffset)
                 const airEnd = formatChannelDateTime(rec, 'end', guideOffset, 'h:mm A')
                 const downloadAt = formatAirDateTime(rec, 'available', guideOffset)
+                const downloadDisplayTime = getChannelDisplayTime(rec, 'available', guideOffset)
+                const timeUntil = formatTimeUntil(downloadDisplayTime, guideOffset)
                 const totalDuration = (rec.duration_minutes || 0) + (rec.pre_padding_minutes || 0) + (rec.post_padding_minutes || 0)
+                const paddingNote = totalDuration !== (rec.duration_minutes || 0) ? `${formatDuration(totalDuration)} with padding` : null
+                const downloadNotes = [timeUntil, paddingNote].filter(Boolean)
                 return (
                   <Card key={rec.id} shadow="sm" padding="md" radius="md" withBorder>
                     <Stack gap={2}>
@@ -745,7 +765,7 @@ export default function Downloads() {
                         Airs: {airStart || 'Unknown'} - {airEnd || 'Unknown'} ({formatDuration(rec.duration_minutes || 0)})
                       </Text>
                       <Text size="xs" c="dimmed">
-                        Download starts: {downloadAt || 'Unknown'}{totalDuration !== (rec.duration_minutes || 0) ? ` (${formatDuration(totalDuration)} with padding)` : ''}
+                        Download starts: {downloadAt || 'Unknown'}{downloadNotes.length > 0 ? ` (${downloadNotes.join(', ')})` : ''}
                       </Text>
                     </Stack>
                   </Card>


### PR DESCRIPTION
## What changed

The Downloads > Upcoming tab now shows how long until a recording's download begins, alongside the existing absolute time.

**Before:** Download starts: Today at 9:30 PM
**After:** Download starts: Today at 9:30 PM (in 20h 1m)

If padding is configured, both notes appear together: (in 20h 1m, 1h 45m with padding).

Once the show has finished airing and the download begins, the countdown disappears automatically.

## Why

A non-technical user seeing "Download starts: Today at 9:30 PM" at 1:30 AM has to do mental arithmetic to realize it is 20 hours away. The countdown makes the wait immediately obvious without requiring any math.

## What changed in code

- Added `formatTimeUntil()` helper in `Downloads.jsx` that takes the guide-offset-adjusted dayjs instant and returns a string like "in 2h 15m", "in 1d 3h", etc., or null once the time has passed.
- Imported `getChannelDisplayTime` and `getNowUtc` from `channelTime` (both already exported, no changes to that file).
- Upcoming card render now combines the countdown and any padding note into a single parenthetical.

Frontend only. No backend changes.

## Screenshots

Screenshots posted in #design. Summary:

**Before** (desktop and mobile): Download starts: Today at 9:30 PM

**After** (desktop and mobile): Download starts: Today at 9:30 PM (in 20h 1m)

## Test plan

- Open Downloads > Upcoming with a scheduled recording in the future: countdown appears.
- Once the recording available time is in the past: countdown disappears (returns null).
- Recordings with pre/post padding: both countdown and padding note appear, e.g. "(in 20h 1m, 1h 45m with padding)".
- Recordings with no padding: only the countdown appears.