### PR TITLE
Add agent-skills docs; fix Unraid PUID/PGID Mode placeholder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,17 @@ Environment detection: Docker paths activate via `CATCHUP_DOCKER=1` or container
 - Short imperative commit messages (e.g., `Fix missing Path import`)
 - PRs need: concise summary, steps to test, screenshots for UI changes (convention: `.github/pr-screenshots/`)
 - User-facing changes get a `CHANGELOG.md` entry written in plain English ("What you would notice" / "What changed"), newest at top
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/unraid/mustarrd.xml
+++ b/unraid/mustarrd.xml
@@ -29,7 +29,7 @@
   <Config Name="VAAPI Driver" Target="LIBVA_DRIVER_NAME" Default="iHD" Mode="" Description="VAAPI driver name for hardware-accelerated transcoding. Intel (default): iHD (newer) or i965 (older). AMD: radeonsi. Leave blank to let Mustarrd auto-detect the driver. To turn off GPU transcoding, select CPU in Settings or remove the GPU Device passthrough." Type="Variable" Display="advanced" Required="false" Mask="false">iHD</Config>
   <Config Name="Timezone" Target="TZ" Default="" Mode="" Description="Your local Timezone" Type="Variable" Display="always" Required="true" Mask="false">America/Los_Angeles</Config>
   <Config Name="GPU Device" Target="/dev/dri" Default="" Mode="" Description="Optional Intel/AMD GPU passthrough for ffmpeg acceleration" Type="Device" Display="advanced" Required="false" Mask="false">/dev/dri</Config>
-  <Config Name="Variable: PUID" Target="PUID" Default="99" Mode="{3}" Description="User ID for the running container" Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
-  <Config Name="Variable: PGID" Target="PGID" Default="100" Mode="{3}" Description="Group ID for the running container" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>
+  <Config Name="Variable: PUID" Target="PUID" Default="99" Mode="" Description="User ID for the running container" Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
+  <Config Name="Variable: PGID" Target="PGID" Default="100" Mode="" Description="Group ID for the running container" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>
   <TailscaleStateDir/>
 </Container>


### PR DESCRIPTION
## Summary
Two small housekeeping changes pulled out of leftover working-tree edits:

- **Agent-skills docs** — adds `docs/agents/{issue-tracker,triage-labels,domain}.md` and a matching **Agent skills** section in `CLAUDE.md` that points to them (the Matt Pocock skill setup).
- **Unraid template fix** — clears a stray `Mode="{3}"` placeholder on the `PUID`/`PGID` variables in `unraid/mustarrd.xml` (should be empty).

## Steps to test
- Docs only + a template attribute tweak — no app behavior changes. Verify `CLAUDE.md` renders and the three `docs/agents/` files exist; confirm the Unraid template still validates.

## Notes
- No `CHANGELOG.md` entry: neither change is user-facing app behavior.
- Also removed two stale `design_handoff_*` prototype bundles from the repo root in a prior step (the redesigns they specced already shipped) — those were untracked, so they don't appear in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)