### PR TITLE
fix: always clean up comskip sidecars on post-process cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-10
 
+### Fixed: Cancelling a recording during commercial removal no longer leaves comskip files on disk
+
+**What you would notice:** After cancelling a recording while Mustarrd was running commercial detection or removal, files like `ShowName.edl`, `ShowName.txt`, `ShowName.log`, and `ShowName.csv` would be left behind in your download folder forever. These are working files Comskip creates and they would slowly accumulate after every cancel. They are now cleaned up automatically when you cancel, the same way they are on a normal failure.
+
+**What changed:** Backend only. When a post-processing job is cancelled, Mustarrd now always cleans up Comskip working files regardless of what the database says about the download's status. Previously, a race condition meant the cancel request would update the database before the cleanup code ran, causing the cleanup to be silently skipped.
+
+---
+
 ### Added: Tune Comskip commercial detection from the Settings page
 
 **What you would notice:** Settings now has a dedicated **Comskip** section (between Post-Processing and File Naming). You can choose which signals Comskip uses to find commercials (black frames, logo detection, scene change, resolution change, aspect ratio change, silence), set commercial break and single-commercial length limits, protect the start and end of recordings from being cut, and pick how many CPU threads Comskip uses. Every field has a tooltip explaining what it does, there is a Reset to Defaults button, and the page warns you inline if a minimum is set higher than its maximum. When Comskip is turned off, the section stays visible but greyed out with a note pointing to Post-Processing. Previously these values could only be changed by editing `comskip.ini` by hand.

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -1110,19 +1110,20 @@ class DownloadManager:
                     download.status = DownloadStatus.CANCELLED.value
                     await self._sync_schedule_status(session, download_id, DownloadStatus.CANCELLED.value)
                     await session.commit()
-                    # Remove Comskip artifacts and partial transcode outputs left
-                    # by the cancelled run. The original recording is kept.
-                    if working_input_path:
-                        self._cleanup_working_files(
-                            working_input_path,
-                            completed_output_path or post_processed_path or working_input_path,
-                            keep_logs=False,
-                            delete_original=False,
-                        )
                     await self._broadcast_progress(
                         download_id, download.progress, DownloadStatus.CANCELLED.value
                     )
                     await self._broadcast_log(download_id, "Post-processing cancelled.", level="warning")
+                # Always clean up working files regardless of DB status: cancel_download
+                # writes CANCELLED to DB before the asyncio CancelledError fires, so the
+                # status guard above would be False and cleanup would be skipped.
+                if working_input_path:
+                    self._cleanup_working_files(
+                        working_input_path,
+                        completed_output_path or post_processed_path or working_input_path,
+                        keep_logs=False,
+                        delete_original=False,
+                    )
 
             except Exception as e:
                 if moved_completed_path is not None and os.path.exists(moved_completed_path):

--- a/backend/tests/test_post_process_failure_cancel_cleanup.py
+++ b/backend/tests/test_post_process_failure_cancel_cleanup.py
@@ -182,6 +182,62 @@ class PostProcessFailureCancelCleanupTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(txt.exists(), ".txt must be cleaned up after cancel.")
         self.assertFalse(partial_mkv.exists(), "Partial .mkv must be cleaned up after cancel.")
 
+    async def test_cancel_after_cancel_download_cleans_sidecars(self):
+        """Regression: cancel_download pre-writes CANCELLED to DB before the asyncio
+        CancelledError fires. The status guard in the CancelledError handler would see
+        CANCELLED and skip cleanup, orphaning EDL and comskip sidecar files."""
+        download_id, ts_path = await self._seed_db()
+        ts_file = Path(ts_path)
+        edl = ts_file.with_suffix(".edl")
+        txt = ts_file.with_suffix(".txt")
+        log = ts_file.with_suffix(".log")
+        partial_mkv = ts_file.with_suffix(".mkv")
+
+        session_factory = self.session_factory
+
+        async def fake_detect(*args, **kwargs):
+            edl.write_text("60.0 120.0 0\n")
+            txt.write_text("comskip output")
+            log.write_text("comskip log")
+            return str(edl)
+
+        async def fake_remove(*args, **kwargs):
+            partial_mkv.write_bytes(b"\x00" * 512)
+            # Simulate what cancel_download does: write CANCELLED to DB before
+            # the CancelledError reaches _execute_post_process.
+            async with session_factory() as session:
+                result = await session.execute(
+                    select(Download).where(Download.id == download_id)
+                )
+                dl = result.scalar_one_or_none()
+                if dl:
+                    dl.status = DownloadStatus.CANCELLED.value
+                    await session.commit()
+            raise asyncio.CancelledError()
+
+        mock_pp = MagicMock()
+        mock_pp.comskip_available = True
+        mock_pp.ffmpeg_available = True
+        mock_pp.get_ffmpeg_path.return_value = "/usr/bin/ffmpeg"
+        mock_pp.detect_commercials = AsyncMock(side_effect=fake_detect)
+        mock_pp.remove_commercials = AsyncMock(side_effect=fake_remove)
+        mock_pp.transcode = AsyncMock()
+
+        p = self._run_with_patches(mock_pp)
+        with p[0], p[1], p[2], p[3]:
+            try:
+                await self.manager._execute_post_process(download_id)
+            except asyncio.CancelledError:
+                pass
+
+        dl = await self._get_download(download_id)
+        self.assertEqual(dl.status, DownloadStatus.CANCELLED.value)
+        self.assertTrue(ts_file.exists(), "Raw recording must stay in the download folder.")
+        self.assertFalse(edl.exists(), ".edl must be cleaned up even when DB already shows CANCELLED.")
+        self.assertFalse(txt.exists(), ".txt must be cleaned up even when DB already shows CANCELLED.")
+        self.assertFalse(partial_mkv.exists(), "Partial .mkv must be cleaned up.")
+        self.assertFalse(log.exists(), ".log must be cleaned up on cancel (keep_logs=False).")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

Backend only. One-line change to `_execute_post_process` in `download_manager.py`, plus a regression test.

## The problem

When you cancel a recording while commercial removal (Comskip) is running, files like `ShowName.edl`, `ShowName.txt`, `ShowName.log`, and `ShowName.csv` were left behind in the download folder permanently. Every cancel during active commercial removal added more orphaned files.

**Root cause:** `cancel_download` writes `CANCELLED` to the database before the asyncio task's `CancelledError` fires. The `CancelledError` handler in `_execute_post_process` re-reads the database, sees `CANCELLED`, and a status guard (`download.status in [PENDING, DOWNLOADING, PROCESSING]`) evaluates to `False`. The `_cleanup_working_files` call inside that guard was never reached. This was effectively dead code on the real cancel path.

The existing test `test_cancel_cleans_comskip_artifacts_and_partial_output` was a false positive: it raises `CancelledError` directly from inside `detect_commercials` without calling `cancel_download` first, so the database still shows `PROCESSING` and the guard passes. It gave false confidence.

## The fix

Move `_cleanup_working_files` outside the status guard so it always runs when `working_input_path` is set. The DB status update and broadcast calls stay inside the guard. This matches how the `except Exception` handler already handles cleanup (line 1163 in the original).

```python
# Before: cleanup inside status guard — dead code when cancel_download pre-writes CANCELLED
if download and download.status in [PENDING, DOWNLOADING, PROCESSING]:
    ...
    if working_input_path:
        self._cleanup_working_files(...)  # never reached

# After: cleanup always runs
if download and download.status in [PENDING, DOWNLOADING, PROCESSING]:
    ...  # DB update + broadcasts only
if working_input_path:
    self._cleanup_working_files(...)  # always runs
```

## Test

`test_cancel_after_cancel_download_cleans_sidecars` reproduces the exact race:

1. Seed download as `PROCESSING`.
2. `fake_detect` creates `.edl`, `.txt`, `.log` files and returns the edl path (succeeds normally).
3. `fake_remove` writes `CANCELLED` to the DB (simulating `cancel_download`), then raises `CancelledError`.
4. `_execute_post_process` catches `CancelledError`, re-reads DB, sees `CANCELLED`.
5. **Before fix:** guard is `False`, cleanup skipped, files remain. **After fix:** cleanup runs, files removed.

1049 tests pass.

## Before / After

**Before:** cancel a recording while Comskip is running. Open your download folder. `ShowName.edl`, `ShowName.txt`, `ShowName.log`, `ShowName.csv` are still there.

**After:** those files are gone after cancel, same as after a failed recording.