### PR TITLE
Refresh README: mark-mode commercials, quick previews, current guide UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Mustarrd Logo](https://github.com/razzamatazm/mustarrd/blob/main/frontend/src/assets/mustarrdlogo.png "Mustarrd Logo")
+![Mustarrd Logo](https://raw.githubusercontent.com/razzamatazm/mustarrd/main/frontend/src/assets/mustarrdlogo.png "Mustarrd Logo")
 # Mustarrd: IPTV Catchup DVR
 
 Mustarrd connects to your IPTV provider and lets you download past programs. Think of it as a DVR for your IPTV catchup library. Browse your provider's program guide, pick anything from the last few days (or schedule shows airing in the future), and download it with a properly named file ready for Plex, Jellyfin, or just your hard drive.
@@ -91,8 +91,7 @@ Then open **http://localhost:4177** in your browser.
 
 ### Monitor Downloads
 
-- Go to the **Downloads** page to see active downloads with progress bars
-- The **Upcoming** tab lists everything scheduled to record automatically, sorted by air date. Each card shows the show name, channel, full air window (start and end time with duration), and when the download will begin. A count badge on the tab heading shows how many recordings are queued at a glance. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge with an alert icon
+- The **Active** tab shows downloads in progress, each as a pipeline of stages — Download, Commercials, Re-encode — side by side. Upcoming recordings live on the **Scheduled** page (a link under Active takes you there)
 - A red badge on the **Downloads** menu item shows how many recordings have permanently failed since you last visited. Opening Downloads clears it
 - A badge at the top shows how much free space is left on your recording drive. It turns red when space is low. If your recording drive is not found (for example after an array restart), the badge shows "Recording drive not found" in orange
 - When any scheduled recording is paused for low disk space, or when free space drops below the configured minimum, an orange banner appears at the top of every page, not just Downloads, so you are alerted no matter where you are in the app
@@ -106,9 +105,9 @@ Then open **http://localhost:4177** in your browser.
 
 ### Schedule a Recording
 
-- Browse to an upcoming program and use the **Schedule** option to download it automatically when it airs
-- Make sure to turn on the view future programming switch
-- The **History** tab on the Scheduled Recordings page shows past scheduled runs. FAILED entries show a **Retry** button directly on the card to re-queue the download without navigating away
+- Browse to an upcoming program and use the **Schedule** option to download it automatically when it airs (turn on the "view future programming" switch first)
+- The **Scheduled** page lists everything queued as a day-by-day agenda ("TONIGHT", then future days) with the air time up front. Recordings paused for low disk space show a yellow "PAUSED (LOW SPACE)" badge
+- The **History** tab on the Scheduled page shows past scheduled runs. FAILED entries show a **Retry** button directly on the card to re-queue the download without navigating away
 
 | Desktop | Mobile |
 |---------|--------|
@@ -125,7 +124,7 @@ Mustarrd reads the program title and automatically formats the filename for your
 | Movie | `The Matrix (1999).ts` |
 | Everything else | `ESPN - SportsCenter - 2026-01-28.ts` |
 
-Filename templates are customizable in Settings if you want a different format. The file extension (.ts, .mkv, .mp4) is set by your Recording Format in Settings, not by the filename template, so you should not add an extension to your template.
+Filename templates are customizable in Settings if you want a different format. The file extension (.ts, .mkv, .mp4) is set by your Container choice in Settings, not by the filename template, so you should not add an extension to your template.
 
 ## Where Your Files Go
 
@@ -181,7 +180,7 @@ npm run dev
 
 **Docker** (full stack):
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Mustarrd connects to your IPTV provider and lets you download past programs. Thi
 
 - **Browse past programs:** scroll back through your provider's program guide (EPG) and see what's available to download
 - **Starred channels:** star your favorite channels so they always appear at the top of the list
-- **Program preview:** preview a live channel or catchup program in your browser before queuing a download
-- **Commercial skip:** ComSkip integration removes commercials before saving. Detection method, break length limits, show-protection margins, and thread count are all configurable from the Settings page, no config file editing needed
+- **Quick channel previews:** preview a live channel or any catchup program right in your browser before queuing a download — plays in every major browser, no separate player needed
+- **Commercial skip (cut *or* mark):** ComSkip finds the ad breaks, then either **cuts them out** of the recording or **marks them** so your media player skips them on playback. Marking leaves the recording whole and writes an `.edl` sidecar (Kodi, Jellyfin, Emby, MythTV) plus commercial chapter markers inside MKV/MP4 (so Plex can jump break-to-break). Detection method, break length limits, show-protection margins, and thread count are all configurable from the Settings page, no config file editing needed
 - **Flexible output formats:** save recordings as-is (.ts), remux to MKV or MP4, or re-encode with FFmpeg for smaller files
 - **GPU-accelerated encoding:** if your server has an Intel, AMD, or NVIDIA GPU, re-encoding uses it automatically; the Settings page shows GPU status in plain language
-- **Download from On Demand:** If your provider provides on demand listings, you can grab those too!
+- **Download from On Demand:** if your provider offers on demand listings, you can grab those too — movies and series browse as a poster grid
 - **Scheduled recordings:** set programs to download automatically when they air; export and import your schedule as a backup or to move to another machine
 - **Smart file naming:** TV shows, movies, and sports get automatically named in the right format (`Breaking Bad - S01E01 - Pilot.ts`, `The Matrix (1999).ts`, etc.)
-- **Plex Link:** Allow your plex users to request programming by logging in with their Plex creds (or don't) and push recording directly to your TV recording library
+- **Plex Link:** let your Plex users request programming by logging in with their Plex credentials (or don't), and push finished recordings straight into your Plex library
 - **Multiple accounts:** connect more than one IPTV provider. Add more users to give them download access
 
 ## Why Do I Need This? I have Sonarr...
@@ -86,8 +86,8 @@ Then open **http://localhost:4177** in your browser.
 
 1. Go to **Browse** and select an account
 2. Click a channel to open its program guide
-3. Programs with a **mustard yellow border** have catchup available. Click one to open the download dialog
-4. Review the auto-generated filename (edit if needed) and click **Download**
+3. Catchup programs have a **mustard left edge** with **Preview** and **Download** buttons; upcoming programs have a **teal edge** with a **Schedule** button
+4. Click **Download**, review the auto-generated filename (edit if needed), and confirm
 
 ### Monitor Downloads
 
@@ -132,7 +132,7 @@ Filename templates are customizable in Settings if you want a different format. 
 | Folder | Contents |
 |--------|----------|
 | `./downloads/` | In-progress downloads and temp files used for ComSkip |
-| `./completed/` | Finished files. Point this at your media library |
+| `./completed/` | Finished files (plus the `.edl` ad-break sidecar when commercial **Mark only** is on). Point this at your media library |
 | `./config/` | Database, settings, and Comskip config. Keep this private |
 
 Before first run, update the host paths in `docker-compose.yml` (`./config`, `./downloads`, `./completed`) to match your system.


### PR DESCRIPTION
## Summary
Brings the README in line with current features and tidies stale copy throughout.

- **Quick channel previews** — reworded; notes previews now play in every major browser
- **Commercial skip** — documents the cut *or* mark choice (Mark only writes an `.edl` sidecar + Plex commercial chapters and keeps the recording whole)
- **Browse & Download** steps rewritten for the redesigned guide (mustard left edge + Preview/Download on catchup, teal edge + Schedule on upcoming)
- Polished On Demand, Plex Link, and the completed-folder table (`.edl` sidecar note)

Docs only — no code or behavior changes.

## Steps to test
- Read the rendered README on the branch; confirm wording matches current app behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)