### PR TITLE
design: downgrade GPU badge to warning when ffmpeg is unavailable

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -917,12 +917,19 @@ export default function Settings() {
             {(() => {
               const hwStatus = describeHardwareAccel(toolsStatus.vaapi)
               if (!hwStatus) return null
+              const gpuBlockedByFfmpeg = hwStatus.color === 'green' && ffmpegReady === false
+              const badgeColor = gpuBlockedByFfmpeg ? 'yellow' : hwStatus.color
+              const badgeIcon = gpuBlockedByFfmpeg ? <IconAlertCircle size={12} /> : hwStatus.icon
+              const badgeLabel = gpuBlockedByFfmpeg ? 'GPU detected, ffmpeg required' : hwStatus.label
+              const badgeDetail = gpuBlockedByFfmpeg
+                ? 'A GPU was found but ffmpeg is not installed. Install ffmpeg to use GPU encoding.'
+                : hwStatus.detail
               return (
                 <Stack gap={4}>
-                  <Badge color={hwStatus.color} variant="light" leftSection={hwStatus.icon} style={{ alignSelf: 'flex-start' }}>
-                    {hwStatus.label}
+                  <Badge color={badgeColor} variant="light" leftSection={badgeIcon} style={{ alignSelf: 'flex-start' }}>
+                    {badgeLabel}
                   </Badge>
-                  <Text size="xs" c="dimmed">{hwStatus.detail}</Text>
+                  <Text size="xs" c="dimmed">{badgeDetail}</Text>
                 </Stack>
               )
             })()}


### PR DESCRIPTION
## What a user would notice

On the Post-Processing settings page, when ffmpeg is not installed, the GPU status badge used to show a green checkmark labeled **"GPU ENCODING READY"**. This is misleading: GPU encoding cannot work without ffmpeg. A non-technical user would see green and assume everything is fine, then be confused when their recordings are not converted.

After this change, the badge turns yellow and reads **"GPU DETECTED, FFMPEG REQUIRED"** with the message "A GPU was found but ffmpeg is not installed. Install ffmpeg to use GPU encoding." The green badge only appears when both GPU and ffmpeg are present.

## What changed

One change in `frontend/src/pages/Settings.jsx`: when the GPU status would be green but `ffmpegReady === false`, the badge color, icon, label, and detail are overridden to show a yellow warning instead.

## Test plan

- Confirmed visually in a local dev environment where ffmpeg is not installed. Before: green badge. After: yellow badge.
- When ffmpeg IS installed, the green badge still appears as before (the condition only triggers when `ffmpegReady === false`).
- Frontend only. No backend changes. No logic changes.