### PR TITLE
Fix Firefox HLS playback and add full-length scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ## 2026-06-11
 
-### Fixed: On phones, the channel guide scrolls again and program titles wrap instead of getting chopped
+### Fixed: Recordings play in Firefox-based browsers, and the player scrub bar now spans the whole recording
+
+**What you would notice:** Playing a finished MKV recording in Firefox (or forks like Zen) failed immediately with a `bufferAddCodecError`, even though the same recording played fine in Chrome. That's fixed. Separately, the in-app player's progress bar used to only cover the part of the recording the server had prepared so far, growing as it went — you couldn't jump ahead. The player now shows a scrub bar spanning the full length of the show right away, and dragging it anywhere starts playback from that spot, even into parts that haven't been prepared yet.
+
+**What changed:** Browser playback of MKV/odd-codec recordings goes through an on-the-fly FFmpeg HLS repackager that copied any AAC audio as-is. Provider streams often carry HE-AAC or a mislabeled "Main"-profile AAC, which becomes a codec string (`mp4a.40.1`/`mp4a.40.5`) Firefox's MediaSource refuses to buffer; Chrome is lenient, which is why it only broke in Firefox. The repackager now copies only AAC-LC and re-encodes anything else to AAC-LC. For scrubbing: a new `playback-info` endpoint reports the recording's full duration up front, the player replaces the native controls with its own transport bar (play/pause, full-length seek slider, mute, fullscreen) when using the HLS path, and seeking past the prepared portion restarts the FFmpeg session at the target offset via a `start` parameter on the playlist URL. Regression tests cover the codec gating, offset sessions, and the new seek behavior.
+
+---
 
 **What you would notice:** On a phone, opening a channel in Browse showed its program list spilling past the bottom of the screen with no way to scroll it — the list wouldn't budge and neither would the page, so anything below the first screenful was unreachable. That works again: the guide panel now ends at the bottom of the screen and the program list scrolls inside it. Long program titles ("Entertainment Tonig…") and the channel header's catchup summary ("105 pro…") were also being cut off mid-word; titles now wrap onto a second line and the header text wraps fully.
 

--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -551,17 +551,33 @@ async def get_download_file(
     )
 
 
+@router.get("/{download_id}/playback-info")
+async def get_download_playback_info(
+    download_id: int,
+    auth: AuthContext = Depends(require_admin_or_download_user),
+    session: AsyncSession = Depends(get_session),
+):
+    """Duration metadata for the player's scrub bar (full length up front,
+    even while the HLS rendition is still being produced)."""
+    file_path = await _resolve_completed_download_file(download_id, auth, session)
+    duration = await hls_streamer.probe_duration(file_path)
+    return {"duration": duration}
+
+
 @router.get("/{download_id}/hls/{asset}")
 async def get_download_hls_asset(
     download_id: int,
     asset: str,
+    start: float = Query(default=0.0, ge=0.0),
     auth: AuthContext = Depends(require_admin_or_download_user),
     session: AsyncSession = Depends(get_session),
 ):
     """Serve an on-the-fly HLS rendition of a completed download.
 
     Requesting playlist.m3u8 starts (or reuses) an FFmpeg repackaging session;
-    init.mp4/segments are only served while that session is alive.
+    init.mp4/segments are only served while that session is alive. `start`
+    repackages from that offset so the player can scrub ahead of the
+    already-produced portion.
     """
     if not HLS_ASSET_PATTERN.match(asset):
         raise HTTPException(status_code=404, detail="Unknown stream asset")
@@ -570,7 +586,7 @@ async def get_download_hls_asset(
 
     if asset == "playlist.m3u8":
         try:
-            hls_session = await hls_streamer.get_or_create(download_id, file_path)
+            hls_session = await hls_streamer.get_or_create(download_id, file_path, start)
             await hls_streamer.wait_for_playlist(hls_session)
         except HLSLimitError as exc:
             raise HTTPException(status_code=429, detail=str(exc))

--- a/backend/services/hls_streamer.py
+++ b/backend/services/hls_streamer.py
@@ -61,6 +61,7 @@ class HLSSession:
     download_id: int
     source_path: Path
     directory: Path
+    start_offset: float = 0.0
     process: Optional[asyncio.subprocess.Process] = None
     last_access: float = field(default_factory=time.monotonic)
     failed_reason: Optional[str] = None
@@ -82,13 +83,17 @@ class HLSStreamer:
 
     # ------------------------------------------------------------------ probe
 
-    async def _probe_codecs(self, ffprobe: str, source: Path) -> tuple[Optional[str], Optional[str]]:
-        """Return (video_codec, audio_codec) of the first streams, or Nones."""
+    async def _probe_media(
+        self, ffprobe: str, source: Path
+    ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[float]]:
+        """Return (video_codec, audio_codec, audio_profile, duration) of the
+        first streams, or Nones for whatever is missing."""
         process = await asyncio.create_subprocess_exec(
             ffprobe,
             "-v", "error",
             "-print_format", "json",
             "-show_streams",
+            "-show_format",
             str(source),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
@@ -104,20 +109,41 @@ class HLSStreamer:
         return self._parse_probe_output(stdout.decode("utf-8", errors="replace"))
 
     @staticmethod
-    def _parse_probe_output(raw: str) -> tuple[Optional[str], Optional[str]]:
+    def _parse_probe_output(
+        raw: str,
+    ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[float]]:
         try:
-            streams = json.loads(raw).get("streams", [])
+            parsed = json.loads(raw)
+            streams = parsed.get("streams", [])
         except (json.JSONDecodeError, AttributeError):
             raise HLSStartError("The recording could not be probed")
         video_codec = None
         audio_codec = None
+        audio_profile = None
         for stream in streams:
             codec_type = stream.get("codec_type")
             if codec_type == "video" and video_codec is None:
                 video_codec = stream.get("codec_name")
             elif codec_type == "audio" and audio_codec is None:
                 audio_codec = stream.get("codec_name")
-        return video_codec, audio_codec
+                audio_profile = stream.get("profile")
+        duration = None
+        try:
+            duration = float(parsed.get("format", {}).get("duration"))
+        except (TypeError, ValueError):
+            pass
+        return video_codec, audio_codec, audio_profile, duration
+
+    async def probe_duration(self, source_path: Path) -> Optional[float]:
+        """Best-effort duration of a recording in seconds, or None."""
+        ffprobe = post_processor.get_ffprobe_path()
+        if not ffprobe:
+            return None
+        try:
+            _, _, _, duration = await self._probe_media(ffprobe, source_path)
+        except HLSError:
+            return None
+        return duration
 
     # ----------------------------------------------------------------- ffmpeg
 
@@ -127,6 +153,8 @@ class HLSStreamer:
         source: Path,
         video_codec: Optional[str],
         audio_codec: Optional[str],
+        audio_profile: Optional[str] = None,
+        start_offset: float = 0.0,
     ) -> list[str]:
         cmd = [
             ffmpeg,
@@ -134,12 +162,18 @@ class HLSStreamer:
             "-nostdin",
             "-hide_banner",
             "-loglevel", "error",
+        ]
+        if start_offset > 0:
+            # Input-side seek: lands on the keyframe at/before the target so
+            # copied video starts decodable.
+            cmd.extend(["-ss", f"{start_offset:.3f}"])
+        cmd.extend([
             "-i", str(source),
             "-map", "0:v:0",
             "-map", "0:a:0?",
             "-sn",
             "-dn",
-        ]
+        ])
         if video_codec in COPYABLE_VIDEO_CODECS:
             cmd.extend(["-c:v", "copy"])
             if video_codec == "hevc":
@@ -153,7 +187,11 @@ class HLSStreamer:
                 "-pix_fmt", "yuv420p",
                 "-force_key_frames", "expr:gte(t,n_forced*6)",
             ])
-        if audio_codec == "aac":
+        if audio_codec == "aac" and audio_profile == "LC":
+            # Only AAC-LC is copied: Firefox's MSE rejects any AAC codec
+            # string other than mp4a.40.2/.5/.29, and provider streams often
+            # carry HE-AAC or a mislabeled Main profile (mp4a.40.1) that
+            # throws bufferAddCodecError. Re-encoding guarantees LC.
             # ADTS-framed AAC (MPEG-TS sources) must be converted to ASC for
             # fMP4; the filter passes non-ADTS packets through untouched.
             cmd.extend(["-c:a", "copy", "-bsf:a", "aac_adtstoasc"])
@@ -182,7 +220,9 @@ class HLSStreamer:
     def touch(session: HLSSession) -> None:
         session.last_access = time.monotonic()
 
-    async def get_or_create(self, download_id: int, source_path: Path) -> HLSSession:
+    async def get_or_create(
+        self, download_id: int, source_path: Path, start_offset: float = 0.0
+    ) -> HLSSession:
         async with self._lock:
             existing = self._sessions.get(download_id)
             if existing:
@@ -192,11 +232,16 @@ class HLSStreamer:
                     and process.returncode is not None
                     and process.returncode != 0
                 )
-                if existing.source_path == source_path and not existing.failed_reason and not crashed:
+                if (
+                    existing.source_path == source_path
+                    and existing.start_offset == start_offset
+                    and not existing.failed_reason
+                    and not crashed
+                ):
                     self.touch(existing)
                     return existing
-                # Source changed (re-download), FFmpeg crashed, or a previous
-                # attempt failed: rebuild from scratch.
+                # Source changed (re-download), seek to a new offset, FFmpeg
+                # crashed, or a previous attempt failed: rebuild from scratch.
                 await self._destroy_locked(existing)
 
             await self._reap_idle_locked()
@@ -210,7 +255,9 @@ class HLSStreamer:
             if not ffmpeg or not ffprobe:
                 raise HLSUnavailableError("FFmpeg is required for browser playback but was not found")
 
-            video_codec, audio_codec = await self._probe_codecs(ffprobe, source_path)
+            video_codec, audio_codec, audio_profile, _ = await self._probe_media(
+                ffprobe, source_path
+            )
             if video_codec is None:
                 raise HLSStartError("The recording has no video stream")
 
@@ -220,9 +267,12 @@ class HLSStreamer:
                 download_id=download_id,
                 source_path=source_path,
                 directory=session_dir,
+                start_offset=start_offset,
             )
 
-            cmd = self.build_ffmpeg_command(ffmpeg, source_path, video_codec, audio_codec)
+            cmd = self.build_ffmpeg_command(
+                ffmpeg, source_path, video_codec, audio_codec, audio_profile, start_offset
+            )
             # stderr goes to a log file in the session dir: no pipe to drain,
             # and the tail is available for error reporting.
             stderr_path = session_dir / "ffmpeg.log"
@@ -249,8 +299,8 @@ class HLSStreamer:
             self._sessions[download_id] = session
             self._ensure_reaper()
             logger.info(
-                "HLS session started download_id=%s video=%s audio=%s dir=%s",
-                download_id, video_codec, audio_codec, session_dir,
+                "HLS session started download_id=%s video=%s audio=%s profile=%s start=%.1f dir=%s",
+                download_id, video_codec, audio_codec, audio_profile, start_offset, session_dir,
             )
             return session
 

--- a/backend/tests/test_hls_api.py
+++ b/backend/tests/test_hls_api.py
@@ -12,7 +12,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from api.downloads import get_download_hls_asset
+from api.downloads import get_download_hls_asset, get_download_playback_info
 from auth import AuthContext
 from models import AppSettings, Download, DownloadStatus
 from services.hls_streamer import HLSSession, HLSStartError
@@ -55,7 +55,7 @@ class HLSAssetValidationTests(unittest.IsolatedAsyncioTestCase):
         session = AsyncMock()
         for asset in ["../playlist.m3u8", "ffmpeg.log", "seg1.m4s", "evil.m4s"]:
             with self.assertRaises(HTTPException) as ctx:
-                await get_download_hls_asset(1, asset, ADMIN, session)
+                await get_download_hls_asset(1, asset, auth=ADMIN, session=session)
             self.assertEqual(ctx.exception.status_code, 404, asset)
         session.execute.assert_not_called()
 
@@ -63,7 +63,7 @@ class HLSAssetValidationTests(unittest.IsolatedAsyncioTestCase):
         session = AsyncMock()
         session.execute = AsyncMock(side_effect=[_ScalarResult(None)])
         with self.assertRaises(HTTPException) as ctx:
-            await get_download_hls_asset(1, "playlist.m3u8", ADMIN, session)
+            await get_download_hls_asset(1, "playlist.m3u8", auth=ADMIN, session=session)
         self.assertEqual(ctx.exception.status_code, 404)
 
     async def test_not_completed_409(self):
@@ -72,7 +72,7 @@ class HLSAssetValidationTests(unittest.IsolatedAsyncioTestCase):
             _ScalarResult(_make_download("/x.ts", status=DownloadStatus.DOWNLOADING.value)),
         ])
         with self.assertRaises(HTTPException) as ctx:
-            await get_download_hls_asset(1, "playlist.m3u8", ADMIN, session)
+            await get_download_hls_asset(1, "playlist.m3u8", auth=ADMIN, session=session)
         self.assertEqual(ctx.exception.status_code, 409)
 
 
@@ -94,11 +94,40 @@ class HLSPlaylistTests(unittest.IsolatedAsyncioTestCase):
                 mock_streamer.get_or_create = AsyncMock(return_value=hls_session)
                 mock_streamer.wait_for_playlist = AsyncMock()
 
-                result = await get_download_hls_asset(1, "playlist.m3u8", ADMIN, session)
+                result = await get_download_hls_asset(
+                    1, "playlist.m3u8", start=0.0, auth=ADMIN, session=session
+                )
 
             self.assertIsInstance(result, FileResponse)
             self.assertEqual(result.media_type, "application/vnd.apple.mpegurl")
             mock_streamer.get_or_create.assert_awaited_once()
+            # No explicit start: session begins at the top of the file.
+            self.assertEqual(mock_streamer.get_or_create.await_args.args[2], 0.0)
+
+    async def test_playlist_passes_start_offset_to_session(self):
+        with tempfile.TemporaryDirectory() as folder:
+            source = os.path.join(folder, "Show.ts")
+            Path(source).write_bytes(b"fake")
+            hls_dir = Path(tempfile.mkdtemp())
+            self.addCleanup(lambda: __import__("shutil").rmtree(hls_dir, ignore_errors=True))
+            hls_session = HLSSession(
+                download_id=1, source_path=Path(source), directory=hls_dir, start_offset=300.0
+            )
+            hls_session.playlist_path.write_text("#EXTM3U\nseg00000.m4s\n")
+
+            session = _session_for(_make_download(source), folder)
+            with patch("api.downloads.settings") as mock_cfg, \
+                    patch("api.downloads.hls_streamer") as mock_streamer:
+                mock_cfg.default_download_folder = folder
+                mock_cfg.default_completed_folder = folder
+                mock_streamer.get_or_create = AsyncMock(return_value=hls_session)
+                mock_streamer.wait_for_playlist = AsyncMock()
+
+                await get_download_hls_asset(
+                    1, "playlist.m3u8", start=300.0, auth=ADMIN, session=session
+                )
+
+            self.assertEqual(mock_streamer.get_or_create.await_args.args[2], 300.0)
 
     async def test_ffmpeg_failure_maps_to_502(self):
         with tempfile.TemporaryDirectory() as folder:
@@ -112,7 +141,7 @@ class HLSPlaylistTests(unittest.IsolatedAsyncioTestCase):
                 mock_streamer.get_or_create = AsyncMock(side_effect=HLSStartError("FFmpeg failed"))
 
                 with self.assertRaises(HTTPException) as ctx:
-                    await get_download_hls_asset(1, "playlist.m3u8", ADMIN, session)
+                    await get_download_hls_asset(1, "playlist.m3u8", auth=ADMIN, session=session)
                 self.assertEqual(ctx.exception.status_code, 502)
 
 
@@ -129,7 +158,7 @@ class HLSSegmentTests(unittest.IsolatedAsyncioTestCase):
                 mock_streamer.get_active.return_value = None
 
                 with self.assertRaises(HTTPException) as ctx:
-                    await get_download_hls_asset(1, "seg00000.m4s", ADMIN, session)
+                    await get_download_hls_asset(1, "seg00000.m4s", auth=ADMIN, session=session)
                 self.assertEqual(ctx.exception.status_code, 409)
 
     async def test_segment_served_and_session_touched(self):
@@ -148,7 +177,7 @@ class HLSSegmentTests(unittest.IsolatedAsyncioTestCase):
                 mock_cfg.default_completed_folder = folder
                 mock_streamer.get_active.return_value = hls_session
 
-                result = await get_download_hls_asset(1, "seg00000.m4s", ADMIN, session)
+                result = await get_download_hls_asset(1, "seg00000.m4s", auth=ADMIN, session=session)
 
             self.assertIsInstance(result, FileResponse)
             self.assertEqual(result.media_type, "video/iso.segment")
@@ -170,8 +199,40 @@ class HLSSegmentTests(unittest.IsolatedAsyncioTestCase):
                 mock_streamer.get_active.return_value = hls_session
 
                 with self.assertRaises(HTTPException) as ctx:
-                    await get_download_hls_asset(1, "seg00000.m4s", ADMIN, session)
+                    await get_download_hls_asset(1, "seg00000.m4s", auth=ADMIN, session=session)
                 self.assertEqual(ctx.exception.status_code, 404)
+
+
+class PlaybackInfoTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_probed_duration(self):
+        with tempfile.TemporaryDirectory() as folder:
+            source = os.path.join(folder, "Show.mkv")
+            Path(source).write_bytes(b"fake")
+            session = _session_for(_make_download(source), folder)
+            with patch("api.downloads.settings") as mock_cfg, \
+                    patch("api.downloads.hls_streamer") as mock_streamer:
+                mock_cfg.default_download_folder = folder
+                mock_cfg.default_completed_folder = folder
+                mock_streamer.probe_duration = AsyncMock(return_value=2641.47)
+
+                result = await get_download_playback_info(1, auth=ADMIN, session=session)
+
+            self.assertEqual(result, {"duration": 2641.47})
+
+    async def test_unprobeable_file_returns_null_duration(self):
+        with tempfile.TemporaryDirectory() as folder:
+            source = os.path.join(folder, "Show.mkv")
+            Path(source).write_bytes(b"fake")
+            session = _session_for(_make_download(source), folder)
+            with patch("api.downloads.settings") as mock_cfg, \
+                    patch("api.downloads.hls_streamer") as mock_streamer:
+                mock_cfg.default_download_folder = folder
+                mock_cfg.default_completed_folder = folder
+                mock_streamer.probe_duration = AsyncMock(return_value=None)
+
+                result = await get_download_playback_info(1, auth=ADMIN, session=session)
+
+            self.assertEqual(result, {"duration": None})
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_hls_streamer.py
+++ b/backend/tests/test_hls_streamer.py
@@ -42,11 +42,13 @@ class AssetPatternTests(unittest.TestCase):
 
 
 class FfmpegCommandTests(unittest.TestCase):
-    def _cmd(self, video, audio):
-        return HLSStreamer.build_ffmpeg_command("ffmpeg", Path("/x/in.ts"), video, audio)
+    def _cmd(self, video, audio, profile="LC", start=0.0):
+        return HLSStreamer.build_ffmpeg_command(
+            "ffmpeg", Path("/x/in.ts"), video, audio, profile, start
+        )
 
-    def test_h264_aac_copies_both(self):
-        cmd = self._cmd("h264", "aac")
+    def test_h264_aac_lc_copies_both(self):
+        cmd = self._cmd("h264", "aac", "LC")
         self.assertIn("-c:v", cmd)
         self.assertEqual(cmd[cmd.index("-c:v") + 1], "copy")
         self.assertEqual(cmd[cmd.index("-c:a") + 1], "copy")
@@ -66,6 +68,32 @@ class FfmpegCommandTests(unittest.TestCase):
         """ADTS AAC from MPEG-TS breaks fMP4 muxing without aac_adtstoasc."""
         cmd = self._cmd("h264", "aac")
         self.assertEqual(cmd[cmd.index("-bsf:a") + 1], "aac_adtstoasc")
+
+    def test_he_aac_transcodes_to_lc(self):
+        """Firefox MSE rejects non-LC AAC codec strings (bufferAddCodecError)."""
+        cmd = self._cmd("h264", "aac", "HE-AAC")
+        self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+        self.assertNotIn("-bsf:a", cmd)
+
+    def test_main_profile_aac_transcodes_to_lc(self):
+        """Provider ADTS headers mislabeled as AAC Main become mp4a.40.1
+        under -c:a copy, which Firefox refuses to buffer."""
+        cmd = self._cmd("h264", "aac", "Main")
+        self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+
+    def test_unknown_aac_profile_transcodes_to_lc(self):
+        cmd = self._cmd("h264", "aac", None)
+        self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+
+    def test_start_offset_seeks_before_input(self):
+        cmd = self._cmd("h264", "aac", "LC", start=93.5)
+        ss = cmd.index("-ss")
+        self.assertEqual(cmd[ss + 1], "93.500")
+        self.assertLess(ss, cmd.index("-i"))
+
+    def test_zero_start_offset_omits_seek(self):
+        cmd = self._cmd("h264", "aac", "LC", start=0.0)
+        self.assertNotIn("-ss", cmd)
 
     def test_ac3_audio_transcodes_to_aac(self):
         cmd = self._cmd("h264", "ac3")
@@ -92,15 +120,30 @@ class ProbeParseTests(unittest.TestCase):
         raw = (
             '{"streams": ['
             '{"codec_type": "video", "codec_name": "h264"},'
-            '{"codec_type": "audio", "codec_name": "ac3"},'
-            '{"codec_type": "audio", "codec_name": "aac"},'
+            '{"codec_type": "audio", "codec_name": "ac3", "profile": "Dolby Digital"},'
+            '{"codec_type": "audio", "codec_name": "aac", "profile": "LC"},'
             '{"codec_type": "subtitle", "codec_name": "dvb_subtitle"}'
             "]}"
         )
-        self.assertEqual(HLSStreamer._parse_probe_output(raw), ("h264", "ac3"))
+        self.assertEqual(
+            HLSStreamer._parse_probe_output(raw), ("h264", "ac3", "Dolby Digital", None)
+        )
+
+    def test_parses_audio_profile_and_duration(self):
+        raw = (
+            '{"streams": ['
+            '{"codec_type": "video", "codec_name": "h264"},'
+            '{"codec_type": "audio", "codec_name": "aac", "profile": "HE-AAC"}'
+            '], "format": {"duration": "2641.472000"}}'
+        )
+        self.assertEqual(
+            HLSStreamer._parse_probe_output(raw), ("h264", "aac", "HE-AAC", 2641.472)
+        )
 
     def test_missing_streams_returns_nones(self):
-        self.assertEqual(HLSStreamer._parse_probe_output('{"streams": []}'), (None, None))
+        self.assertEqual(
+            HLSStreamer._parse_probe_output('{"streams": []}'), (None, None, None, None)
+        )
 
     def test_garbage_raises(self):
         with self.assertRaises(HLSStartError):
@@ -125,6 +168,20 @@ class SessionLifecycleTests(unittest.IsolatedAsyncioTestCase):
         result = await streamer.get_or_create(1, Path("/media/a.ts"))
         self.assertIs(result, session)
         self.assertTrue(session.directory.exists())
+        await streamer.shutdown()
+
+    async def test_different_start_offset_rebuilds_session(self):
+        """Seeking outside the produced range requests a new offset; the old
+        session must be torn down rather than served from the wrong position."""
+        streamer = HLSStreamer()
+        session = self._make_session(streamer, 1, "/media/a.ts")
+        with patch("services.hls_streamer.post_processor") as mock_pp:
+            mock_pp.get_ffmpeg_path.return_value = None
+            mock_pp.get_ffprobe_path.return_value = None
+            with self.assertRaises(hls_module.HLSUnavailableError):
+                await streamer.get_or_create(1, Path("/media/a.ts"), start_offset=120.0)
+        self.assertNotIn(1, streamer._sessions)
+        self.assertFalse(session.directory.exists())
         await streamer.shutdown()
 
     async def test_failed_session_is_not_reused(self):
@@ -225,7 +282,7 @@ class SessionLifecycleTests(unittest.IsolatedAsyncioTestCase):
         with (
             patch("services.hls_streamer.tempfile.mkdtemp", tracking_mkdtemp),
             patch("services.hls_streamer.asyncio.create_subprocess_exec", cancelled_spawn),
-            patch.object(streamer, "_probe_codecs", AsyncMock(return_value=("h264", "aac"))),
+            patch.object(streamer, "_probe_media", AsyncMock(return_value=("h264", "aac", "LC", None))),
             patch("services.hls_streamer.post_processor") as mock_pp,
         ):
             mock_pp.get_ffmpeg_path.return_value = "/usr/bin/ffmpeg"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -124,6 +124,7 @@ export const downloadsApi = {
   getQueue: () => request('/downloads/queue'),
   getHistory: () => request('/downloads/history'),
   get: (id) => request(`/downloads/${id}`),
+  playbackInfo: (id) => request(`/downloads/${id}/playback-info`),
   create: (data) => request('/downloads', { method: 'POST', body: data }),
   cancel: (id) => request(`/downloads/${id}`, { method: 'DELETE' }),
   retry: (id) => request(`/downloads/${id}/retry`, { method: 'POST' }),

--- a/frontend/src/pages/DownloadPlayer.jsx
+++ b/frontend/src/pages/DownloadPlayer.jsx
@@ -1,10 +1,30 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Alert, Button, Group, Loader, Stack, Text, Title } from '@mantine/core'
-import { IconAlertCircle, IconDownload } from '@tabler/icons-react'
+import { ActionIcon, Alert, Button, Group, Loader, Slider, Stack, Text, Title } from '@mantine/core'
+import {
+  IconAlertCircle,
+  IconDownload,
+  IconMaximize,
+  IconPlayerPauseFilled,
+  IconPlayerPlayFilled,
+  IconVolume,
+  IconVolumeOff,
+} from '@tabler/icons-react'
 import { downloadsApi } from '../api'
 import { attachHls, attachMpegts, pickEngine } from '../utils/playbackEngine'
+
+function formatTime(totalSeconds) {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '0:00'
+  const s = Math.floor(totalSeconds)
+  const hours = Math.floor(s / 3600)
+  const minutes = Math.floor((s % 3600) / 60)
+  const seconds = s % 60
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
 
 export default function DownloadPlayer() {
   const { downloadId } = useParams()
@@ -12,6 +32,7 @@ export default function DownloadPlayer() {
   const isValidId = Number.isInteger(parsedId) && parsedId > 0
 
   const videoRef = useRef(null)
+  const containerRef = useRef(null)
   // Engine fallback chain: preferred engine first; native/mpegts failures
   // retry through the server-side HLS rendition before giving up.
   const [engine, setEngine] = useState(null)
@@ -20,12 +41,32 @@ export default function DownloadPlayer() {
   // allow one transparent restart that resumes from the same position.
   const [hlsAttempt, setHlsAttempt] = useState(0)
   const resumePositionRef = useRef(-1)
+  // The HLS rendition is produced on the fly, so the playlist only covers
+  // what FFmpeg has emitted so far. Scrubbing past that point restarts the
+  // session at the target offset; hlsStart is that offset, and all timeline
+  // positions shown to the user are hlsStart + the element's currentTime.
+  const [hlsStart, setHlsStart] = useState(0)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [isMuted, setIsMuted] = useState(false)
+  const [scrubValue, setScrubValue] = useState(null)
 
   const { data: download, isLoading, error: loadError } = useQuery({
     queryKey: ['download', parsedId],
     queryFn: () => downloadsApi.get(parsedId),
     enabled: isValidId,
   })
+
+  const { data: playbackInfo } = useQuery({
+    queryKey: ['download-playback-info', parsedId],
+    queryFn: () => downloadsApi.playbackInfo(parsedId),
+    enabled: isValidId && engine === 'hls',
+    staleTime: Infinity,
+  })
+  const fullDuration = playbackInfo?.duration > 0 ? playbackInfo.duration : null
+  // Custom transport bar only makes sense for the HLS rendition (the other
+  // engines play the finished file, where native controls already work).
+  const customControls = engine === 'hls' && fullDuration != null
 
   const playUrl = useMemo(() => {
     if (!isValidId) return null
@@ -39,14 +80,17 @@ export default function DownloadPlayer() {
 
   const hlsUrl = useMemo(() => {
     if (!isValidId) return null
-    return `/api/downloads/${parsedId}/hls/playlist.m3u8`
-  }, [isValidId, parsedId])
+    const base = `/api/downloads/${parsedId}/hls/playlist.m3u8`
+    return hlsStart > 0 ? `${base}?start=${hlsStart.toFixed(3)}` : base
+  }, [isValidId, parsedId, hlsStart])
 
   useEffect(() => {
     if (download?.output_path) {
       setEngine(pickEngine(download.output_path))
       setPlaybackError(null)
       setHlsAttempt(0)
+      setHlsStart(0)
+      setCurrentTime(0)
       resumePositionRef.current = -1
     }
   }, [download?.output_path])
@@ -90,6 +134,72 @@ export default function DownloadPlayer() {
       video.load()
     }
   }, [engine, playUrl, hlsUrl, hlsAttempt])
+
+  // Mirror the media element's state into the custom transport bar.
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video || !customControls) return undefined
+    const onTimeUpdate = () => setCurrentTime(video.currentTime || 0)
+    const onPlay = () => setIsPlaying(true)
+    const onPause = () => setIsPlaying(false)
+    const onVolumeChange = () => setIsMuted(video.muted)
+    video.addEventListener('timeupdate', onTimeUpdate)
+    video.addEventListener('play', onPlay)
+    video.addEventListener('pause', onPause)
+    video.addEventListener('volumechange', onVolumeChange)
+    setIsPlaying(!video.paused)
+    setIsMuted(video.muted)
+    return () => {
+      video.removeEventListener('timeupdate', onTimeUpdate)
+      video.removeEventListener('play', onPlay)
+      video.removeEventListener('pause', onPause)
+      video.removeEventListener('volumechange', onVolumeChange)
+    }
+  }, [customControls])
+
+  const seekTo = useCallback((target) => {
+    const video = videoRef.current
+    if (!video || fullDuration == null) return
+    const clamped = Math.min(Math.max(target, 0), fullDuration)
+    const relative = clamped - hlsStart
+    const seekableEnd = video.seekable?.length
+      ? video.seekable.end(video.seekable.length - 1)
+      : 0
+    if (relative >= 0 && relative <= seekableEnd) {
+      video.currentTime = relative
+      setCurrentTime(relative)
+      return
+    }
+    // Outside what this session has produced: restart FFmpeg at the target.
+    resumePositionRef.current = -1
+    setCurrentTime(0)
+    setHlsStart(clamped)
+  }, [fullDuration, hlsStart])
+
+  const togglePlay = useCallback(() => {
+    const video = videoRef.current
+    if (!video) return
+    if (video.paused) {
+      video.play()?.catch(() => {})
+    } else {
+      video.pause()
+    }
+  }, [])
+
+  const toggleMute = useCallback(() => {
+    const video = videoRef.current
+    if (video) video.muted = !video.muted
+  }, [])
+
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen()?.catch(() => {})
+    } else {
+      containerRef.current?.requestFullscreen()?.catch(() => {})
+    }
+  }, [])
+
+  const timelinePosition = scrubValue ?? Math.min(hlsStart + currentTime, fullDuration || 0)
 
   if (!isValidId) {
     return (
@@ -142,15 +252,73 @@ export default function DownloadPlayer() {
       {isLoading ? (
         <Group justify="center" py="xl"><Loader /></Group>
       ) : (
-        <video
-          ref={videoRef}
-          controls
-          autoPlay
-          playsInline
-          preload="metadata"
-          style={{ width: '100%', maxHeight: '70vh', background: '#000', borderRadius: 8 }}
-          data-engine={engine || undefined}
-        />
+        <div
+          ref={containerRef}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            background: '#000',
+            borderRadius: 8,
+            overflow: 'hidden',
+          }}
+        >
+          <video
+            ref={videoRef}
+            controls={!customControls}
+            autoPlay
+            playsInline
+            preload="metadata"
+            onClick={customControls ? togglePlay : undefined}
+            style={{ width: '100%', maxHeight: '70vh', background: '#000', flex: 1, minHeight: 0 }}
+            data-engine={engine || undefined}
+          />
+          {customControls && (
+            <Group gap="sm" px="sm" py={8} wrap="nowrap" bg="dark.8" data-testid="transport-bar">
+              <ActionIcon
+                variant="subtle"
+                color="gray.0"
+                onClick={togglePlay}
+                aria-label={isPlaying ? 'Pause' : 'Play'}
+              >
+                {isPlaying ? <IconPlayerPauseFilled size={18} /> : <IconPlayerPlayFilled size={18} />}
+              </ActionIcon>
+              <Text size="xs" c="gray.3" style={{ whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}>
+                {formatTime(timelinePosition)} / {formatTime(fullDuration)}
+              </Text>
+              <Slider
+                style={{ flex: 1 }}
+                size="sm"
+                min={0}
+                max={fullDuration}
+                step={1}
+                value={timelinePosition}
+                onChange={setScrubValue}
+                onChangeEnd={(value) => {
+                  setScrubValue(null)
+                  seekTo(value)
+                }}
+                label={(value) => formatTime(value)}
+                thumbLabel="Seek"
+              />
+              <ActionIcon
+                variant="subtle"
+                color="gray.0"
+                onClick={toggleMute}
+                aria-label={isMuted ? 'Unmute' : 'Mute'}
+              >
+                {isMuted ? <IconVolumeOff size={18} /> : <IconVolume size={18} />}
+              </ActionIcon>
+              <ActionIcon
+                variant="subtle"
+                color="gray.0"
+                onClick={toggleFullscreen}
+                aria-label="Fullscreen"
+              >
+                <IconMaximize size={18} />
+              </ActionIcon>
+            </Group>
+          )}
+        </div>
       )}
     </Stack>
   )

--- a/frontend/src/pages/DownloadPlayer.test.jsx
+++ b/frontend/src/pages/DownloadPlayer.test.jsx
@@ -1,11 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { renderWithQuery } from '../test/renderWithProviders'
 
 const getDownload = vi.fn()
+const getPlaybackInfo = vi.fn()
 vi.mock('../api', () => ({
-  downloadsApi: { get: (...args) => getDownload(...args) },
+  downloadsApi: {
+    get: (...args) => getDownload(...args),
+    playbackInfo: (...args) => getPlaybackInfo(...args),
+  },
 }))
 
 const attachMpegts = vi.fn(() => () => {})
@@ -34,6 +38,7 @@ function renderPlayer(downloadId) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  getPlaybackInfo.mockResolvedValue({ duration: null })
 })
 
 describe('DownloadPlayer', () => {
@@ -89,6 +94,67 @@ describe('DownloadPlayer', () => {
     // A second fatal error surfaces the failure instead of looping.
     attachHls.mock.calls[1][2].onError('fatalError')
     await waitFor(() => expect(screen.getByText(/Playback failed/)).toBeInTheDocument())
+  })
+
+  it('shows a full-length transport bar once the duration is known', async () => {
+    getDownload.mockResolvedValue({
+      id: 7,
+      output_path: '/data/completed/Show.mkv',
+      program_title: 'Show',
+    })
+    getPlaybackInfo.mockResolvedValue({ duration: 600 })
+    renderPlayer(7)
+
+    await waitFor(() => expect(screen.getByTestId('transport-bar')).toBeInTheDocument())
+    // Native controls give way to the custom bar, which spans the recording.
+    expect(document.querySelector('video')).not.toHaveAttribute('controls')
+    expect(screen.getByText('0:00 / 10:00')).toBeInTheDocument()
+    expect(screen.getByRole('slider', { name: 'Seek' })).toHaveAttribute('aria-valuemax', '600')
+  })
+
+  it('restarts the HLS session at the scrub target when seeking past the produced range', async () => {
+    getDownload.mockResolvedValue({
+      id: 7,
+      output_path: '/data/completed/Show.mkv',
+      program_title: 'Show',
+    })
+    getPlaybackInfo.mockResolvedValue({ duration: 600 })
+    renderPlayer(7)
+
+    await waitFor(() => expect(screen.getByRole('slider', { name: 'Seek' })).toBeInTheDocument())
+    expect(attachHls).toHaveBeenCalledTimes(1)
+    expect(attachHls.mock.calls[0][1]).toBe('/api/downloads/7/hls/playlist.m3u8')
+
+    // jsdom's video has no seekable ranges, so any forward seek lands outside
+    // the produced portion and must spawn a fresh session at the offset.
+    const slider = screen.getByRole('slider', { name: 'Seek' })
+    fireEvent.keyDown(slider, { key: 'ArrowRight' })
+
+    await waitFor(() => expect(attachHls).toHaveBeenCalledTimes(2))
+    expect(attachHls.mock.calls[1][1]).toBe('/api/downloads/7/hls/playlist.m3u8?start=1.000')
+  })
+
+  it('seeks within the already-produced range without a new session', async () => {
+    getDownload.mockResolvedValue({
+      id: 7,
+      output_path: '/data/completed/Show.mkv',
+      program_title: 'Show',
+    })
+    getPlaybackInfo.mockResolvedValue({ duration: 600 })
+    renderPlayer(7)
+
+    await waitFor(() => expect(screen.getByRole('slider', { name: 'Seek' })).toBeInTheDocument())
+    const video = document.querySelector('video')
+    Object.defineProperty(video, 'seekable', {
+      value: { length: 1, end: () => 120 },
+    })
+    Object.defineProperty(video, 'currentTime', { value: 0, writable: true })
+
+    const slider = screen.getByRole('slider', { name: 'Seek' })
+    fireEvent.keyDown(slider, { key: 'ArrowRight' })
+
+    await waitFor(() => expect(video.currentTime).toBe(1))
+    expect(attachHls).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to HLS when mpegts.js reports an error', async () => {


### PR DESCRIPTION
## Summary
- Playing a remuxed MKV in Firefox-based browsers (e.g. Zen) failed with `bufferAddCodecError`. The on-the-fly HLS repackager copied any AAC audio; provider streams often carry HE-AAC or a mislabeled Main-profile AAC, producing codec strings (`mp4a.40.1`/`mp4a.40.5`) Firefox's MediaSource refuses. Audio is now copied only when ffprobe reports the LC profile and re-encoded to AAC-LC otherwise.
- The player's progress bar only covered what FFmpeg had produced so far. A new `GET /api/downloads/{id}/playback-info` endpoint reports full duration up front; the player swaps native controls for a custom transport bar (play/pause, full-length seek slider, mute, fullscreen) on the HLS path. Seeking past the produced range restarts the FFmpeg session at the target via `?start=<seconds>` on the playlist URL (input-side `-ss`).

## Steps to test
1. Pick a completed MKV recording whose audio is HE-AAC or AAC Main (`ffprobe` shows profile != LC).
2. Open it in the in-app player in Firefox/Zen — it plays instead of failing with `bufferAddCodecError`.
3. While the HLS rendition is still being produced, the scrub bar already spans the full show; drag it well past the current point — playback resumes from there within a few seconds.
4. Scrub back and forth inside the already-produced range — seeks are instant, no session restart (no new `playlist.m3u8?start=` request in the network tab).

## Tests
- Backend: profile-gated copy, `-ss` placement, probe parsing, session rebuild on new offset, `start` passthrough, playback-info endpoint (`python -m unittest discover -s tests` — all green).
- Frontend: transport bar render, seek-past-range restarts with `?start=`, in-range seek stays in session (`npm test` — 100 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)