### PR TITLE
design: remove confusing "(in progress)" from Download folder label

### DIFF
--- a/frontend/src/components/settings/FoldersStatus.jsx
+++ b/frontend/src/components/settings/FoldersStatus.jsx
@@ -64,7 +64,7 @@ export default function FoldersStatus() {
         )}
         {data && (
           <>
-            <FolderRow label="Download folder (in progress)" status={data.download_folder} />
+            <FolderRow label="Download folder" status={data.download_folder} />
             <FolderRow label="Completed recordings folder" status={data.completed_folder} />
           </>
         )}

--- a/frontend/src/components/settings/FoldersStatus.test.jsx
+++ b/frontend/src/components/settings/FoldersStatus.test.jsx
@@ -21,7 +21,7 @@ describe('FoldersStatus', () => {
 
     renderWithQuery(<FoldersStatus />)
 
-    expect(await screen.findByText('Download folder (in progress)')).toBeInTheDocument()
+    expect(await screen.findByText('Download folder')).toBeInTheDocument()
     expect(screen.getByText('Completed recordings folder')).toBeInTheDocument()
     expect(screen.getAllByText('Writable')).toHaveLength(2)
     expect(screen.getByText('/downloads')).toBeInTheDocument()


### PR DESCRIPTION
## What a user would notice

In Settings > Recording, the folder status card showed **"Download folder (in progress)"** next to the WRITABLE badge. Non-technical users read "(in progress)" as a status message, like something is broken or still being configured. It is not. The label was just trying to distinguish the active download folder from the completed folder.

## What changed

Removed the "(in progress)" parenthetical. The label is now **"Download folder"**, matching the plain-English naming used in the folder input fields directly above it.

## How it was tested

Before and after Playwright screenshots at desktop (1280px) and mobile (390px). See #design thread for images.

## Before

- Label: "Download folder (in progress)"

## After

- Label: "Download folder"