### PR TITLE
Detect spaced and multi-digit season/episode markers in EPG data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-11
 
+### Fixed: TV episodes are actually detected, so recordings get proper episode filenames
+
+**What you would notice:** Programs with season/episode info in their guide data — like "S54 E173" in the description — were being treated as generic programs and named with just the title and date (e.g. `The Price Is Right 2026-06-10.ts`). They're now recognized as TV episodes and named accordingly (e.g. `The Price Is Right - S54E173.ts`), both in the download dialog's filename preview and in the final file. Sports detection also got smarter: it no longer flags titles like "Canvas Painting" as sports just because "vs" appears inside a word, and it recognizes more leagues and competitions (MLS, WNBA, NCAA, F1, NASCAR, world cup, playoffs, and others).
+
+**What changed:** Backend only. The episode detection regex only matched `S01E01` glued together with a two-digit episode number; real EPG data commonly uses spaced (`S54 E173`), punctuated (`S04, E12`), worded (`Season 4, Episode 12`, `S54 Ep. 173`), and three-digit-episode forms, all of which now match (episode numbers up to 4 digits). The program-type classifier (`epg_service.detect_program_type`) and the filename generator (`file_namer`) each had their own slightly different patterns and could disagree; both now share one pattern set in `FileNamer`. Sports keyword matching switched from substring checks to word-boundary regexes with an expanded league list, and news keywords got word boundaries too ("The Newsroom" is no longer classified as news). Regression tests cover all the new formats.
+
+---
+
 ### Changed: Channel logos in the guide render clean and load instantly after the first visit
 
 **What you would notice:** In the Browse channel list and guide header, channel logos no longer sit inside a bordered box with a dark fill behind them — logos with transparency now sit directly on the row, sized consistently. The boxed look only remains for channels with no logo at all, which still show their two-letter initials. Logos also load instantly after the first visit instead of re-downloading from your provider every time you open the guide; if a channel's logo URL is dead, the initials fallback appears instead of a broken image.

--- a/backend/services/epg_service.py
+++ b/backend/services/epg_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from models import XtreamAccount, EPGProgram, AppSettings
 from services.account_credentials import resolve_account_password_with_migration
+from services.file_namer import FileNamer
 from services.xtream_client import XtreamClient
 from config import settings as app_settings
 
@@ -484,25 +485,24 @@ class EPGService:
 
         Returns: 'tv_show', 'movie', 'sports', 'news', or 'other'
         """
-        title = program.get("title", "").lower()
-        description = program.get("description", "").lower()
+        import re
+        title = program.get("title", "") or ""
+        description = program.get("description", "") or ""
         category = ""
         if channel:
-            category = channel.get("category_name", "").lower()
+            category = (channel.get("category_name", "") or "").lower()
 
-        # Check for TV show patterns (season/episode)
-        import re
-        if re.search(r's\d{1,2}e\d{1,2}|season\s*\d+|episode\s*\d+', title + description, re.IGNORECASE):
+        # TV show: season/episode markers anywhere in title or description.
+        # Uses the same patterns as FileNamer so the detected type and the
+        # generated filename can't disagree.
+        full_text = f"{title} {description}"
+        if FileNamer.extract_season_episode(full_text):
+            return "tv_show"
+        # Episode-only markers (daily shows): "Ep 173", "Episode 5"
+        if re.search(r'\b(?:season|episode|ep)\.?\s*\d{1,4}\b', full_text, re.IGNORECASE):
             return "tv_show"
 
-        # Check for sports
-        sports_keywords = ['vs', 'vs.', ' @ ', 'nfl', 'nba', 'nhl', 'mlb', 'ufc', 'boxing',
-                          'soccer', 'football', 'basketball', 'hockey', 'baseball', 'tennis',
-                          'golf', 'racing', 'motorsport', 'wrestling', 'mma']
-        sports_categories = ['sports', 'deportes', 'sport', 'esports']
-
-        if any(kw in title for kw in sports_keywords) or \
-           any(cat in category for cat in sports_categories):
+        if FileNamer.detect_sports(title, category):
             return "sports"
 
         # Check for movies
@@ -513,7 +513,8 @@ class EPGService:
         # Check for news
         news_keywords = ['news', 'noticias', 'journal', 'breaking']
         news_categories = ['news', 'noticias', 'information']
-        if any(kw in title for kw in news_keywords) or \
+        title_lower = title.lower()
+        if any(re.search(rf'\b{kw}\b', title_lower) for kw in news_keywords) or \
            any(cat in category for cat in news_categories):
             return "news"
 

--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -4,13 +4,32 @@ from typing import Optional, Tuple
 
 
 class FileNamer:
-    # Sports keywords for detection
-    SPORTS_KEYWORDS = [
-        'vs', 'vs.', ' @ ', 'nfl', 'nba', 'nhl', 'mlb', 'ufc', 'boxing',
-        'soccer', 'football', 'basketball', 'hockey', 'baseball', 'tennis',
-        'golf', 'racing', 'motorsport', 'wrestling', 'mma', 'fifa', 'uefa',
-        'premier league', 'la liga', 'serie a', 'bundesliga', 'champions league'
+    # Shared season/episode patterns. Order matters: the S/E form is tried first
+    # so "S54 E173" doesn't fall through to the looser NxNN form.
+    # Covers: S01E01, S54 E173, S54.E173, S54-E173, S04, E12,
+    # Season 4 Episode 12, Season 4, Episode 12, S54 Ep. 173, Sn 4 Ep 12
+    SEASON_EPISODE_PATTERNS = [
+        re.compile(
+            r'\b[Ss](?:eason|n)?\s*(\d{1,2})\s*[.,\-]?\s*'
+            r'[Ee](?:p(?:isode)?)?\.?\s*(\d{1,4})\b'
+        ),
+        # 4x12, 54x173 — no spaces around the x, so "3 x 4" in prose doesn't match
+        re.compile(r'\b(\d{1,2})[xX](\d{1,4})\b'),
     ]
+
+    # Word-boundary sports detection: bare substrings like 'vs' or 'mma'
+    # false-positive inside words ("canvas", "grammar").
+    SPORTS_TITLE_PATTERN = re.compile(
+        r'\bvs\.?\b'
+        r'|@'
+        r'|\b(?:nfl|nba|wnba|nhl|mlb|mls|ufc|mma|ncaa|fifa|uefa|f1|nascar|motogp|pga|lpga|atp|wta)\b'
+        r'|\b(?:boxing|soccer|football|basketball|hockey|baseball|tennis|golf|racing|motorsport|wrestling|cricket|rugby)\b'
+        r'|\b(?:premier league|la liga|serie a|bundesliga|ligue 1|champions league|europa league'
+        r'|world cup|stanley cup|super bowl|world series|grand prix)\b'
+        r'|\b(?:round|week|matchday)\s+\d+\b'
+        r'|\bplayoffs?\b|\bsemi-?finals?\b|\bquarter-?finals?\b',
+        re.IGNORECASE,
+    )
 
     SPORTS_CATEGORIES = ['sports', 'deportes', 'sport', 'esports']
 
@@ -41,53 +60,43 @@ class FileNamer:
             sanitized = encoded[:200].decode("utf-8", errors="ignore").rstrip() or "unknown-program"
         return sanitized
 
-    @staticmethod
-    def extract_season_episode(text: str) -> Optional[Tuple[int, int]]:
+    @classmethod
+    def extract_season_episode(cls, text: str) -> Optional[Tuple[int, int]]:
         """Extract season and episode numbers from text."""
-        # Common patterns: S01E01, S1E1, Season 1 Episode 1, 1x01
-        patterns = [
-            r'[Ss](\d{1,2})[Ee](\d{1,2})',  # S01E01
-            r'[Ss]eason\s*(\d{1,2})\s*[Ee]pisode\s*(\d{1,2})',  # Season 1 Episode 1
-            r'(\d{1,2})[xX](\d{1,2})',  # 1x01
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, text, re.IGNORECASE)
+        for pattern in cls.SEASON_EPISODE_PATTERNS:
+            match = pattern.search(text)
             if match:
                 return (int(match.group(1)), int(match.group(2)))
 
         return None
 
-    @staticmethod
-    def extract_show_name(title: str) -> str:
+    @classmethod
+    def extract_show_name(cls, title: str) -> str:
         """Extract the show name from a title with season/episode info."""
-        # Remove season/episode patterns
-        patterns = [
-            r'\s*[Ss]\d{1,2}[Ee]\d{1,2}.*$',
-            r'\s*[Ss]eason\s*\d+.*$',
-            r'\s*\d{1,2}[xX]\d{1,2}.*$',
-        ]
+        for pattern in cls.SEASON_EPISODE_PATTERNS:
+            match = pattern.search(title)
+            if match:
+                before = title[:match.start()].strip(' -:,.(')
+                if before:
+                    return before
+                # Pattern at the very start of the title — keep whatever follows
+                return pattern.sub('', title, count=1).strip(' -:,.)')
 
-        show_name = title
-        for pattern in patterns:
-            show_name = re.sub(pattern, '', show_name, flags=re.IGNORECASE)
-
+        # Season-only titles like "Show Name Season 4"
+        show_name = re.sub(r'\s*[Ss]eason\s*\d+.*$', '', title)
         return show_name.strip(' -:')
 
-    @staticmethod
-    def extract_episode_title(title: str) -> str:
+    @classmethod
+    def extract_episode_title(cls, title: str) -> str:
         """Extract the episode title from a full title."""
-        # Try to find content after season/episode pattern
-        patterns = [
-            r'[Ss]\d{1,2}[Ee]\d{1,2}\s*[-:]\s*(.+)$',
-            r'[Ss]eason\s*\d+\s*[Ee]pisode\s*\d+\s*[-:]\s*(.+)$',
-            r'\d{1,2}[xX]\d{1,2}\s*[-:]\s*(.+)$',
-        ]
-
-        for pattern in patterns:
-            match = re.search(pattern, title, re.IGNORECASE)
+        for pattern in cls.SEASON_EPISODE_PATTERNS:
+            match = pattern.search(title)
             if match:
-                return match.group(1).strip()
+                after = title[match.end():]
+                sep = re.match(r'\s*[-–:]\s*(.+)$', after)
+                if sep:
+                    return sep.group(1).strip()
+                return ""
 
         return ""
 
@@ -102,11 +111,10 @@ class FileNamer:
     @classmethod
     def detect_sports(cls, title: str, category: str = "") -> bool:
         """Check if content is sports-related."""
-        title_lower = title.lower()
         category_lower = category.lower()
 
         return (
-            any(kw in title_lower for kw in cls.SPORTS_KEYWORDS) or
+            bool(cls.SPORTS_TITLE_PATTERN.search(title)) or
             any(cat in category_lower for cat in cls.SPORTS_CATEGORIES)
         )
 

--- a/backend/tests/test_detect_program_type.py
+++ b/backend/tests/test_detect_program_type.py
@@ -1,0 +1,71 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from services.epg_service import epg_service
+
+
+class DetectProgramTypeTests(unittest.TestCase):
+    def _detect(self, title, description="", category=None):
+        program = {"title": title, "description": description}
+        channel = {"category_name": category} if category is not None else None
+        return epg_service.detect_program_type(program, channel)
+
+    def test_spaced_episode_in_description_is_tv_show(self):
+        # Regression: "S54 E173" (spaced) was classified as "other"
+        result = self._detect(
+            "The Price Is Right",
+            "S54 E173 Participants must guess the prices of different types of items.",
+        )
+        self.assertEqual(result, "tv_show")
+
+    def test_glued_episode_is_tv_show(self):
+        self.assertEqual(self._detect("The Crown S01E01 - Hyde Park Corner"), "tv_show")
+
+    def test_three_digit_episode_is_tv_show(self):
+        self.assertEqual(self._detect("Show", "S54E173"), "tv_show")
+
+    def test_episode_only_marker_is_tv_show(self):
+        self.assertEqual(self._detect("Late Night Show", "Ep 173"), "tv_show")
+
+    def test_nba_title_is_sports(self):
+        result = self._detect(
+            "2026 NBA Finals : San Antonio Spurs at New York Knicks",
+            "The Knicks host the Spurs at Madison Square Garden for Game 4 of the NBA Finals.",
+        )
+        self.assertEqual(result, "sports")
+
+    def test_sports_channel_category(self):
+        self.assertEqual(self._detect("Some Broadcast", category="US Sports"), "sports")
+
+    def test_vs_inside_word_not_sports(self):
+        self.assertEqual(self._detect("Canvas Painting Masterclass"), "other")
+
+    def test_mma_inside_word_not_sports(self):
+        self.assertEqual(self._detect("Grammar School Stories"), "other")
+
+    def test_roman_numeral_not_sports(self):
+        self.assertEqual(self._detect("Henry V"), "other")
+
+    def test_news_word_boundary(self):
+        self.assertEqual(self._detect("Evening News"), "news")
+        # "news" inside "Newsroom" must not match
+        self.assertEqual(self._detect("The Newsroom"), "other")
+
+    def test_movie_category(self):
+        self.assertEqual(self._detect("Heat", category="Movies"), "movie")
+
+    def test_none_description(self):
+        # Programs with a null description must not crash detection
+        self.assertEqual(epg_service.detect_program_type({"title": "Show", "description": None}), "other")
+
+    def test_plain_program_is_other(self):
+        self.assertEqual(self._detect("Morning Talk"), "other")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_file_namer.py
+++ b/backend/tests/test_file_namer.py
@@ -80,5 +80,151 @@ class SanitizeFilenameTests(unittest.TestCase):
         self.assertLessEqual(len(result.encode("utf-8")), 200)
 
 
+class ExtractSeasonEpisodeTests(unittest.TestCase):
+    def test_glued_format(self):
+        self.assertEqual(FileNamer.extract_season_episode("S01E01"), (1, 1))
+
+    def test_glued_three_digit_episode(self):
+        # Daily shows exceed 99 episodes; old pattern capped at 2 digits
+        self.assertEqual(FileNamer.extract_season_episode("S54E173"), (54, 173))
+
+    def test_spaced_format(self):
+        # The common EPG format "S54 E173" was not detected at all
+        self.assertEqual(FileNamer.extract_season_episode("S54 E173"), (54, 173))
+
+    def test_dot_separator(self):
+        self.assertEqual(FileNamer.extract_season_episode("S54.E173"), (54, 173))
+
+    def test_dash_separator(self):
+        self.assertEqual(FileNamer.extract_season_episode("S54-E173"), (54, 173))
+
+    def test_comma_separator(self):
+        self.assertEqual(FileNamer.extract_season_episode("S04, E12"), (4, 12))
+
+    def test_season_episode_words(self):
+        self.assertEqual(FileNamer.extract_season_episode("Season 4 Episode 12"), (4, 12))
+
+    def test_season_episode_words_with_comma(self):
+        self.assertEqual(FileNamer.extract_season_episode("Season 4, Episode 12"), (4, 12))
+
+    def test_ep_abbreviation(self):
+        self.assertEqual(FileNamer.extract_season_episode("S54 Ep 173"), (54, 173))
+
+    def test_ep_abbreviation_with_period(self):
+        self.assertEqual(FileNamer.extract_season_episode("S54 Ep. 173"), (54, 173))
+
+    def test_cross_format(self):
+        self.assertEqual(FileNamer.extract_season_episode("4x12"), (4, 12))
+
+    def test_cross_format_three_digit_episode(self):
+        self.assertEqual(FileNamer.extract_season_episode("54x173"), (54, 173))
+
+    def test_resolution_not_matched(self):
+        # "1280x720" in a description must not parse as season/episode
+        self.assertIsNone(FileNamer.extract_season_episode("Broadcast in 1280x720"))
+
+    def test_spaced_x_in_prose_not_matched(self):
+        self.assertIsNone(FileNamer.extract_season_episode("a 3 x 4 grid of items"))
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(FileNamer.extract_season_episode("The Evening Show"))
+
+    def test_marker_in_description(self):
+        text = "The Price Is Right S54 E173 Participants must guess the prices"
+        self.assertEqual(FileNamer.extract_season_episode(text), (54, 173))
+
+
+class ExtractShowNameTests(unittest.TestCase):
+    def test_glued_marker(self):
+        self.assertEqual(FileNamer.extract_show_name("The Crown S01E01 - Hyde Park Corner"), "The Crown")
+
+    def test_spaced_marker(self):
+        self.assertEqual(FileNamer.extract_show_name("The Crown S1 E1 - Hyde Park Corner"), "The Crown")
+
+    def test_cross_marker(self):
+        self.assertEqual(FileNamer.extract_show_name("The Office 2x04 - The Dundies"), "The Office")
+
+    def test_season_only(self):
+        self.assertEqual(FileNamer.extract_show_name("Show Name Season 4"), "Show Name")
+
+    def test_no_marker_unchanged(self):
+        self.assertEqual(FileNamer.extract_show_name("The Price Is Right"), "The Price Is Right")
+
+
+class ExtractEpisodeTitleTests(unittest.TestCase):
+    def test_dash_subtitle(self):
+        self.assertEqual(
+            FileNamer.extract_episode_title("The Crown S01E01 - Hyde Park Corner"),
+            "Hyde Park Corner",
+        )
+
+    def test_colon_subtitle_spaced_marker(self):
+        self.assertEqual(
+            FileNamer.extract_episode_title("The Crown S1 E1: Hyde Park Corner"),
+            "Hyde Park Corner",
+        )
+
+    def test_no_subtitle(self):
+        self.assertEqual(FileNamer.extract_episode_title("The Crown S01E01"), "")
+
+    def test_no_marker(self):
+        self.assertEqual(FileNamer.extract_episode_title("The Price Is Right"), "")
+
+
+class DetectSportsTests(unittest.TestCase):
+    def test_league_acronym(self):
+        self.assertTrue(FileNamer.detect_sports("2026 NBA Finals : San Antonio Spurs at New York Knicks"))
+
+    def test_at_sign(self):
+        self.assertTrue(FileNamer.detect_sports("Spurs @ Knicks"))
+
+    def test_vs_word(self):
+        self.assertTrue(FileNamer.detect_sports("Team A vs Team B"))
+
+    def test_vs_inside_word_not_matched(self):
+        # 'vs' substring in "canvas" used to false-positive
+        self.assertFalse(FileNamer.detect_sports("Canvas Painting Masterclass"))
+
+    def test_mma_inside_word_not_matched(self):
+        self.assertFalse(FileNamer.detect_sports("Grammar School Stories"))
+
+    def test_sports_category(self):
+        self.assertTrue(FileNamer.detect_sports("Some Broadcast", "US Sports"))
+
+
+class GenerateFilenameTests(unittest.TestCase):
+    def setUp(self):
+        self.namer = FileNamer()
+        self.channel = {"name": "US CBS EAST"}
+
+    def test_spaced_episode_in_description(self):
+        # Regression: "S54 E173" in the description must produce an episode filename
+        program = {
+            "title": "The Price Is Right",
+            "description": "S54 E173 Participants must guess the prices of different types of items.",
+            "start_time": "2026-06-10T08:00:00",
+        }
+        result = self.namer.generate_filename(program, self.channel, "tv_show")
+        self.assertEqual(result, "The Price Is Right - S54E173.ts")
+
+    def test_episode_with_subtitle_in_title(self):
+        program = {
+            "title": "The Crown S01E01 - Hyde Park Corner",
+            "description": "",
+            "start_time": "2026-06-10T20:00:00",
+        }
+        result = self.namer.generate_filename(program, self.channel, "tv_show")
+        self.assertEqual(result, "The Crown - S01E01 - Hyde Park Corner.ts")
+
+    def test_sports_filename(self):
+        program = {
+            "title": "2026 NBA Finals : San Antonio Spurs at New York Knicks",
+            "description": "Game 4 of the NBA Finals.",
+            "start_time": "2026-06-10T17:30:00",
+        }
+        result = self.namer.generate_filename(program, self.channel, "sports")
+        self.assertEqual(result, "2026 NBA Finals San Antonio Spurs at New York Knicks - 2026-06-10.ts")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- EPG episode detection only matched glued `S01E01` with a 2-digit episode; real guide data uses `S54 E173`, `S04, E12`, `Season 4, Episode 12`, `S54 Ep. 173`, `54x173`. All now match (episodes up to 4 digits), so daily shows like The Price Is Right get `Show - S54E173.ts` instead of `Show 2026-06-10.ts`.
- `epg_service.detect_program_type` and `FileNamer` had separate, slightly different regexes that could disagree between the type badge and the generated filename; both now share one pattern set in `FileNamer`.
- Sports/news keyword matching switched from substring to word-boundary regexes ("Canvas" no longer matches `vs`, "The Newsroom" no longer news) and the sports list gained MLS, WNBA, NCAA, F1, NASCAR, world cup, playoffs, and more.

## Steps to test
1. `cd backend && python -m unittest tests.test_file_namer tests.test_detect_program_type`
2. In the app, open a Download dialog for a program whose description starts with `S## E###` (e.g. The Price Is Right): badge should read TV SHOW and the filename preview should be `Show - S##E###.ts`.
3. Open a sports event (e.g. an NBA game): badge stays SPORTS, filename `{title} - {date}.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)