### PR TITLE
Make VA-API render device configurable

### DIFF
--- a/backend/services/post_processor.py
+++ b/backend/services/post_processor.py
@@ -59,7 +59,10 @@ ENCODER_MAP = {
 class PostProcessor:
     """Handles transcoding and commercial detection/removal."""
 
-    VAAPI_RENDER_DEVICE = Path("/dev/dri/renderD128")
+    VAAPI_RENDER_DEVICE = Path(
+        (os.environ.get("CATCHUP_VAAPI_RENDER_DEVICE") or "").strip()
+        or "/dev/dri/renderD128"
+    )
     VAAPI_SYSFS_DRM_CLASS = Path("/sys/class/drm")
     # Corrupt input can make ffprobe hang forever; cap how long we wait for it.
     FFPROBE_TIMEOUT_SECONDS = 60.0
@@ -857,7 +860,7 @@ class PostProcessor:
         # Build ffmpeg command
         cmd = [self._ffmpeg_path]
         if hw_accel == HardwareAccel.VAAPI:
-            cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
+            cmd.extend(["-vaapi_device", str(self.VAAPI_RENDER_DEVICE)])
         cmd.extend([
             "-i", str(input_path),
             "-y",  # Overwrite output
@@ -935,7 +938,7 @@ class PostProcessor:
                             pass
                     retry_cmd = [self._ffmpeg_path]
                     if hw_accel == HardwareAccel.VAAPI:
-                        retry_cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
+                        retry_cmd.extend(["-vaapi_device", str(self.VAAPI_RENDER_DEVICE)])
                     retry_cmd.extend([
                         "-i", str(input_path),
                         "-y",
@@ -1231,7 +1234,7 @@ class PostProcessor:
         Remove commercials from video using EDL file.
 
         Args:
-            input_path: Path to video file
+            input_path: Path to input file
             edl_path: Path to EDL file from Comskip
             output_format: Output format
             hw_accel: Hardware acceleration method
@@ -1382,7 +1385,7 @@ class PostProcessor:
             # Concat and encode
             cmd = [self._ffmpeg_path]
             if hw_accel == HardwareAccel.VAAPI:
-                cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
+                cmd.extend(["-vaapi_device", str(self.VAAPI_RENDER_DEVICE)])
             cmd.extend([
                 "-f", "concat",
                 "-safe", "0",
@@ -1447,7 +1450,7 @@ class PostProcessor:
                             pass
                     retry_cmd = [self._ffmpeg_path]
                     if hw_accel == HardwareAccel.VAAPI:
-                        retry_cmd.extend(["-vaapi_device", "/dev/dri/renderD128"])
+                        retry_cmd.extend(["-vaapi_device", str(self.VAAPI_RENDER_DEVICE)])
                     retry_cmd.extend([
                         "-f", "concat",
                         "-safe", "0",

--- a/backend/tests/test_post_processor_vaapi.py
+++ b/backend/tests/test_post_processor_vaapi.py
@@ -53,6 +53,25 @@ class VaapiDriverResolutionTests(unittest.TestCase):
 
         return device, sysfs_class_dir
 
+    def test_render_device_environment_override(self):
+        with patch.dict(
+            os.environ,
+            {"CATCHUP_VAAPI_RENDER_DEVICE": "/dev/dri/renderD129"},
+            clear=False,
+        ):
+            spec = importlib.util.spec_from_file_location(
+                "post_processor_vaapi_device_env_under_test",
+                MODULE_PATH,
+            )
+            module = importlib.util.module_from_spec(spec)
+            assert spec and spec.loader
+            spec.loader.exec_module(module)
+
+        self.assertEqual(
+            module.PostProcessor.VAAPI_RENDER_DEVICE,
+            Path("/dev/dri/renderD129"),
+        )
+
     def test_env_override_wins(self):
         with patch.object(POST_PROCESSOR_MODULE.platform, "system", return_value="Linux"):
             with patch.dict(os.environ, {"LIBVA_DRIVER_NAME": "custom-driver"}, clear=False):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     devices:
       - /dev/dri:/dev/dri # Optional: pass through render nodes for Linux hardware transcoding
     environment:
-      # Optional manual VA-API override. Leave unset for automatic Intel/AMD selection.
+      # Optional VA-API render device override. Defaults to /dev/dri/renderD128.
+      # - CATCHUP_VAAPI_RENDER_DEVICE=/dev/dri/renderD129
+      # Optional manual VA-API driver override. Leave unset for automatic Intel/AMD selection.
       # - LIBVA_DRIVER_NAME=radeonsi
       # Container/system timezone (used for logs, cron-like tools, etc.).
       - TZ=America/Los_Angeles


### PR DESCRIPTION
## Summary

- make the VA-API render device configurable with `CATCHUP_VAAPI_RENDER_DEVICE`
- preserve `/dev/dri/renderD128` as the default when the variable is unset or blank
- use the configured device consistently for VA-API diagnostics and all FFmpeg encoding/retry paths
- document the override in `docker-compose.yml`
- add regression coverage for selecting `/dev/dri/renderD129` via the environment

## Why

Systems with multiple DRM render nodes may expose the GPU intended for Mustarrd as something other than `renderD128`. The previous hard-coded path prevented VA-API encoding from working on those systems.

## Validation

Manually tested with `CATCHUP_VAAPI_RENDER_DEVICE=/dev/dri/renderD129` and confirmed hardware-accelerated encoding works. Automated regression coverage was added for the environment override.