### PR TITLE
Commercial Skip: add Mark mode (.edl sidecar + Plex chapters, no cut)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Mustarrd are listed here. Most recent changes are at the 
 
 ---
 
+## 2026-06-23
+
+### Added: Commercial Skip can now mark ad breaks instead of cutting them
+
+**What you would notice:** The Settings "Remove commercials" on/off switch is now a three-way choice called **Commercials**: **Off · Mark only · Cut out**. "Cut out" is exactly the old behaviour — Comskip finds the ads and they're physically removed from the recording. The new "Mark only" keeps your recording whole and untouched, and instead saves where the ads are two ways: an `.edl` file next to the video (so Kodi, Jellyfin, Emby and MythTV auto-skip them) and commercial chapter markers inside MKV/MP4 files (so Plex can jump break-to-break by chapter). Unlike "Cut out," "Mark only" no longer forces a re-encode, so it works even with **Keep .ts** — though on Keep .ts you only get the `.edl` file, not the Plex chapters (Settings warns you about this). Existing setups come up as "Cut out," so nothing changes unless you switch.
+
+**What changed:** Commercial Skip split into two ideas: `comskip_enabled` ("does Comskip run") and a new `comskip_cut` flag ("cut vs. mark," defaults to cut). The "Comskip forces a re-encode" rule now applies to Cut mode only. In Mark mode the pipeline runs detection, skips the cut, keeps the Comskip `.edl` renamed to match the finished video and carried into the completed folder beside it, and — on an MKV/MP4 container pass — muxes in "Commercial" chapter markers derived from the same detection. Plex auto-skip of external files isn't possible without writing into Plex's private database (rejected); chapters are the supported stand-in. Regression tests cover the Mark-mode settings constraint, the chapter metadata, the kept/renamed sidecar, and that no cut is applied.
+
+---
+
 ## 2026-06-11
 
 ### Fixed: Recordings play in Firefox-based browsers, and the player scrub bar now spans the whole recording

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# Mustarrd
+
+An IPTV catchup DVR. It browses past EPG programs on Xtream Codes servers and
+downloads catchup/timeshift streams, with optional commercial detection and
+re-encoding before the finished file lands in the completed folder.
+
+## Language
+
+### Commercial Skip
+
+**Commercial Skip**:
+The feature (and Settings section) that runs Comskip over a recording to find
+advertising. It has three modes: Off, Mark, and Cut.
+_Avoid_: Comskip (that's the tool, not the feature), ad-detection
+
+**Mark** (mode):
+Comskip detects commercials and Mustarrd, without cutting the video, writes an
+EDL sidecar (for generic players) and embeds commercial-break chapter markers in
+the container (for Plex). The original content stays intact. Chapters require an
+MKV/MP4 container; on Keep .ts, Mark produces the sidecar only.
+_Avoid_: soft cut, EDL mode, sidecar mode
+
+**Commercial chapter**:
+A chapter marker embedded in the finished MKV/MP4 at a commercial boundary, so a
+Plex client can jump the break by chapter. Mustarrd's stand-in for Plex
+commercial skip, which Plex does not offer for non-DVR library files.
+_Avoid_: marker (overloaded by Plex's own DB markers), ad break
+
+**Cut** (mode):
+Comskip detects commercials and FFmpeg physically removes them, producing an
+altered, shorter video file. The pre-existing behaviour.
+_Avoid_: remove, hard cut, strip
+
+**EDL sidecar**:
+The `.edl` (Edit Decision List) file Comskip emits, named to match the finished
+video and placed alongside it, listing commercial segments so players can skip
+them. Produced only in Mark mode.
+_Avoid_: cutlist, skip file, chapters

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -98,6 +98,7 @@ class SettingsUpdate(BaseModel):
     remux_only: Optional[bool] = None
     integrity_check_enabled: Optional[bool] = None
     comskip_enabled: Optional[bool] = None
+    comskip_cut: Optional[bool] = None
     comskip_path: Optional[str] = None
     comskip_ini_path: Optional[str] = None
     comskip_custom_ini_path: Optional[str] = None
@@ -137,6 +138,7 @@ NON_NULLABLE_FIELDS = {
     "remux_only",
     "integrity_check_enabled",
     "comskip_enabled",
+    "comskip_cut",
     "comskip_detect_method",
     "comskip_max_commercialbreak",
     "comskip_min_commercialbreak",
@@ -302,12 +304,15 @@ async def update_settings(
             value = value.strip() or None
         setattr(settings, field, value)
 
-    # Enforce ComSkip constraint on the final stored state: comskip requires
-    # FFmpeg, so transcode_enabled must stay True.  remux_only is NOT forced
-    # off: the pipeline supports stream-copy commercial removal (segment
-    # extraction + concat with -c copy), so remux_only=True + comskip_enabled=True
-    # is the valid "fast remux + skip commercials" profile written by onboarding.
-    if settings.comskip_enabled:
+    # Enforce ComSkip constraint on the final stored state: the cut needs
+    # FFmpeg, so transcode_enabled must stay True.  This applies to Cut mode
+    # ONLY (comskip_enabled AND comskip_cut).  Mark mode (comskip_cut=False)
+    # does not cut, so it honours the format picker — including Keep .ts — and
+    # never forces a re-encode (see docs/adr/0001-commercial-skip-mark-mode.md).
+    # remux_only is NOT forced off: the pipeline supports stream-copy commercial
+    # removal (segment extraction + concat with -c copy), so remux_only=True +
+    # Cut is the valid "fast remux + skip commercials" profile from onboarding.
+    if settings.comskip_enabled and settings.comskip_cut:
         settings.transcode_enabled = True
 
     # Validate min<=max pairs on the final stored state so two separate PUT

--- a/backend/database.py
+++ b/backend/database.py
@@ -155,6 +155,13 @@ async def _apply_lightweight_migrations(conn) -> None:
         if await _column_exists(conn, "app_settings", "comskip_ini_path"):
             await _carry_over_legacy_comskip_ini(conn)
 
+    # Cut-vs-Mark flag for Commercial Skip. Defaults to 1 (Cut) so existing
+    # comskip_enabled installs keep cutting commercials exactly as before.
+    if not await _column_exists(conn, "app_settings", "comskip_cut"):
+        await conn.execute(
+            text("ALTER TABLE app_settings ADD COLUMN comskip_cut BOOLEAN DEFAULT 1")
+        )
+
 
 async def _carry_over_legacy_comskip_ini(conn) -> None:
     """Preserve a pre-editor custom comskip INI choice.

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -58,6 +58,11 @@ class AppSettings(Base):
     integrity_check_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
 
     comskip_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Cut vs Mark. True = Cut (physically remove commercials, the pre-existing
+    # behaviour, forces a re-encode). False = Mark (detect only; write an EDL
+    # sidecar + embed commercial chapters, no cut, no forced re-encode).
+    # Defaults to Cut so existing comskip_enabled installs are unchanged.
+    comskip_cut: Mapped[bool] = mapped_column(Boolean, default=True)
     comskip_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     comskip_ini_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
 
@@ -107,6 +112,7 @@ class AppSettings(Base):
             "remux_only": self.remux_only,
             "integrity_check_enabled": self.integrity_check_enabled,
             "comskip_enabled": self.comskip_enabled,
+            "comskip_cut": self.comskip_cut,
             "comskip_path": self.comskip_path,
             "comskip_ini_path": self.comskip_ini_path,
             "comskip_custom_ini_path": self.comskip_custom_ini_path,

--- a/backend/services/download_manager.py
+++ b/backend/services/download_manager.py
@@ -986,6 +986,7 @@ class DownloadManager:
             working_input_path: Optional[str] = None
             completed_output_path: Optional[str] = None
             post_processed_path: Optional[str] = None
+            moved_sidecar_path: Optional[str] = None
             try:
                 result = await session.execute(
                     select(Download).where(Download.id == download_id)
@@ -1066,6 +1067,11 @@ class DownloadManager:
                 completed_path = await self._move_to_completed_async(final_path, completed_folder, download_folder)
                 completed_output_path = completed_path
                 moved_completed_path = completed_path
+                # Mark mode leaves an .edl sidecar next to the final video; carry
+                # it to the completed folder in lockstep so its stem keeps matching.
+                moved_sidecar_path = await self._move_sidecar_to_completed(
+                    final_path, completed_path, completed_folder, download_folder
+                )
                 download.output_path = completed_path
                 await self._store_recorded_duration(download, completed_path)
                 integrity_warning = await self._integrity_check_warning(completed_path, settings)
@@ -1087,6 +1093,7 @@ class DownloadManager:
                     completed_path,
                     keep_logs=bool(warnings),
                     delete_original=delete_original,
+                    keep_paths=[moved_sidecar_path] if moved_sidecar_path else None,
                 )
 
                 download.status = DownloadStatus.COMPLETED.value
@@ -1462,11 +1469,40 @@ class DownloadManager:
         except Exception:
             pass
 
-    def _cleanup_working_files(self, original_path: str, completed_path: str, keep_logs: bool, delete_original: bool = True) -> None:
+    async def _move_sidecar_to_completed(
+        self,
+        final_path: str,
+        completed_path: str,
+        completed_folder: str,
+        download_folder: Optional[str],
+    ) -> Optional[str]:
+        """Carry a Mark-mode .edl sidecar to the completed folder beside its video.
+
+        The sidecar shares the final video's stem; it must land next to the moved
+        video so players find `Show - S01E04.edl` beside `Show - S01E04.mkv`.
+        No-op when there is no sidecar (Cut mode, or Comskip found nothing).
+        """
+        sidecar = Path(final_path).with_suffix(".edl")
+        if not sidecar.exists():
+            return None
+        dest = str(Path(completed_path).with_suffix(".edl"))
+        if os.path.abspath(str(sidecar)) == os.path.abspath(dest):
+            return dest  # completed == download folder; already in place
+        try:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            return await asyncio.to_thread(shutil.move, str(sidecar), dest)
+        except OSError:
+            return None
+
+    def _cleanup_working_files(self, original_path: str, completed_path: str, keep_logs: bool, delete_original: bool = True, keep_paths: Optional[list] = None) -> None:
         try:
             original_file = Path(original_path)
             base_dir = original_file.parent
             stem = original_file.stem
+            protected_reals = set()
+            for keep in (keep_paths or []):
+                if keep:
+                    protected_reals.add(os.path.realpath(os.path.abspath(str(keep))))
             # Escape glob special chars ([, ], ?) in the stem so channel names like
             # "[BBC HD]" don't silently fail to match or accidentally match unrelated files.
             escaped_stem = glob_module.escape(stem)
@@ -1502,6 +1538,8 @@ class DownloadManager:
                     try:
                         candidate_real = os.path.realpath(os.path.abspath(str(path)))
                         if candidate_real == completed_real:
+                            continue
+                        if candidate_real in protected_reals:
                             continue
                         path.unlink()
                     except Exception:
@@ -1938,6 +1976,12 @@ class DownloadManager:
 
         will_comskip = settings.comskip_enabled and post_processor.comskip_available
         will_transcode = settings.transcode_enabled and post_processor.ffmpeg_available
+        # Cut physically removes commercials (forces a container pass); Mark only
+        # detects, then keeps an EDL sidecar + embeds chapters on whatever
+        # container pass the format picker asks for. See ADR-0001.
+        comskip_cut = getattr(settings, "comskip_cut", True)
+        will_cut = will_comskip and comskip_cut
+        will_mark = will_comskip and not comskip_cut
 
         if not will_comskip and not will_transcode:
             return current_path, warnings
@@ -2012,6 +2056,7 @@ class DownloadManager:
         # log_callback defined above to also persist logs
 
         commercials_removed = False
+        mark_edl_path: Optional[str] = None  # set in Mark mode when commercials are found
 
         # Run Comskip if enabled
         if will_comskip:
@@ -2049,7 +2094,15 @@ class DownloadManager:
                 comskip_indeterminate = False
                 await broadcast_processing(comskip_progress, current_message, indeterminate=False)
 
-                if edl_path:
+                if edl_path and will_mark:
+                    # Mark mode: detection only. Defer the EDL sidecar + chapter
+                    # embedding until after any container pass so the sidecar is
+                    # named after the final video. The cut is intentionally skipped.
+                    mark_edl_path = edl_path
+                    await log_callback(
+                        "Comskip: commercials detected; marking only (video left uncut)."
+                    )
+                elif edl_path:
                     output_format = OutputFormat(settings.transcode_format or "mkv")
                     accel_name = hw_accel.value if hw_accel != HardwareAccel.CPU else "CPU"
                     if remux_only:
@@ -2115,6 +2168,22 @@ class DownloadManager:
                 await log_callback(f"Transcode error: {e}")
                 warnings.append(f"Transcode failed: {e}")
                 logger.exception("Transcode error (continuing anyway)")
+
+        # Mark mode: now that the final video exists (a container pass above for
+        # MKV/MP4, or the untouched .ts for Keep .ts), embed commercial chapters
+        # (MKV/MP4 only) and keep the EDL sidecar named after the final video.
+        if will_mark and mark_edl_path:
+            try:
+                current_path = await post_processor.embed_chapters(
+                    current_path, mark_edl_path, log_callback=log_callback
+                )
+                sidecar_path = post_processor._write_edl_sidecar(current_path, mark_edl_path)
+                if sidecar_path:
+                    await log_callback(f"Commercial Skip (Mark): wrote sidecar {os.path.basename(sidecar_path)}")
+            except Exception as e:
+                await log_callback(f"Commercial Skip (Mark) finalize error: {e}")
+                warnings.append(f"Commercial marking failed: {e}")
+                logger.exception("Mark-mode finalize error (continuing anyway)")
 
         return current_path, warnings
 

--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -1596,6 +1596,161 @@ class PostProcessor:
                         segments.append((start, end, seg_type))
         return segments
 
+    def _edl_to_ffmetadata_chapters(self, commercial_segments: list, duration: float) -> str:
+        """Build an FFMETADATA chapter block from parsed EDL commercial segments.
+
+        Used by Mark mode (see docs/adr/0002-plex-commercial-skip-via-chapters.md):
+        the unaltered video keeps its full runtime, and these chapters let a Plex
+        client jump break-to-break. Commercial spans are titled "Commercial"; the
+        content spans between/around them are chaptered too so every boundary is a
+        seek target. Returns "" when no commercials were found (no chapters to add).
+        """
+        commercials = [
+            (start, end) for start, end, _ in commercial_segments if end > start
+        ]
+        if not commercials:
+            return ""
+
+        # Label the whole timeline: commercial spans plus the content gaps
+        # between them (the inverse), then order by start time.
+        content = self._invert_segments(commercial_segments, duration)
+        spans = [(start, end, "Commercial") for start, end in commercials]
+        spans.extend((start, end, "Content") for start, end in content if end > start)
+        spans.sort(key=lambda s: s[0])
+
+        lines = [";FFMETADATA1"]
+        for start, end, title in spans:
+            start_ms = int(round(start * 1000))
+            end_ms = int(round(end * 1000))
+            if end_ms <= start_ms:
+                continue
+            lines.extend([
+                "",
+                "[CHAPTER]",
+                "TIMEBASE=1/1000",
+                f"START={start_ms}",
+                f"END={end_ms}",
+                f"title={title}",
+            ])
+        return "\n".join(lines) + "\n"
+
+    def _write_edl_sidecar(self, video_path: str, edl_path: str) -> Optional[str]:
+        """Keep the detected EDL as a sidecar named after the finished video.
+
+        Mark mode preserves Comskip's detection alongside the unaltered video:
+        `Show - S01E04.mkv` → `Show - S01E04.edl` in the same folder, so generic
+        players (Kodi/Jellyfin/Emby/MythTV) auto-skip from it. Returns the sidecar
+        path, or None when Comskip found no commercials (no stray sidecar then).
+
+        The Comskip EDL may be named after a probe file (`*_comskip_input.edl`)
+        rather than the final video; this renames it to the video's stem.
+        """
+        if not edl_path or not os.path.exists(edl_path):
+            return None
+
+        # Only keep a sidecar when there is something to skip.
+        if not self._parse_edl(edl_path):
+            return None
+
+        target = Path(video_path).with_suffix(".edl")
+        source = Path(edl_path)
+        if source.resolve() == target.resolve():
+            return str(target)
+
+        shutil.copyfile(source, target)
+        return str(target)
+
+    async def embed_chapters(
+        self,
+        video_path: str,
+        edl_path: str,
+        log_callback: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        """Mux commercial-break chapters (from the EDL) into an MKV/MP4 in place.
+
+        Mark mode's Plex path (ADR-0002): the unaltered video gets "Commercial"
+        chapter markers a Plex client can jump by. Chapters need a real container,
+        so this is a no-op for MPEG-TS (Keep .ts → sidecar only) and whenever
+        Comskip found nothing. Returns the path to the chaptered video (same path
+        on success; the original, untouched, on any skip/failure).
+        """
+        video = Path(video_path)
+        if video.suffix.lower() not in (".mkv", ".mp4"):
+            return str(video_path)  # chapters can't be embedded in MPEG-TS
+        if not self.ffmpeg_available:
+            return str(video_path)
+
+        segments = (
+            self._parse_edl(edl_path)
+            if edl_path and os.path.exists(edl_path)
+            else []
+        )
+        if not segments:
+            return str(video_path)
+
+        duration = await self._get_duration(video_path, log_callback=log_callback)
+        metadata = self._edl_to_ffmetadata_chapters(segments, duration)
+        if not metadata:
+            return str(video_path)
+
+        meta_path = video.with_suffix(".chapters.ffmeta")
+        tmp_out = video.with_stem(f"{video.stem}_chapters_tmp").with_suffix(video.suffix)
+        try:
+            meta_path.write_text(metadata)
+            cmd = [
+                self._ffmpeg_path,
+                "-i", str(video),
+                "-i", str(meta_path),
+                "-y",
+                "-map", "0",
+                "-map_metadata", "1",
+                "-map_chapters", "1",
+                "-c", "copy",
+                str(tmp_out),
+            ]
+            await self._notify_log(
+                log_callback,
+                f"Embedding commercial chapters: {' '.join(shlex.quote(str(c)) for c in cmd)}"
+            )
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await process.communicate()
+            except asyncio.CancelledError:
+                await self._terminate_process(process)
+                raise
+            returncode = process.returncode if process.returncode is not None else -1
+            if returncode != 0:
+                excerpt = (stderr or b"").decode(errors="ignore").strip()[-400:]
+                await self._notify_log(
+                    log_callback,
+                    f"Chapter embedding failed (exit {returncode}); keeping video without chapters."
+                    + (f" {excerpt}" if excerpt else "")
+                )
+                self._remove_partial_output(tmp_out)
+                return str(video_path)
+            os.replace(tmp_out, video)
+            return str(video_path)
+        except asyncio.CancelledError:
+            self._remove_partial_output(tmp_out)
+            raise
+        except Exception as exc:
+            await self._notify_log(
+                log_callback,
+                f"Chapter embedding error ({exc}); keeping video without chapters."
+            )
+            self._remove_partial_output(tmp_out)
+            return str(video_path)
+        finally:
+            try:
+                if meta_path.exists():
+                    meta_path.unlink()
+            except Exception:
+                pass
+
     def _invert_segments(self, commercial_segments: list, duration: float) -> list:
         """Convert commercial segments to keep segments."""
         if not commercial_segments:

--- a/backend/tests/test_comskip_mark_mode.py
+++ b/backend/tests/test_comskip_mark_mode.py
@@ -1,0 +1,279 @@
+"""
+Regression tests for Commercial Skip Mark mode (issue #397).
+
+Commercial Skip becomes three-way: Off / Mark / Cut.
+
+- `comskip_enabled` keeps its meaning: "Comskip runs."
+- New `comskip_cut` flag (default True = Cut) decides whether the detected
+  commercials are physically removed (Cut) or merely marked (Mark).
+
+Mark mode does NOT force a re-encode; Cut still does. See
+docs/adr/0001-commercial-skip-mark-mode.md.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+import importlib.util
+import os
+import tempfile
+
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+
+from database import Base
+from models import AppSettings
+from api.settings import SettingsUpdate, update_settings
+
+_PP_PATH = BACKEND_ROOT / "services" / "post_processor.py"
+_PP_SPEC = importlib.util.spec_from_file_location("post_processor_mark_test", _PP_PATH)
+_PP_MODULE = importlib.util.module_from_spec(_PP_SPEC)
+assert _PP_SPEC and _PP_SPEC.loader
+_PP_SPEC.loader.exec_module(_PP_MODULE)
+PostProcessor = _PP_MODULE.PostProcessor
+
+
+class ComskipCutFieldTests(unittest.IsolatedAsyncioTestCase):
+    """Slice 1: the comskip_cut flag exists, defaults to Cut, and persists."""
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _apply(self, initial: dict, update: dict) -> dict:
+        async with self.session_factory() as session:
+            settings = AppSettings(**initial)
+            session.add(settings)
+            await session.commit()
+
+        async with self.session_factory() as session:
+            return await update_settings(
+                update_data=SettingsUpdate(**update),
+                _admin=None,
+                session=session,
+            )
+
+    async def test_comskip_cut_defaults_to_cut(self):
+        """A row created without comskip_cut comes up as True (Cut).
+
+        Existing comskip_enabled installs must default to Cut so behaviour is
+        byte-identical after the upgrade.
+        """
+        async with self.session_factory() as session:
+            settings = AppSettings(comskip_enabled=True)
+            session.add(settings)
+            await session.commit()
+            await session.refresh(settings)
+            self.assertTrue(settings.comskip_cut,
+                "comskip_cut must default to True (Cut) for byte-identical upgrades")
+
+    async def test_comskip_cut_persists_and_is_exposed(self):
+        """Setting comskip_cut=False (Mark) persists and appears in the settings dict."""
+        result = await self._apply(
+            initial={"comskip_enabled": True},
+            update={"comskip_cut": False},
+        )
+        self.assertIn("comskip_cut", result, "comskip_cut must be exposed via the settings API")
+        self.assertFalse(result["comskip_cut"], "comskip_cut=False (Mark) must persist")
+
+
+class MarkModeConstraintTests(unittest.IsolatedAsyncioTestCase):
+    """Slice 2: 'comskip forces re-encode' narrows to Cut mode only.
+
+    Cut (comskip_enabled + comskip_cut) still forces transcode_enabled=True.
+    Mark (comskip_enabled + not comskip_cut) must NOT force it: Mark honours
+    the format picker, including Keep .ts.
+    """
+
+    async def asyncSetUp(self):
+        self.engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def _apply(self, initial: dict, update: dict) -> dict:
+        async with self.session_factory() as session:
+            settings = AppSettings(**initial)
+            session.add(settings)
+            await session.commit()
+
+        async with self.session_factory() as session:
+            return await update_settings(
+                update_data=SettingsUpdate(**update),
+                _admin=None,
+                session=session,
+            )
+
+    async def test_cut_mode_still_forces_transcode(self):
+        """Cut mode (comskip_cut=True) keeps forcing transcode_enabled=True."""
+        result = await self._apply(
+            initial={"comskip_enabled": False, "transcode_enabled": False, "comskip_cut": True},
+            update={"comskip_enabled": True},
+        )
+        self.assertTrue(result["comskip_enabled"])
+        self.assertTrue(result["comskip_cut"])
+        self.assertTrue(result["transcode_enabled"],
+            "Cut mode must still force transcode_enabled=True")
+
+    async def test_mark_mode_does_not_force_transcode(self):
+        """Mark mode (comskip_cut=False) must NOT force transcode_enabled.
+
+        Mark + Keep .ts is a valid combination: transcode_enabled=False stays.
+        """
+        result = await self._apply(
+            initial={"comskip_enabled": False, "transcode_enabled": False},
+            update={"comskip_enabled": True, "comskip_cut": False},
+        )
+        self.assertTrue(result["comskip_enabled"])
+        self.assertFalse(result["comskip_cut"])
+        self.assertFalse(result["transcode_enabled"],
+            "Mark mode must not force transcode_enabled; it honours the format picker")
+
+    async def test_switching_cut_to_mark_releases_forced_transcode(self):
+        """Turning an existing Cut install into Mark stops forcing transcode."""
+        result = await self._apply(
+            initial={"comskip_enabled": True, "comskip_cut": True, "transcode_enabled": True},
+            update={"comskip_cut": False, "transcode_enabled": False},
+        )
+        self.assertFalse(result["comskip_cut"])
+        self.assertFalse(result["transcode_enabled"],
+            "Mark mode must let the user turn transcode off (Keep .ts)")
+
+
+class FfmetadataChaptersTests(unittest.TestCase):
+    """Slice 3: derive ffmetadata chapters from parsed EDL segments.
+
+    Commercial spans are labeled "Commercial"; the content spans between them
+    are chaptered too, so a Plex client can jump break-to-break by chapter.
+    """
+
+    def setUp(self):
+        self.processor = PostProcessor()
+
+    def test_no_segments_yields_no_chapters(self):
+        """No commercials detected → no chapter metadata (falsy)."""
+        out = self.processor._edl_to_ffmetadata_chapters([], 1800.0)
+        self.assertFalse(out, "No commercial segments must produce no chapters")
+
+    def test_commercial_span_labeled_and_timed(self):
+        """A commercial span becomes a 'Commercial' chapter with millisecond bounds."""
+        segments = [(60.0, 120.0, 0)]
+        out = self.processor._edl_to_ffmetadata_chapters(segments, 180.0)
+
+        self.assertIn(";FFMETADATA1", out, "must start with the ffmetadata header")
+        self.assertIn("title=Commercial", out, "commercial span must be labeled Commercial")
+        # Default ffmetadata chapter timebase is 1/1000 (milliseconds).
+        self.assertIn("START=60000", out, "commercial chapter must start at 60s = 60000ms")
+        self.assertIn("END=120000", out, "commercial chapter must end at 120s = 120000ms")
+
+    def test_content_gaps_are_chaptered(self):
+        """Content spans around the commercial are chaptered too.
+
+        For commercial [60,120] in a 180s file there are three chapters:
+        content [0,60], commercial [60,120], content [120,180].
+        """
+        segments = [(60.0, 120.0, 0)]
+        out = self.processor._edl_to_ffmetadata_chapters(segments, 180.0)
+
+        self.assertEqual(out.count("[CHAPTER]"), 3,
+            "expected content + commercial + content = 3 chapters")
+        self.assertIn("START=120000", out, "trailing content chapter must start at 120000ms")
+        self.assertIn("END=180000", out, "trailing content chapter must end at duration (180000ms)")
+
+
+class EmbedChaptersGuardTests(unittest.IsolatedAsyncioTestCase):
+    """Slice 5 (unit): chapters can't go in MPEG-TS, so Keep .ts gets no chapters."""
+
+    def setUp(self):
+        self.processor = PostProcessor()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, self.tmp)
+
+    async def test_ts_container_gets_no_chapters(self):
+        """embed_chapters is a no-op for a .ts file (returns it untouched)."""
+        ts = Path(self.tmp) / "Show.ts"
+        ts.write_bytes(b"\x47" * 188)
+        edl = Path(self.tmp) / "Show.edl"
+        edl.write_text("60.00 120.00 0\n")
+
+        result = await self.processor.embed_chapters(str(ts), str(edl))
+
+        self.assertEqual(result, str(ts), "Keep .ts must not be rewritten for chapters")
+        self.assertEqual(ts.read_bytes(), b"\x47" * 188, "the .ts must be left byte-identical")
+
+
+class EdlSidecarTests(unittest.TestCase):
+    """Slice 4: Mark mode keeps the EDL as a sidecar named after the final video.
+
+    `Show - S01E04.mkv` → `Show - S01E04.edl`, in the same folder. No sidecar
+    when Comskip found nothing.
+    """
+
+    def setUp(self):
+        self.processor = PostProcessor()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(__import__("shutil").rmtree, self.tmp)
+
+    def _path(self, name: str) -> str:
+        return str(Path(self.tmp) / name)
+
+    def _write(self, name: str, content: str) -> str:
+        p = Path(self.tmp) / name
+        p.write_text(content)
+        return str(p)
+
+    def test_sidecar_matches_video_stem(self):
+        """Sidecar is <video stem>.edl beside the video and carries the segments."""
+        video = self._path("Show - S01E04.mkv")
+        edl = self._write("Show - S01E04.edl", "60.00 120.00 0\n")
+
+        sidecar = self.processor._write_edl_sidecar(video, edl)
+
+        self.assertEqual(sidecar, self._path("Show - S01E04.edl"))
+        self.assertTrue(os.path.exists(sidecar), "sidecar must exist beside the video")
+        self.assertIn("60.00", Path(sidecar).read_text())
+
+    def test_no_commercials_no_sidecar(self):
+        """An EDL with no commercial entries yields no sidecar."""
+        video = self._path("Show - S01E04.mkv")
+        edl = self._write("Show - S01E04.edl", "")
+
+        sidecar = self.processor._write_edl_sidecar(video, edl)
+
+        self.assertIsNone(sidecar, "no commercials → no sidecar")
+        self.assertFalse(os.path.exists(self._path("Show - S01E04.edl")) and
+                         Path(self._path("Show - S01E04.edl")).read_text().strip() != "",
+                         "must not leave a non-empty stray sidecar")
+
+    def test_probe_named_edl_renamed_to_video_stem(self):
+        """When Comskip retried on a probe file, the EDL stem differs; rename it.
+
+        detection EDL = 'Show_comskip_input.edl', final video = 'Show.mkv'
+        → sidecar must be 'Show.edl'.
+        """
+        video = self._path("Show.mkv")
+        edl = self._write("Show_comskip_input.edl", "60.00 120.00 0\n")
+
+        sidecar = self.processor._write_edl_sidecar(video, edl)
+
+        self.assertEqual(sidecar, self._path("Show.edl"))
+        self.assertTrue(os.path.exists(sidecar))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_mark_mode_post_process.py
+++ b/backend/tests/test_mark_mode_post_process.py
@@ -1,0 +1,112 @@
+"""
+Acceptance test for Commercial Skip Mark mode orchestration (issue #397).
+
+Drives DownloadManager._post_process with a faked post_processor and asserts the
+Mark-mode contract:
+
+  - the cut is NOT applied (remove_commercials is never called),
+  - chapters are embedded on the container pass (embed_chapters is called),
+  - the .edl sidecar is kept, named after the final video.
+
+See docs/adr/0001-commercial-skip-mark-mode.md and 0002-...chapters.md.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from models import AppSettings
+from services.download_manager import DownloadManager
+from services import post_processor as pp_module
+
+
+class MarkModePostProcessTests(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.manager = DownloadManager()
+        self.download_dir = tempfile.mkdtemp()
+        self.completed_dir = tempfile.mkdtemp()
+
+    async def asyncTearDown(self):
+        shutil.rmtree(self.download_dir, ignore_errors=True)
+        shutil.rmtree(self.completed_dir, ignore_errors=True)
+
+    def _settings(self, **overrides) -> AppSettings:
+        base = dict(
+            comskip_enabled=True,
+            comskip_cut=False,  # Mark
+            transcode_enabled=True,
+            transcode_format="mkv",
+            hw_accel="cpu",
+            remux_only=False,
+            delete_original_after_transcode=False,
+            min_free_space_gb=0,
+            download_folder=self.download_dir,
+            completed_folder=self.completed_dir,
+        )
+        base.update(overrides)
+        return AppSettings(**base)
+
+    async def _run(self, settings: AppSettings):
+        ts_path = os.path.join(self.download_dir, "Show.ts")
+        Path(ts_path).write_bytes(b"\x47" * 188)
+        edl_path = os.path.join(self.download_dir, "Show.edl")
+
+        async def fake_detect(input_path, ini_path=None, **kwargs):
+            Path(edl_path).write_text("60.00 120.00 0\n")
+            return edl_path
+
+        async def fake_transcode(input_path, output_format, **kwargs):
+            out = os.path.join(self.download_dir, "Show.mkv")
+            Path(out).write_bytes(b"\x00" * 1024)
+            return out
+
+        remove_commercials = AsyncMock()
+        embed_chapters = AsyncMock(side_effect=lambda video, edl, **k: video)
+
+        with patch.object(pp_module, "post_processor") as pp:
+            pp.comskip_available = True
+            pp.ffmpeg_available = True
+            pp.comskip_path = None
+            pp.detect_commercials = AsyncMock(side_effect=fake_detect)
+            pp.transcode = AsyncMock(side_effect=fake_transcode)
+            pp.remove_commercials = remove_commercials
+            pp.embed_chapters = embed_chapters
+            # _write_edl_sidecar is a pure file op; delegate to the real one.
+            pp._write_edl_sidecar = pp_module.PostProcessor._write_edl_sidecar.__get__(pp)
+            pp.resolve_hw_accel = MagicMock(return_value=(pp_module.HardwareAccel.CPU, None))
+            pp.get_ffmpeg_path = MagicMock(return_value=None)
+            pp.set_comskip_path = MagicMock()
+
+            with patch("services.download_manager.get_free_space_shortfall",
+                       AsyncMock(return_value=None)), \
+                 patch("services.comskip_ini.resolve_comskip_ini",
+                       MagicMock(return_value=None)), \
+                 patch.object(self.manager, "_update_processing", AsyncMock()), \
+                 patch.object(self.manager, "_broadcast_log", AsyncMock()):
+                final_path, warnings = await self.manager._post_process(
+                    ts_path, download_id=1, session=MagicMock(), settings=settings
+                )
+
+        return final_path, warnings, remove_commercials, embed_chapters
+
+    async def test_mark_mkv_does_not_cut_and_keeps_sidecar(self):
+        final_path, warnings, remove_commercials, embed_chapters = await self._run(self._settings())
+
+        remove_commercials.assert_not_called()
+        self.assertTrue(embed_chapters.called, "Mark + MKV must embed commercial chapters")
+        self.assertTrue(final_path.endswith("Show.mkv"), "final output is the unaltered MKV")
+        sidecar = os.path.join(self.download_dir, "Show.edl")
+        self.assertTrue(os.path.exists(sidecar), "the .edl sidecar must be kept beside the video")
+        self.assertEqual(warnings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/adr/0001-commercial-skip-mark-mode.md
+++ b/docs/adr/0001-commercial-skip-mark-mode.md
@@ -1,0 +1,35 @@
+# Commercial Skip gains a Mark mode, decoupled from cutting
+
+## Context
+
+Commercial Skip was a single on/off (`comskip_enabled`) that always meant
+"detect and physically cut," and it forced `transcode_enabled=true` because the
+cut needs FFmpeg. Users wanted a non-destructive option: keep the full recording
+but expose where the ads are.
+
+## Decision
+
+Commercial Skip becomes a three-way mode — **Off / Mark / Cut**:
+
+- **Cut** is the pre-existing behaviour, unchanged. Still forces re-encode/remux.
+- **Mark** runs Comskip but does not cut. It writes an EDL sidecar and (when the
+  container is MKV/MP4) embeds commercial-break chapters. See [ADR-0002](0002-plex-commercial-skip-via-chapters.md).
+
+Mark is fully decoupled from cutting: it no longer forces a container conversion.
+The "comskip forces re-encode" rule narrows to **Cut only**, so Mark honours the
+Post-Processing format picker, including Keep .ts (sidecar-only in that case).
+
+Schema: keep `comskip_enabled` meaning "Comskip runs" and add a cut-vs-mark flag
+defaulting to **Cut**, so existing installs are byte-for-byte unchanged.
+
+## Considered options
+
+- A two-switch model ("write EDL" + "cut them out") was rejected: it admits a
+  meaningless "both on" state. The three-way mode makes illegal combinations
+  unrepresentable.
+
+## Consequences
+
+- The old invariant "comskip_enabled ⇒ transcode_enabled" is no longer absolute.
+  Anything relying on it must check the mode.
+- A new container combination becomes reachable: Comskip running with Keep .ts.

--- a/docs/adr/0002-plex-commercial-skip-via-chapters.md
+++ b/docs/adr/0002-plex-commercial-skip-via-chapters.md
@@ -1,0 +1,31 @@
+# Plex commercial skip via embedded chapters, not DB injection
+
+## Context
+
+In Mark mode we want Plex users to benefit from commercial detection. But Plex
+offers automatic commercial skip **only for recordings its own DVR made**; for a
+file Mustarrd drops into a normal library, Plex ignores sidecar `.edl` and has no
+supported auto-skip. The only way to make Plex clients auto-skip an external file
+is to write "commercial" markers directly into Plex's private SQLite database.
+
+## Decision
+
+Mark mode embeds commercial-break **chapter markers** into the MKV/MP4 (derived
+from the same Comskip segments as the EDL). Plex shows these chapters, giving
+one-click / chapter-nav skipping. The EDL sidecar continues to serve generic
+players (Kodi, Jellyfin, Emby, MythTV) that auto-skip from it.
+
+## Considered options
+
+- **Plex DB marker injection** (true auto-skip) was rejected. It requires
+  Mustarrd to run on the same host as the Plex server with read/write access to
+  `com.plexapp.plugins.library.db`, is unsupported by Plex, and breaks on Plex
+  schema changes. Mustarrd integrates with Plex over the API only and must not
+  depend on co-location or Plex internals.
+
+## Consequences
+
+- Plex gets **manual** chapter skip, not automatic skip. This is an accepted
+  limitation, surfaced in the UI.
+- Chapters need a container, so Mark + Keep .ts yields the sidecar with no Plex
+  benefit; the UI warns about this.

--- a/frontend/src/components/settings/sections.js
+++ b/frontend/src/components/settings/sections.js
@@ -64,7 +64,7 @@ export const SEARCH_INDEX = [
   { label: 'Minimum free space', section: 'recording', kw: 'disk gb pause low' },
   { label: 'Recording padding (start early / end late)', section: 'recording', kw: 'minutes before after buffer' },
   { label: 'Output container (.ts / MKV / MP4)', section: 'processing', kw: 'format remux transcode encode ffmpeg' },
-  { label: 'Remove commercials', section: 'processing', kw: 'comskip ads skip' },
+  { label: 'Commercials', section: 'processing', kw: 'comskip ads skip mark cut commercials' },
   { label: 'Hardware acceleration', section: 'processing', kw: 'gpu vaapi intel quick sync encode' },
   { label: 'Delete original after processing', section: 'processing', kw: 'source ts cleanup' },
   { label: 'Max concurrent post-processing', section: 'processing', kw: 'parallel conversion limit' },

--- a/frontend/src/pages/Scheduled.test.jsx
+++ b/frontend/src/pages/Scheduled.test.jsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MantineProvider } from '@mantine/core'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -6,6 +6,18 @@ import { MemoryRouter } from 'react-router-dom'
 import dayjs from 'dayjs'
 
 import Scheduled from './Scheduled'
+
+// Freeze the clock at midday before the relative fixtures below are built.
+// The day-grouping ("TONIGHT" = starts today) compares against the real clock,
+// so a fixture of `now + 2h` built near midnight would slip into tomorrow and
+// drop the TONIGHT header — a flake that only fired when CI ran close to UTC
+// midnight. Pinning to noon keeps every offset on a predictable calendar day.
+// shouldAdvanceTime lets Testing Library's waitFor still progress.
+vi.useFakeTimers({ shouldAdvanceTime: true })
+vi.setSystemTime(new Date('2026-06-23T12:00:00Z'))
+afterAll(() => {
+  vi.useRealTimers()
+})
 
 vi.mock('../api', () => ({
   schedulesApi: {

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -994,7 +994,7 @@ export default function Settings() {
               label="Commercials"
               description={isTs
                 ? 'Mark writes an .edl sidecar (no cut). Cutting needs MKV or MP4 above.'
-                : 'Mark keeps the full video and tags the ad breaks; Cut removes them.'}
+                : 'Mark keeps the full video — it writes an .edl sidecar and embeds Plex chapters at the ad breaks; Cut removes them.'}
             >
               {comskipOn && (
                 <Button variant="subtle" size="xs" onClick={() => selectSection('comskip')}>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -913,7 +913,9 @@ export default function Settings() {
     const container = !formData.transcode_enabled ? 'ts' : formData.transcode_format === 'mp4' ? 'mp4' : 'mkv'
     const method = formData.remux_only ? 'remux' : 'encode'
     const isTs = container === 'ts'
-    const comskipOn = Boolean(formData.comskip_enabled) && !isTs
+    const comskipOn = Boolean(formData.comskip_enabled)
+    // Off / Mark / Cut. comskip_cut defaults to Cut (true) when comskip is on.
+    const comskipMode = !comskipOn ? 'off' : (formData.comskip_cut === false ? 'mark' : 'cut')
     const ffmpegReady = toolsStatus?.ffmpeg?.available
     const comskipReady = toolsStatus?.comskip?.available
 
@@ -927,9 +929,30 @@ export default function Settings() {
 
     const handleContainerChange = (value) => {
       if (value === 'ts') {
-        applyChanges({ transcode_enabled: false, comskip_enabled: false })
+        // Cut needs a container, so switching to Keep .ts drops Cut. Mark works
+        // on .ts (sidecar only), so it is left in place.
+        const patch = { transcode_enabled: false }
+        if (comskipMode === 'cut') patch.comskip_enabled = false
+        applyChanges(patch)
       } else {
         applyChanges({ transcode_enabled: true, transcode_format: value })
+      }
+    }
+
+    const handleCommercialsChange = (mode) => {
+      if (mode === 'off') {
+        applyChanges({ comskip_enabled: false })
+      } else if (mode === 'mark') {
+        // Mark detects but does not cut; it never forces a re-encode.
+        applyChanges({ comskip_enabled: true, comskip_cut: false })
+      } else {
+        // Cut physically removes commercials and needs a container conversion.
+        const patch = { comskip_enabled: true, comskip_cut: true }
+        if (isTs) {
+          patch.transcode_enabled = true
+          patch.transcode_format = 'mkv'
+        }
+        applyChanges(patch)
       }
     }
 
@@ -968,25 +991,37 @@ export default function Settings() {
               </SettingRow>
             )}
             <SettingRow
-              label="Remove commercials"
+              label="Commercials"
               description={isTs
-                ? 'Requires a container conversion — choose MKV or MP4 above'
-                : 'Detect and cut ad breaks with Comskip before saving'}
+                ? 'Mark writes an .edl sidecar (no cut). Cutting needs MKV or MP4 above.'
+                : 'Mark keeps the full video and tags the ad breaks; Cut removes them.'}
             >
               {comskipOn && (
                 <Button variant="subtle" size="xs" onClick={() => selectSection('comskip')}>
                   Tune detection →
                 </Button>
               )}
-              <Switch
-                size={switchSize}
-                aria-label="Remove commercials"
-                checked={comskipOn}
-                disabled={isTs}
-                onChange={(e) => handleChange('comskip_enabled', e.currentTarget.checked)}
+              <SegmentedControl
+                value={comskipMode}
+                onChange={handleCommercialsChange}
+                data={[
+                  { value: 'off', label: 'Off' },
+                  { value: 'mark', label: 'Mark only' },
+                  { value: 'cut', label: 'Cut out', disabled: isTs },
+                ]}
               />
             </SettingRow>
           </Stack>
+
+          {comskipMode === 'mark' && isTs && (
+            <Alert color="yellow" variant="light">
+              <Text size="sm">
+                Plex chapter-skip needs MKV or MP4. On{' '}
+                <Text component="span" fw={500}>Keep .ts</Text> you'll only get the .edl sidecar
+                (Kodi/Jellyfin/Emby still work).
+              </Text>
+            </Alert>
+          )}
 
           {ffmpegReady === false && !isTs && (
             <Alert color="yellow" variant="light">

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -139,7 +139,7 @@ describe('Settings page', () => {
     await screen.findByText('Connections')
 
     fireEvent.change(screen.getByLabelText('Search settings'), { target: { value: 'commercials' } })
-    fireEvent.click(await screen.findByText('Remove commercials'))
+    fireEvent.click(await screen.findByText('Commercials'))
 
     expect(await screen.findByText('Container')).toBeInTheDocument()
     expect(screen.getByText('Conversion method')).toBeInTheDocument()
@@ -185,29 +185,60 @@ describe('Settings page', () => {
     // remux + mkv + no comskip from the fixture
     expect(await screen.findByRole('radio', { name: 'MKV' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'Remux (fast)' })).toBeChecked()
-    const comskipSwitch = screen.getByRole('switch', { name: 'Remove commercials' })
-    expect(comskipSwitch).not.toBeChecked()
+    expect(screen.getByRole('radio', { name: 'Off' })).toBeChecked()
+  })
 
-    // turning on commercial removal marks comskip_enabled dirty
-    fireEvent.click(comskipSwitch)
+  it('offers Off / Mark only / Cut out and Mark does not force a re-encode', async () => {
+    renderSettings()
+    await screen.findByText('Connections')
+
+    fireEvent.click(screen.getByText('Post-Processing'))
+
+    // fixture has comskip off → Off selected
+    expect(await screen.findByRole('radio', { name: 'Off' })).toBeChecked()
+
+    // Mark only: detect but do not cut; must NOT force transcode fields
+    fireEvent.click(screen.getByRole('radio', { name: 'Mark only' }))
     fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
     await waitFor(() => {
       expect(settingsApi.update).toHaveBeenCalled()
     })
-    expect(settingsApi.update.mock.calls[0][0]).toEqual({ comskip_enabled: true })
+    expect(settingsApi.update.mock.calls[0][0]).toEqual({
+      comskip_enabled: true,
+      comskip_cut: false,
+    })
   })
 
-  it('disables commercial removal on Keep .ts', async () => {
+  it('Cut out enables comskip and cuts (forces a container conversion)', async () => {
+    renderSettings()
+    await screen.findByText('Connections')
+
+    fireEvent.click(screen.getByText('Post-Processing'))
+
+    fireEvent.click(await screen.findByRole('radio', { name: 'Cut out' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+    await waitFor(() => {
+      expect(settingsApi.update).toHaveBeenCalled()
+    })
+    // fixture is already MKV/transcode-enabled, so only the comskip fields change
+    expect(settingsApi.update.mock.calls[0][0]).toEqual({
+      comskip_enabled: true,
+      comskip_cut: true,
+    })
+  })
+
+  it('allows Mark only on Keep .ts but disables Cut out, with a chapter warning', async () => {
     renderSettings()
     await screen.findByText('Connections')
 
     fireEvent.click(screen.getByText('Post-Processing'))
     fireEvent.click(await screen.findByRole('radio', { name: 'Keep .ts' }))
 
-    expect(screen.getByRole('switch', { name: 'Remove commercials' })).toBeDisabled()
-    expect(
-      screen.getByText('Requires a container conversion — choose MKV or MP4 above')
-    ).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Cut out' })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: 'Mark only' })).not.toBeDisabled()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Mark only' }))
+    expect(screen.getByText(/Plex chapter-skip needs MKV or MP4/i)).toBeInTheDocument()
     // method row hidden for .ts
     expect(screen.queryByText('Conversion method')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
Closes #397.

Adds a **Mark** mode to Commercial Skip. The old on/off "Remove commercials" becomes a three-way **Commercials** control: `Off · Mark only · Cut out`.

- **Off / Cut out** — unchanged. Cut still detects + physically removes commercials and forces a container conversion.
- **Mark only** — Comskip detects but nothing is cut. The unaltered video gets:
  - an **`.edl` sidecar** named to match the finished video (Kodi/Jellyfin/Emby/MythTV auto-skip), and
  - embedded **"Commercial" chapter markers** on the MKV/MP4 container pass (Plex one-click/chapter-nav skip).
  - On **Keep .ts**: sidecar only (chapters can't live in MPEG-TS); the UI warns about this.

Domain rationale lives in `CONTEXT.md` and `docs/adr/0001`/`0002` (on this branch).

## What changed
- **Schema:** keep `comskip_enabled` = "Comskip runs"; add `comskip_cut` (default **Cut**) so existing installs are byte-identical. `models/settings.py`, `database.py` ALTER, settings schema/whitelist.
- **Constraint narrowed:** "Comskip forces re-encode" now applies to **Cut only** (`api/settings.py`). Mark honours the format picker, including Keep .ts.
- **post_processor:** `_edl_to_ffmetadata_chapters` (EDL → chapters), `_write_edl_sidecar` (keep + rename EDL to final stem), `embed_chapters` (mux chapters; no-op on .ts).
- **download_manager:** `_post_process` branches Cut vs Mark — Mark skips the cut, embeds chapters on the container pass, keeps the sidecar; the sidecar is moved to the completed folder in lockstep and protected from cleanup.
- **Frontend:** three-way `Off / Mark only / Cut out` SegmentedControl; Cut gated to MKV/MP4, Mark allowed on Keep .ts with an inline chapter warning. Search index updated.
- **CHANGELOG** entry in plain English.

Plex DB marker injection was rejected (ADR-0002); chapters are the supported stand-in. VOD is out of scope (never post-processes).

## Steps to test
- Backend: `cd backend && python -m unittest discover -s tests` (full suite green; new `test_comskip_mark_mode.py` + `test_mark_mode_post_process.py`).
- Frontend: `cd frontend && npm test` (green; new three-way control tests in `Settings.test.jsx`).
- Manual smoke worth doing before merge: a real Mark + MKV recording → confirm unaltered MKV + matching `.edl` + "Commercial" chapters visible in a player (the live ffmpeg/Comskip chapter-mux path isn't exercised by unit tests).

## Acceptance (from #397)
- [x] Three-way `Off / Mark only / Cut out`; existing installs come up as **Cut**.
- [x] Mark does **not** force re-encode; Cut still does.
- [x] `.edl` stem matches the final templated filename, in the completed folder.
- [x] No-commercials in Mark mode → video only, no stray sidecar.
- [x] Mark + Keep .ts → sidecar only + inline warning; Cut gated to MKV/MP4.
- [x] Regression tests + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)