### PR TITLE
design: add countdown to download start time on Scheduled Recordings cards

### DIFF
--- a/frontend/src/pages/Scheduled.jsx
+++ b/frontend/src/pages/Scheduled.jsx
@@ -41,7 +41,7 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 
 import { accountsApi, authApi, downloadsApi, schedulesApi, settingsApi } from '../api'
-import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours } from '../utils/channelTime'
+import { formatChannelDateTime, formatAirDateTime, getGuideOffsetHours, getChannelDisplayTime, getNowUtc } from '../utils/channelTime'
 
 dayjs.extend(duration)
 
@@ -70,6 +70,22 @@ function formatDuration(minutes) {
     return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
   }
   return `${mins}m`
+}
+
+function formatTimeUntil(displayTime, guideOffsetHours = 0) {
+  if (!displayTime) return null
+  const nowDisplay = getNowUtc().add(getGuideOffsetHours(guideOffsetHours), 'hour')
+  const diffMinutes = displayTime.diff(nowDisplay, 'minute')
+  if (diffMinutes <= 0) return null
+  const hours = Math.floor(diffMinutes / 60)
+  const mins = diffMinutes % 60
+  if (hours >= 48) return `in ${Math.floor(hours / 24)}d`
+  if (hours >= 24) {
+    const remHours = hours % 24
+    return remHours > 0 ? `in 1d ${remHours}h` : 'in 1d'
+  }
+  if (hours > 0) return mins > 0 ? `in ${hours}h ${mins}m` : `in ${hours}h`
+  return `in ${mins}m`
 }
 
 function getStatusBadge(status) {
@@ -117,9 +133,13 @@ function ScheduleCard({
   const startTime = formatAirDateTime(schedule, 'start', guideOffsetHours)
   const endTime = formatChannelDateTime(schedule, 'end', guideOffsetHours, 'h:mm A')
   const availableAt = formatAirDateTime(schedule, 'available', guideOffsetHours)
+  const downloadDisplayTime = getChannelDisplayTime(schedule, 'available', guideOffsetHours)
+  const timeUntil = isActive ? formatTimeUntil(downloadDisplayTime, guideOffsetHours) : null
   const totalDuration = (schedule.duration_minutes || 0)
     + (schedule.pre_padding_minutes || 0)
     + (schedule.post_padding_minutes || 0)
+  const paddingNote = totalDuration !== (schedule.duration_minutes || 0) ? `${formatDuration(totalDuration)} with padding` : null
+  const downloadNotes = [timeUntil, paddingNote].filter(Boolean)
   const downloadHref = schedule.download_id
     ? `/api/downloads/${schedule.download_id}/file?action=download`
     : null
@@ -174,7 +194,7 @@ function ScheduleCard({
 
         {(isActive || schedule.status === 'completed') && (
           <Text size="xs" c="dimmed">
-            Download starts: {availableAt || 'Unknown'}{totalDuration !== (schedule.duration_minutes || 0) ? ` (${formatDuration(totalDuration)} with padding)` : ''}
+            Download starts: {availableAt || 'Unknown'}{downloadNotes.length > 0 ? ` (${downloadNotes.join(', ')})` : ''}
           </Text>
         )}
 


### PR DESCRIPTION
## What changed

Scheduled Recordings > Upcoming cards now show how long until the download starts, matching what Downloads > Upcoming already shows after PR #378.

**Before:** "Download starts: Today at 9:30 PM"
**After:** "Download starts: Today at 9:30 PM (in 18h 39m)"

## Why

A non-technical user who schedules a show from the Scheduled page had to do mental arithmetic to know how long they would wait. PR #378 fixed this for Downloads > Upcoming but the Scheduled page was not updated at the same time.

## What changed in the code

One file: `frontend/src/pages/Scheduled.jsx`.

- Added `getChannelDisplayTime` and `getNowUtc` to the import from `channelTime` (already exported, already used in Downloads.jsx).
- Added `formatTimeUntil` function (identical logic to the one in Downloads.jsx).
- In `ScheduleCard`, computed `downloadDisplayTime`, `timeUntil`, and `downloadNotes` alongside the existing variables.
- Updated the "Download starts" line to append the countdown when notes are present.

The countdown only appears for active schedules (scheduled, queued, downloading, etc.). Completed, failed, and cancelled cards are unchanged.

## How it was tested

- Started backend and frontend locally.
- Playwright screenshots at 1280px desktop and 390px mobile: before and after both captured.
- Countdown appears correctly on both widths.
- No changes to backend, API, or other UI components.

## Screenshots

Before and after posted in #design (Pixel iteration 52).