### PR TITLE
docs: changelog for PR #382, update README Comskip feature line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+### Fixed: Transcoded recordings are no longer lost when the completed folder drive is full
+
+**What you would notice:** On Unraid (or any setup where your completed recordings folder is on a different drive or NAS array than your download folder), if that destination drive ran out of space while Mustarrd was moving a freshly-transcoded .mkv or .mp4 into it, the file could vanish completely. The original .ts was already deleted by the transcode step, and the error handler then deleted the .mkv too, leaving you with nothing and a FAILED status. After this fix, the .mkv or .mp4 stays safely in the download folder when the move fails, so you can free up space and move it yourself.
+
+**What changed:** The post-processing step now tracks the transcoded output file path separately from the original recording. If the drive-full error fires during the move, cleanup code uses the transcoded path as the "keep this" marker instead of the now-deleted original .ts path. The same protection applies when commercial removal is on (which also deletes the source .ts before returning). A new regression test confirms the .mkv survives a simulated out-of-space move. Backend only.
+
+---
+
 ### Improved: Downloads page now shows a countdown to when a scheduled recording will start
 
 **What you would notice:** On the Downloads page, each card in the Upcoming tab now shows how long until the recording begins, next to the scheduled start time. For example, you might see "Download starts: Today at 9:30 PM (in 20h 1m)". Previously you had to do the math yourself. If you have pre or post-recording padding set, the countdown and the padding note appear together: "(in 20h 1m, 1h 45m with padding)". The countdown disappears automatically once the recording is underway.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Mustarrd connects to your IPTV provider and lets you download past programs. Thi
 - **Browse past programs:** scroll back through your provider's program guide (EPG) and see what's available to download
 - **Starred channels:** star your favorite channels so they always appear at the top of the list
 - **Program preview:** preview a live channel or catchup program in your browser before queuing a download
-- **Commercial skip:** ComSkip integration removes commercials before saving
+- **Commercial skip:** ComSkip integration removes commercials before saving. Detection method, break length limits, show-protection margins, and thread count are all configurable from the Settings page, no config file editing needed
 - **Flexible output formats:** save recordings as-is (.ts), remux to MKV or MP4, or re-encode with FFmpeg for smaller files
 - **GPU-accelerated encoding:** if your server has an Intel, AMD, or NVIDIA GPU, re-encoding uses it automatically; the Settings page shows GPU status in plain language
 - **Download from On Demand:** If your provider provides on demand listings, you can grab those too!


### PR DESCRIPTION
## What changed

Two documentation updates for recently merged work.

**PR #382** (fix: protect transcoded output when move-to-completed fails, ENOSPC): Plain-English changelog entry. Explains the scenario where both the original .ts and the transcoded .mkv could vanish on Unraid when the destination drive was full. Written for a non-technical operator: you get nothing and a FAILED status before; you get the .mkv sitting in the download folder (safe, movable) after.

**README feature list**: Updated the Commercial skip bullet to mention that detection settings are now configurable in the Settings page, not just by editing comskip.ini by hand. Reflects the new Comskip section added by PR #387 (already in CHANGELOG).

## How tested

- Reviewed PR #382 diff and PR body for accuracy
- Checked the new CHANGELOG entry against the before/after screenshots in PR #382
- Grep confirms no em dashes in new prose
- README change is one sentence, matches what the Settings page actually shows after PR #387