### PR TITLE
fix: snapshot schedule attributes before dispatch loop to prevent sibling FAILED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Fixed: Scheduling two recordings at once no longer breaks the second one when the first fails
+
+**What you would notice:** On Unraid, if two scheduled recordings were due to start in the same 30-second window and something went wrong with the first one (such as a provider rejecting it), the second recording would silently fail with a confusing internal error ("greenlet_spawn has not been called") and stay stuck as FAILED. The second recording is now unaffected by the first's failure and will be queued normally.
+
+**What changed:** Backend only. When a scheduled recording fails to start, the scheduler now saves a copy of each recording's details before processing begins. This means a failure in one recording can no longer corrupt the data needed to start the next one.
+
+---
+
 ### Improved: Downloads page now shows a countdown to when a scheduled recording will start
 
 **What you would notice:** On the Downloads page, each card in the Upcoming tab now shows how long until the recording begins, next to the scheduled start time. For example, you might see "Download starts: Today at 9:30 PM (in 20h 1m)". Previously you had to do the math yourself. If you have pre or post-recording padding set, the countdown and the padding note appear together: "(in 20h 1m, 1h 45m with padding)". The countdown disappears automatically once the recording is underway.

--- a/backend/services/scheduled_manager.py
+++ b/backend/services/scheduled_manager.py
@@ -143,7 +143,43 @@ class ScheduledManager:
             # past the minimum free space threshold.
             projected_used_gb = 0.0
 
-            for schedule in ready:
+            # Snapshot all ORM attributes that the dispatch loop will read,
+            # before entering the loop. session.rollback() in a prior
+            # iteration's except handler expires every object in the session
+            # identity map. Without local copies, the next iteration raises
+            # MissingGreenlet when it reads the expired attributes in an async
+            # context, and the generic except marks that schedule FAILED with
+            # a cryptic SQLAlchemy error.
+            ready_data = [
+                {
+                    "schedule": s,
+                    "account_id": s.account_id,
+                    "channel_id": s.channel_id,
+                    "channel_name": s.channel_name,
+                    "program_title": s.program_title,
+                    "program_description": s.program_description,
+                    "program_start": s.program_start,
+                    "program_end": s.program_end,
+                    "start_timestamp": s.start_timestamp,
+                    "stop_timestamp": s.stop_timestamp,
+                    "provider_start": s.provider_start,
+                    "provider_stop": s.provider_stop,
+                    "duration_minutes": s.duration_minutes,
+                    "epg_id": s.epg_id,
+                    "program_id": s.program_id,
+                    "channel_category_name": s.channel_category_name,
+                    "custom_filename": s.custom_filename,
+                    "pre_padding_minutes": s.pre_padding_minutes,
+                    "post_padding_minutes": s.post_padding_minutes,
+                    "requested_by_user_id": s.requested_by_user_id,
+                    "request_source": s.request_source,
+                }
+                for s in ready
+            ]
+
+            for snap in ready_data:
+                schedule = snap["schedule"]
+
                 if free_gb is None:
                     # Folder missing or unreachable (e.g. NAS not mounted).
                     # Fail safe: hold the schedule instead of recording onto
@@ -167,31 +203,31 @@ class ScheduledManager:
 
                 try:
                     program = {
-                        "title": schedule.program_title,
-                        "description": schedule.program_description or "",
-                        "start_time": schedule.program_start.isoformat() if schedule.program_start else None,
-                        "end_time": schedule.program_end.isoformat() if schedule.program_end else None,
-                        "start_timestamp": schedule.start_timestamp,
-                        "stop_timestamp": schedule.stop_timestamp,
-                        "provider_start": schedule.provider_start,
-                        "provider_stop": schedule.provider_stop,
-                        "duration_minutes": schedule.duration_minutes,
-                        "epg_id": schedule.epg_id,
-                        "id": schedule.program_id,
-                        "category": schedule.channel_category_name or "",
+                        "title": snap["program_title"],
+                        "description": snap["program_description"] or "",
+                        "start_time": snap["program_start"].isoformat() if snap["program_start"] else None,
+                        "end_time": snap["program_end"].isoformat() if snap["program_end"] else None,
+                        "start_timestamp": snap["start_timestamp"],
+                        "stop_timestamp": snap["stop_timestamp"],
+                        "provider_start": snap["provider_start"],
+                        "provider_stop": snap["provider_stop"],
+                        "duration_minutes": snap["duration_minutes"],
+                        "epg_id": snap["epg_id"],
+                        "id": snap["program_id"],
+                        "category": snap["channel_category_name"] or "",
                     }
 
                     download = await build_download_from_program(
                         session,
-                        account_id=schedule.account_id,
-                        channel_id=schedule.channel_id,
-                        channel_name=schedule.channel_name,
+                        account_id=snap["account_id"],
+                        channel_id=snap["channel_id"],
+                        channel_name=snap["channel_name"],
                         program=program,
-                        custom_filename=schedule.custom_filename,
-                        pre_padding_minutes=schedule.pre_padding_minutes,
-                        post_padding_minutes=schedule.post_padding_minutes,
-                        requested_by_user_id=schedule.requested_by_user_id,
-                        request_source=schedule.request_source or "admin",
+                        custom_filename=snap["custom_filename"],
+                        pre_padding_minutes=snap["pre_padding_minutes"],
+                        post_padding_minutes=snap["post_padding_minutes"],
+                        requested_by_user_id=snap["requested_by_user_id"],
+                        request_source=snap["request_source"] or "admin",
                     )
 
                     # Stage the download row on this session so it commits

--- a/backend/tests/test_dispatch_rollback_expiry.py
+++ b/backend/tests/test_dispatch_rollback_expiry.py
@@ -1,0 +1,179 @@
+"""
+Regression test: session.rollback() during dispatch of schedule A must not
+mark schedule B FAILED via SQLAlchemy attribute expiry (MissingGreenlet).
+
+When two schedules are ready in the same tick and A's queue_download fails
+after starting a DB transaction, session.rollback() expires all SQLAlchemy
+objects in the identity map. Without the fix, the next loop iteration reads
+B's expired attributes, raises MissingGreenlet in async context, and the
+generic except catches it and marks B FAILED with a cryptic error message.
+
+With the fix, schedule attributes are snapshotted into local variables before
+the dispatch try block, so the rollback's expiry has no effect on B's data.
+"""
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from database import Base
+from models import (
+    AppSettings,
+    Download,
+    DownloadStatus,
+    ScheduledRecording,
+    ScheduledStatus,
+    XtreamAccount,
+)
+from services.scheduled_manager import ScheduledManager
+
+
+def _make_schedule(channel_id: str, title: str) -> ScheduledRecording:
+    now = datetime.now(timezone.utc)
+    end = now - timedelta(minutes=5)
+    start = end - timedelta(hours=1)
+    return ScheduledRecording(
+        account_id=1,
+        channel_id=channel_id,
+        channel_name=f"Channel {channel_id}",
+        program_title=title,
+        program_description="Test description",
+        program_start=start.replace(tzinfo=None),
+        program_end=end.replace(tzinfo=None),
+        start_timestamp=int(start.timestamp()),
+        stop_timestamp=int(end.timestamp()),
+        duration_minutes=60,
+        status=ScheduledStatus.SCHEDULED.value,
+    )
+
+
+def _make_download(call_num: int) -> Download:
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    return Download(
+        account_id=1,
+        channel_id=f"ch{call_num}",
+        channel_name="Test Channel",
+        program_title=f"Show {call_num}",
+        program_start=now,
+        program_end=now,
+        start_timestamp=0,
+        stop_timestamp=0,
+        duration_minutes=60,
+        source_url="http://provider/stream.ts",
+        output_path=f"/tmp/test_show_{call_num}.ts",
+    )
+
+
+class DispatchRollbackExpiryTests(unittest.IsolatedAsyncioTestCase):
+    """Rollback on A (with active transaction) must not corrupt B via expiry."""
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        # expire_on_commit=False matches the production session factory: only
+        # rollback (not commit) can expire objects.
+        self.Session = async_sessionmaker(self.engine, expire_on_commit=False)
+
+        async with self.Session() as session:
+            session.add(XtreamAccount(
+                id=1, name="acc", server_url="http://test",
+                username="u", password="p",
+            ))
+            session.add(AppSettings(
+                download_folder="/tmp/dl",
+                completed_folder="/tmp/done",
+                min_free_space_gb=1,
+            ))
+            await session.commit()
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _add_schedules(self, *schedules):
+        async with self.Session() as session:
+            for s in schedules:
+                session.add(s)
+            await session.commit()
+            for s in schedules:
+                await session.refresh(s)
+
+    async def test_b_dispatches_after_a_queue_fails(self):
+        """B is QUEUED even when A's queue_download raises after starting a DB
+        transaction, which causes session.rollback() to expire B's attributes."""
+        sched_a = _make_schedule("ch1", "Show A")
+        sched_b = _make_schedule("ch2", "Show B")
+        await self._add_schedules(sched_a, sched_b)
+        a_id, b_id = sched_a.id, sched_b.id
+
+        build_call = [0]
+        queue_call = [0]
+
+        async def fake_build(session, **kwargs):
+            build_call[0] += 1
+            return _make_download(build_call[0])
+
+        async def fake_queue(dl, session=None):
+            queue_call[0] += 1
+            if queue_call[0] == 1 and session is not None:
+                # Simulate real queue_download: execute a DB statement so the
+                # session has an active transaction, then raise. This causes the
+                # scheduler's session.rollback() to expire all session objects
+                # (including B), reproducing the MissingGreenlet bug.
+                await session.execute(text("SELECT 1"))
+                raise Exception("Simulated queue failure for A")
+            return dl
+
+        fake_dm = MagicMock()
+        fake_dm.queue_download = AsyncMock(side_effect=fake_queue)
+        fake_dm.enqueue_persisted = AsyncMock(side_effect=lambda dl: dl)
+
+        manager = ScheduledManager()
+
+        @asynccontextmanager
+        async def session_maker():
+            async with self.Session() as session:
+                yield session
+
+        with (
+            patch("services.scheduled_manager.async_session_maker", session_maker),
+            patch("services.scheduled_manager.build_download_from_program", new=fake_build),
+            patch("services.scheduled_manager.download_manager", fake_dm),
+            patch.object(manager, "_get_free_space_gb", return_value=100.0),
+            patch.object(manager, "_get_catchup_window_days", new=AsyncMock(return_value=7)),
+        ):
+            await manager._queue_ready_recordings()
+
+        async with self.Session() as session:
+            a_db = (await session.execute(
+                select(ScheduledRecording).where(ScheduledRecording.id == a_id)
+            )).scalar_one()
+            b_db = (await session.execute(
+                select(ScheduledRecording).where(ScheduledRecording.id == b_id)
+            )).scalar_one()
+
+        self.assertEqual(
+            a_db.status,
+            ScheduledStatus.FAILED.value,
+            "Schedule A must be FAILED because its queue raised an exception.",
+        )
+        self.assertEqual(
+            b_db.status,
+            ScheduledStatus.QUEUED.value,
+            f"Schedule B must be QUEUED after A fails. "
+            f"Got status={b_db.status!r}, message={b_db.status_message!r}",
+        )
+        self.assertNotIn(
+            "MissingGreenlet",
+            b_db.status_message or "",
+            "B must not be marked FAILED with a SQLAlchemy internal error.",
+        )


### PR DESCRIPTION
## What this fixes

On Unraid, if two recordings are scheduled to start within the same 30-second window and the first one hits an error (for example, the provider rejects it), the second recording would silently fail with a confusing internal error. In the Scheduled Recordings history, users would see a message like:

> greenlet_spawn has not been called; can't call await_only() here.

This is a SQLAlchemy internal error with no meaning to the operator. The second recording stays stuck as FAILED forever, even though nothing was wrong with it.

## Root cause

When a dispatch fails, the scheduler calls `session.rollback()` to undo the staging of the failed download. SQLAlchemy's rollback expires all objects in the session's identity map, including the *next* schedule in the same batch. When the loop then reads that schedule's attributes (`program_title`, `channel_id`, etc.), the async session cannot lazily reload them and raises `MissingGreenlet`. The generic `except Exception` handler catches it and marks the schedule FAILED.

## Fix

All schedule attributes that the dispatch block needs are now read into a plain Python dict before the loop starts, while the session is clean. The local copies survive any rollback, so a failure on schedule A cannot affect schedule B's data.

`session.refresh(schedule)` inside the loop still re-reads the ORM object from the DB before committing, so the QUEUED update always reflects the current DB state.

## How it was tested

**Before the fix:** `test_dispatch_rollback_expiry.py` fails with `AssertionError: 'failed' != 'queued'`, and schedule B's `status_message` contains the `MissingGreenlet` error text.

**After the fix:** The same test passes. Schedule A is FAILED (its queue raised), schedule B is QUEUED (dispatched normally).

The test uses a real SQLAlchemy async session with SQLite in-memory. It makes `queue_download` execute a `SELECT 1` before raising, which starts a real active transaction. The subsequent rollback genuinely expires B's attributes, reproducing the exact failure mode.

Full backend test suite: 1022 tests pass.

## Steps to verify

1. Apply this PR locally.
2. Run `cd backend && python -m unittest tests.test_dispatch_rollback_expiry -v` -- should show OK.
3. Run the full suite: `python -m unittest discover -s tests` -- all 1022 tests pass.

There is no easy way to reproduce the original bug manually because it requires two schedules firing in the exact same 30-second tick, the first one failing with a DB write in flight.