### PR TITLE
Preserve template subdirectories in recording paths

### DIFF
--- a/backend/api/schedules.py
+++ b/backend/api/schedules.py
@@ -112,7 +112,7 @@ def _sanitize_filename(name: Optional[str]) -> Optional[str]:
     filename = name
     if not filename.endswith(".ts"):
         filename += ".ts"
-    return file_namer.sanitize_filename(filename.removesuffix(".ts")) + ".ts"
+    return file_namer.sanitize_relative_path(filename.removesuffix(".ts")) + ".ts"
 
 
 def _map_download_status(status: str) -> str:

--- a/backend/services/file_namer.py
+++ b/backend/services/file_namer.py
@@ -35,7 +35,7 @@ class FileNamer:
 
     @staticmethod
     def sanitize_filename(name: str) -> str:
-        """Remove invalid characters for filesystem."""
+        """Remove invalid characters for a single filesystem path component."""
         # Remove stylized "New" markers used in some EPG titles
         name = re.sub(r'[\[\(\-–—|:]*\s*ᴺᵉʷ\s*[\]\)]*\s*(?:-\s*)?', ' ', name)
         # Remove stylized "Live" markers frequently injected by providers
@@ -59,6 +59,45 @@ class FileNamer:
         if len(encoded) > 200:
             sanitized = encoded[:200].decode("utf-8", errors="ignore").rstrip() or "unknown-program"
         return sanitized
+
+    @classmethod
+    def sanitize_relative_path(cls, path: str) -> str:
+        """Sanitize an already-rendered relative path while preserving ``/`` levels.
+
+        Each slash-delimited component is sanitized independently. Empty
+        components are dropped so a leading slash cannot make the result
+        absolute, while ``.`` and ``..`` become ``unknown-program`` through
+        ``sanitize_filename`` and therefore cannot traverse outside the
+        configured recording folder. Backslashes remain invalid filename
+        characters instead of becoming path separators.
+        """
+        components = []
+        for component in path.split('/'):
+            if not component.strip():
+                continue
+            components.append(cls.sanitize_filename(component))
+        return '/'.join(components) or "unknown-program"
+
+    @classmethod
+    def render_template_path(cls, template: str, context: dict) -> str:
+        """Render a filename template as a safe relative path.
+
+        Forward slashes written literally in a saved template create directory
+        levels. Each level is formatted and sanitized independently so slashes
+        coming from provider metadata (for example a show named ``AC/DC``) stay
+        inside that component rather than becoming extra directories. Empty
+        path levels are ignored, which also prevents a leading slash from
+        turning a template into an absolute path. ``.`` and ``..`` sanitize to
+        ``unknown-program`` and therefore cannot traverse outside the configured
+        download folder.
+        """
+        components = []
+        for component_template in template.split('/'):
+            if not component_template.strip():
+                continue
+            rendered = component_template.format_map(context)
+            components.append(cls.sanitize_filename(rendered))
+        return '/'.join(components) or "unknown-program"
 
     @classmethod
     def extract_season_episode(cls, text: str) -> Optional[Tuple[int, int]]:
@@ -182,11 +221,11 @@ class FileNamer:
             template = s.get("default_template") or self._DEFAULT_TEMPLATES["default"]
 
         try:
-            filename = template.format_map(context)
+            filename = self.render_template_path(template, context)
         except (KeyError, ValueError, AttributeError):
-            filename = f"{title} - {date_str}"
+            filename = self.sanitize_filename(f"{title} - {date_str}")
 
-        return self.sanitize_filename(filename) + ".ts"
+        return filename + ".ts"
 
 
 # Global instance

--- a/backend/services/output_path.py
+++ b/backend/services/output_path.py
@@ -72,7 +72,7 @@ class OutputPath:
             filename = custom_filename
             if not filename.endswith(".ts"):
                 filename += ".ts"
-            filename = file_namer.sanitize_filename(filename.removesuffix(".ts")) + ".ts"
+            filename = file_namer.sanitize_relative_path(filename.removesuffix(".ts")) + ".ts"
         else:
             filename = file_namer.generate_filename(
                 program, channel, program_type, _settings_dict(settings)

--- a/backend/tests/test_filename_templates.py
+++ b/backend/tests/test_filename_templates.py
@@ -42,6 +42,21 @@ class TemplateWiringTests(unittest.TestCase):
         )
         self.assertEqual(result, "Breaking Bad 2x05.ts")
 
+    def test_tv_template_can_create_show_and_season_subdirectories(self):
+        settings = {
+            "tv_template": (
+                "TV Shows/{show}/Season {season:02d}/"
+                "{show} - S{season:02d}E{episode:02d} - {title}"
+            )
+        }
+        result = FileNamer().generate_filename(
+            _prog("Breaking Bad S02E05 - Breakage"), _channel(), "tv_show", settings
+        )
+        self.assertEqual(
+            result,
+            "TV Shows/Breaking Bad/Season 02/Breaking Bad - S02E05 - Breakage.ts",
+        )
+
     def test_tv_falls_back_to_default_template_when_no_season_episode(self):
         settings = {"default_template": "{title} ({date})"}
         result = FileNamer().generate_filename(_prog("Evening News"), _channel(), "tv_show", settings)
@@ -56,10 +71,29 @@ class TemplateWiringTests(unittest.TestCase):
         result = FileNamer().generate_filename(_prog("Evening News"), _channel(), "other", settings)
         self.assertEqual(result, "Evening News - 2024-03-15.ts")
 
-    def test_channel_variable_available_in_template(self):
+    def test_template_slash_creates_subdirectory(self):
         settings = {"default_template": "{channel}/{title}"}
         result = FileNamer().generate_filename(_prog("The Wire"), _channel("HBO"), "other", settings)
-        self.assertEqual(result, "HBO The Wire.ts")
+        self.assertEqual(result, "HBO/The Wire.ts")
+
+    def test_slash_from_metadata_does_not_create_extra_subdirectory(self):
+        settings = {"default_template": "{channel}/{title}"}
+        result = FileNamer().generate_filename(
+            _prog("AC/DC Live"), _channel("HBO/West"), "other", settings
+        )
+        self.assertEqual(result, "HBO West/AC DC Live.ts")
+
+    def test_template_cannot_escape_with_parent_segments(self):
+        settings = {"default_template": "../../{title}"}
+        result = FileNamer().generate_filename(_prog("The Wire"), _channel(), "other", settings)
+        self.assertEqual(result, "unknown-program/unknown-program/The Wire.ts")
+        self.assertNotIn("..", result)
+        self.assertFalse(result.startswith("/"))
+
+    def test_leading_template_slash_remains_relative(self):
+        settings = {"default_template": "/TV Shows/{title}"}
+        result = FileNamer().generate_filename(_prog("The Wire"), _channel(), "other", settings)
+        self.assertEqual(result, "TV Shows/The Wire.ts")
 
     def test_tv_no_subtitle_default_omits_title_segment(self):
         # EPG title with no episode subtitle must not duplicate the show name.

--- a/backend/tests/test_move_to_completed_prunes_empty_dirs.py
+++ b/backend/tests/test_move_to_completed_prunes_empty_dirs.py
@@ -68,6 +68,30 @@ class MoveToCompletedPrunesEmptyDirsTests(unittest.TestCase):
             "The configured download folder itself must never be removed.",
         )
 
+    def test_template_hierarchy_is_preserved_in_completed_folder(self):
+        episode = self._make_episode(
+            "TV Shows",
+            "Breaking Bad",
+            "Season 02",
+            "Breaking Bad - S02E05 - Breakage.ts",
+        )
+
+        dest = self.manager._move_to_completed(
+            str(episode), str(self.completed_dir), str(self.download_dir)
+        )
+
+        self.assertEqual(
+            dest,
+            str(
+                self.completed_dir
+                / "TV Shows"
+                / "Breaking Bad"
+                / "Season 02"
+                / "Breaking Bad - S02E05 - Breakage.ts"
+            ),
+        )
+        self.assertTrue(os.path.isfile(dest))
+
     def test_non_empty_dirs_are_kept(self):
         episode = self._make_episode("My Show", "Season 01", "My Show S01E01.ts")
         sibling = self._make_episode("My Show", "Season 01", "My Show S01E02.ts")

--- a/backend/tests/test_output_path_assembly.py
+++ b/backend/tests/test_output_path_assembly.py
@@ -86,7 +86,50 @@ class CatchupAssemblyTests(unittest.TestCase):
         )
         self.assertTrue(download.output_path.endswith(".ts"), download.output_path)
 
-    def test_catchup_custom_filename_is_sanitised_and_joined(self):
+    def test_catchup_template_subdirectories_are_joined_under_download_folder(self):
+        account = _account()
+        settings = AppSettings(
+            download_folder="/recordings",
+            tv_template=(
+                "TV Shows/{show}/Season {season:02d}/"
+                "{show} - S{season:02d}E{episode:02d} - {title}"
+            ),
+        )
+        program = {
+            "title": "Breaking Bad S02E05 - Breakage",
+            "description": "",
+            "start_time": "2026-03-30T10:00:00",
+            "end_time": "2026-03-30T11:00:00",
+            "category": "TV Shows",
+        }
+
+        async def run():
+            with (
+                patch(
+                    "services.download_builder.resolve_account_password_with_migration",
+                    new=AsyncMock(return_value="pass"),
+                ),
+                patch(
+                    "services.download_builder.epg_service.detect_program_type",
+                    return_value="tv_show",
+                ),
+            ):
+                return await build_download_from_program(
+                    _session(account, settings),
+                    account_id=1,
+                    channel_id="999",
+                    channel_name="AMC",
+                    program=program,
+                )
+
+        download = asyncio.run(run())
+        self.assertEqual(
+            download.output_path,
+            "/recordings/TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage.ts",
+        )
+
+    def test_catchup_custom_filename_preserves_safe_subdirectories(self):
         account = _account()
         settings = AppSettings(download_folder="/recordings")
         program = {
@@ -106,12 +149,73 @@ class CatchupAssemblyTests(unittest.TestCase):
                     channel_id="999",
                     channel_name="Cinema",
                     program=program,
-                    custom_filename="My/Recording",
+                    custom_filename=(
+                        "TV Shows/Breaking Bad/Season 02/"
+                        "Breaking Bad - S02E05 - Breakage.ts"
+                    ),
                 )
 
         download = asyncio.run(run())
-        # Slash in the custom name must be sanitised away, not create a subfolder.
-        self.assertEqual(download.output_path, "/recordings/My Recording.ts")
+        self.assertEqual(
+            download.output_path,
+            "/recordings/TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage.ts",
+        )
+
+    def test_catchup_custom_filename_cannot_escape_download_folder(self):
+        account = _account()
+        settings = AppSettings(download_folder="/recordings")
+        program = {
+            "title": "Whatever",
+            "start_time": "2026-03-30T10:00:00",
+            "end_time": "2026-03-30T11:00:00",
+        }
+
+        async def run():
+            with patch(
+                "services.download_builder.resolve_account_password_with_migration",
+                new=AsyncMock(return_value="pass"),
+            ):
+                return await build_download_from_program(
+                    _session(account, settings),
+                    account_id=1,
+                    channel_id="999",
+                    channel_name="Cinema",
+                    program=program,
+                    custom_filename="../../Escape.ts",
+                )
+
+        download = asyncio.run(run())
+        self.assertEqual(
+            download.output_path,
+            "/recordings/unknown-program/unknown-program/Escape.ts",
+        )
+
+    def test_catchup_custom_filename_leading_slash_remains_relative(self):
+        account = _account()
+        settings = AppSettings(download_folder="/recordings")
+        program = {
+            "title": "Whatever",
+            "start_time": "2026-03-30T10:00:00",
+            "end_time": "2026-03-30T11:00:00",
+        }
+
+        async def run():
+            with patch(
+                "services.download_builder.resolve_account_password_with_migration",
+                new=AsyncMock(return_value="pass"),
+            ):
+                return await build_download_from_program(
+                    _session(account, settings),
+                    account_id=1,
+                    channel_id="999",
+                    channel_name="Cinema",
+                    program=program,
+                    custom_filename="/TV Shows/Whatever.ts",
+                )
+
+        download = asyncio.run(run())
+        self.assertEqual(download.output_path, "/recordings/TV Shows/Whatever.ts")
 
 
 class MovieAssemblyTests(unittest.TestCase):

--- a/backend/tests/test_schedule_filename_paths.py
+++ b/backend/tests/test_schedule_filename_paths.py
@@ -1,0 +1,49 @@
+import sys
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from api.schedules import _sanitize_filename
+
+
+class ScheduleFilenamePathTests(unittest.TestCase):
+    def test_nested_custom_filename_preserved(self):
+        result = _sanitize_filename(
+            "TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage.ts"
+        )
+        self.assertEqual(
+            result,
+            "TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage.ts",
+        )
+
+    def test_nested_custom_filename_gets_extension(self):
+        result = _sanitize_filename(
+            "TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage"
+        )
+        self.assertEqual(
+            result,
+            "TV Shows/Breaking Bad/Season 02/"
+            "Breaking Bad - S02E05 - Breakage.ts",
+        )
+
+    def test_parent_segments_cannot_escape(self):
+        self.assertEqual(
+            _sanitize_filename("../../Escape.ts"),
+            "unknown-program/unknown-program/Escape.ts",
+        )
+
+    def test_leading_slash_stays_relative(self):
+        self.assertEqual(
+            _sanitize_filename("/TV Shows/Episode.ts"),
+            "TV Shows/Episode.ts",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow filename templates to create safe relative subdirectories
- preserve generated subdirectory paths when the download UI sends them back as `custom_filename`
- preserve the same hierarchy for scheduled recordings and completed-folder moves
- sanitize each path component independently while preventing absolute paths and `..` traversal
- add regression coverage for nested template paths, immediate downloads, schedules, and completed-folder moves

## Example

A template such as:

`TV Shows/{show}/Season {season:02d}/{show} - S{season:02d}E{episode:02d} - {title}`

now produces and preserves:

`TV Shows/Breaking Bad/Season 02/Breaking Bad - S02E05 - Breakage.ts`

instead of flattening `/` into spaces.

## Validation

The changes were manually tested against the reported download flow. Regression tests were added, but the full repository test suite has not been executed locally in this environment.