### PR TITLE
Security: upgrade jellyfin-ffmpeg7 → jellyfin-ffmpeg8 (fixes PixelSmash CVE-2026-8461)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,7 +62,7 @@ RUN sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubun
   && echo "deb [signed-by=/etc/apt/keyrings/jellyfin.gpg] https://repo.jellyfin.org/${ID} ${VERSION_CODENAME} main" \
        > /etc/apt/sources.list.d/jellyfin.list \
   && apt-get update -o Acquire::Retries=3 \
-  && apt-get install -y --no-install-recommends jellyfin-ffmpeg7 \
+  && apt-get install -y --no-install-recommends jellyfin-ffmpeg8 \
   && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
        for pkg in mesa-va-drivers intel-media-va-driver i965-va-driver; do \
          apt-get install -y --no-install-recommends -o Acquire::Retries=3 "$pkg" || true; \


### PR DESCRIPTION
## Summary

- Replaces `jellyfin-ffmpeg7` with `jellyfin-ffmpeg8` in `backend/Dockerfile` (one line change)
- `jellyfin-ffmpeg8` v8.1.2-1 (released 2026-07-06) is built on FFmpeg 8.1.2, which contains the upstream fix for **CVE-2026-8461 (PixelSmash)** — a heap out-of-bounds write in FFmpeg's MagicYUV decoder (CVSS 8.8, RCE possible via crafted media file)
- All install paths remain `/usr/lib/jellyfin-ffmpeg/` so no other Dockerfile lines, env vars, or symlinks need changing

Closes #402

## Background

The 7.x line (`jellyfin-ffmpeg7`) has no patched release yet; latest is v7.1.4-3 (2026-06-06), which predates the upstream fix. The 8.x line shipped v8.1.2-1 on 2026-07-06 and is the only available patched build.

Note: Jellyfin describes the 8.x line as targeting their upcoming v12.0. Hardware-accel paths (NVENC/QSV/VAAPI/AMF) should be tested after deploying this image.

## Steps to test

1. Build the Docker image: `docker-compose build`
2. Start the container: `docker-compose up -d`
3. Verify FFmpeg version inside the container: `docker exec <container> /usr/lib/jellyfin-ffmpeg/ffmpeg -version` — should report `ffmpeg version 8.1.2-Jellyfin`
4. Trigger a catchup download and confirm the stream processes correctly
5. If hardware transcoding is configured, trigger a transcode job and verify GPU path works

## Test results

- Backend: 1210/1210 tests pass (1 skipped, expected)
- Frontend: 102/102 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhzPDDFkofz5tBBzJ5xMRR)_